### PR TITLE
[GFX-558] External device and buffer + GLTF import support for iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,19 +29,19 @@ set(FILAMENT_NDK_VERSION "" CACHE STRING
     "Android NDK version or version prefix to be used when building for Android."
 )
 
-set(FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB "2" CACHE STRING
+set(FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB "50" CACHE STRING
     "Per render pass arena size. Must be roughly 1 MB larger than FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB, default 2."
 )
 
-set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "1" CACHE STRING
+set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "49" CACHE STRING
     "Size of the high-level draw commands buffer. Rule of thumb, 1 MB less than FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB, default 1."
 )
 
-set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "1" CACHE STRING
+set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "49" CACHE STRING
     "Size of the command-stream buffer. As a rule of thumb use the same value as FILAMENT_PER_FRRAME_COMMANDS_SIZE_IN_MB, default 1."
 )
 
-set(FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB "4" CACHE STRING
+set(FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB "10" CACHE STRING
     "Size of the OpenGL handle arena, default 4."
 )
 

--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,8 @@ function print_help {
     echo "        Run all unit tests, will trigger a debug build if needed."
     echo "    -v"
     echo "        Exclude Vulkan support from the Android build."
+    echo "    -g"
+    echo "        Exclude OpenGL support from the iOS build."
     echo "    -s"
     echo "        Add iOS simulator support to the iOS build."
     echo "    -t"
@@ -156,6 +158,8 @@ INSTALL_COMMAND=
 
 VULKAN_ANDROID_OPTION="-DFILAMENT_SUPPORTS_VULKAN=ON"
 VULKAN_ANDROID_GRADLE_OPTION=""
+
+OPENGL_IOS_OPTION="-DFILAMENT_SUPPORTS_OPENGL=ON"
 
 SWIFTSHADER_OPTION="-DFILAMENT_USE_SWIFTSHADER=OFF"
 
@@ -578,6 +582,7 @@ function build_ios_target {
             -DIOS=1 \
             -DCMAKE_TOOLCHAIN_FILE=../../third_party/clang/iOS.cmake \
             ${MATDBG_OPTION} \
+            ${OPENGL_IOS_OPTION} \
             ../..
     fi
 
@@ -748,7 +753,7 @@ function run_tests {
 
 pushd "$(dirname "$0")" > /dev/null
 
-while getopts ":hacCfijmp:q:uvslwtdk:" opt; do
+while getopts ":hacCfijmp:q:uvgslwtdk:" opt; do
     case ${opt} in
         h)
             print_help
@@ -848,6 +853,10 @@ while getopts ":hacCfijmp:q:uvslwtdk:" opt; do
             VULKAN_ANDROID_GRADLE_OPTION="-Pfilament_exclude_vulkan"
             echo "Disabling support for Vulkan in the core Filament library."
             echo "Consider using -c after changing this option to clear the Gradle cache."
+            ;;
+        g)
+            OPENGL_IOS_OPTION="-DFILAMENT_SUPPORTS_OPENGL=OFF"
+            echo "Disabling support for OpenGL in the core Filament library."
             ;;
         s)
             IOS_BUILD_SIMULATOR=true

--- a/build.sh
+++ b/build.sh
@@ -696,7 +696,7 @@ function validate_build_command {
     fi
     # Make sure we have Java
     local javac_binary=$(command -v javac)
-    if [[ "${JAVA_HOME}" == "" ]] || [[ ! "${javac_binary}" ]]; then
+    if [[ "${ISSUE_DESKTOP_BUILD}" == "true" ]] && ([[ "${JAVA_HOME}" == "" ]] || [[ ! "${javac_binary}" ]]); then
         echo "Warning: JAVA_HOME is not set, skipping Java projects"
         FILAMENT_ENABLE_JAVA=OFF
     fi

--- a/filament/backend/include/backend/Platform.h
+++ b/filament/backend/include/backend/Platform.h
@@ -84,7 +84,7 @@ public:
      *
      * @see destroy
      */
-    static DefaultPlatform* create(backend::Backend* backendHint) noexcept;
+    static DefaultPlatform* create(backend::Backend* backendHint, void* nativeDevice = nullptr) noexcept;
 
     /**
      * Destroys a Platform object returned by create()

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -145,6 +145,10 @@ DECL_DRIVER_API_N(setFrameCompletedCallback,
         backend::FrameCompletedCallback, callback,
         void*, user)
 
+DECL_DRIVER_API_N(setSwapInterval,
+        backend::SwapChainHandle, sch,
+        int32_t, interval)
+
 DECL_DRIVER_API_N(setPresentationTime,
         int64_t, monotonic_clock_ns)
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -173,11 +173,13 @@ DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
         uint32_t, indexCount,
-        backend::BufferUsage, usage)
+        backend::BufferUsage, usage,
+        bool, wrapsExternalBuffer)
 
 DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
         uint32_t, byteCount,
-        backend::BufferObjectBinding, bindingType)
+        backend::BufferObjectBinding, bindingType,
+        bool, wrapsExternalBuffer)
 
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,
@@ -309,6 +311,14 @@ DECL_DRIVER_API_SYNCHRONOUS_N(backend::SyncStatus, getSyncStatus, backend::SyncH
  * Updating driver objects
  * -----------------------
  */
+
+DECL_DRIVER_API_N(setExternalIndexBuffer,
+        backend::IndexBufferHandle, ibh,
+        void*, externalBuffer)
+
+DECL_DRIVER_API_N(setExternalBuffer,
+        backend::BufferObjectHandle, boh,
+        void*, externalBuffer)
 
 DECL_DRIVER_API_N(setVertexBufferObject,
         backend::VertexBufferHandle, vbh,

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -63,6 +63,7 @@ public:
     // swap draw buffers (i.e. for double-buffered rendering).
     virtual void commit(SwapChain* swapChain) noexcept = 0;
 
+    virtual void setSwapInterval(int32_t swapInterval) noexcept = 0;
     virtual void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept = 0;
 
     virtual bool canCreateFence() noexcept { return false; }

--- a/filament/backend/src/Platform.cpp
+++ b/filament/backend/src/Platform.cpp
@@ -80,7 +80,7 @@ Platform::~Platform() noexcept = default;
 // Creates the platform-specific Platform object. The caller takes ownership and is
 // responsible for destroying it. Initialization of the backend API is deferred until
 // createDriver(). The passed-in backend hint is replaced with the resolved backend.
-DefaultPlatform* DefaultPlatform::create(Backend* backend) noexcept {
+DefaultPlatform* DefaultPlatform::create(Backend* backend, void* nativeDevice) noexcept {
     SYSTRACE_CALL();
     assert_invariant(backend);
 

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -38,6 +38,16 @@ public:
     size_t getSize() const noexcept { return mBufferSize; }
 
     /**
+     * Wrap an external Metal buffer. Stores a strong reference to it.
+     */
+    void wrapExternalBuffer(id<MTLBuffer> buffer);
+
+    /**
+     * Release the external Metal buffer, if wrapping any.
+     */
+    bool releaseExternalBuffer();
+
+    /**
      * Update the buffer with data inside src. Potentially allocates a new buffer allocation to hold
      * the bytes which will be released when the current frame is finished.
      */
@@ -72,6 +82,7 @@ public:
 private:
 
     size_t mBufferSize = 0;
+    id<MTLBuffer> mExternalBuffer = nil;
     const MetalBufferPoolEntry* mBufferPoolEntry = nullptr;
     void* mCpuBuffer = nullptr;
     MetalContext& mContext;

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -143,6 +143,9 @@ void MetalDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
     swapChain->setFrameCompletedCallback(callback, user);
 }
 
+void MetalDriver::setSwapInterval(Handle<HwSwapChain> sch, int32_t interval) {
+}
+
 void MetalDriver::execute(std::function<void(void)> fn) noexcept {
     @autoreleasepool {
         fn();

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -194,14 +194,14 @@ void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t buffer
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage) {
+        uint32_t indexCount, BufferUsage usage, bool wrapsExternalBuffer) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     construct_handle<MetalIndexBuffer>(mHandleMap, ibh, *mContext, elementSize, indexCount);
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType) {
-    construct_handle<MetalBufferObject>(mHandleMap, boh, *mContext, byteCount);
+        BufferObjectBinding bindingType, bool wrapsExternalBuffer) {
+    construct_handle<MetalBufferObject>(mHandleMap, boh, *mContext, byteCount, wrapsExternalBuffer);
 }
 
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
@@ -696,6 +696,18 @@ void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescripto
     auto* bo = handle_cast<MetalBufferObject>(mHandleMap, boh);
     bo->updateBuffer(data.buffer, data.size, byteOffset);
     scheduleDestroy(std::move(data));
+}
+
+void MetalDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, void* externalBuffer) {
+    auto* ib = handle_cast<MetalIndexBuffer>(mHandleMap, ibh);
+    ib->buffer.releaseExternalBuffer();
+    ib->buffer.wrapExternalBuffer((__bridge id<MTLBuffer>)externalBuffer);
+}
+
+void MetalDriver::setExternalBuffer(Handle<HwBufferObject> boh, void* externalBuffer) {
+    auto* bo = handle_cast<MetalBufferObject>(mHandleMap, boh);
+    bo->getBuffer()->releaseExternalBuffer();
+    bo->getBuffer()->wrapExternalBuffer((__bridge id<MTLBuffer>)externalBuffer);
 }
 
 void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -128,6 +128,23 @@ constexpr inline MTLVertexFormat getMetalFormat(ElementType type, bool normalize
 
 inline MTLPixelFormat getMetalFormat(TextureFormat format) noexcept {
 #if defined(IOS)
+    switch (format) {
+        case TextureFormat::SRGB8_ALPHA8_ASTC_4x4: return MTLPixelFormatASTC_4x4_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x4: return MTLPixelFormatASTC_5x4_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_5x5: return MTLPixelFormatASTC_5x5_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x5: return MTLPixelFormatASTC_6x5_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_6x6: return MTLPixelFormatASTC_6x6_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x5: return MTLPixelFormatASTC_8x5_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x6: return MTLPixelFormatASTC_8x6_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_8x8: return MTLPixelFormatASTC_8x8_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x5: return MTLPixelFormatASTC_10x5_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x6: return MTLPixelFormatASTC_10x6_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x8: return MTLPixelFormatASTC_10x8_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_10x10: return MTLPixelFormatASTC_10x10_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x10: return MTLPixelFormatASTC_12x10_sRGB;
+        case TextureFormat::SRGB8_ALPHA8_ASTC_12x12: return MTLPixelFormatASTC_12x12_sRGB;
+        default: break;
+    }
     // Only iOS 13.0 and above supports the ASTC HDR profile. Older versions of iOS fallback to LDR.
     // The HDR profile is a superset of the LDR profile.
     if (@available(iOS 13, *)) {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -114,7 +114,7 @@ private:
 
 class MetalBufferObject : public HwBufferObject {
 public:
-    MetalBufferObject(MetalContext& context, uint32_t byteCount);
+    MetalBufferObject(MetalContext& context, uint32_t byteCount, bool wrapsExternalBuffer);
 
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
     MetalBuffer* getBuffer() const { return buffer.get(); }

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -266,8 +266,8 @@ void MetalSwapChain::scheduleFrameCompletedCallback() {
     }];
 }
 
-MetalBufferObject::MetalBufferObject(MetalContext& context, uint32_t byteCount)
-        : HwBufferObject(byteCount), buffer(std::make_unique<MetalBuffer>(context, byteCount)) {}
+MetalBufferObject::MetalBufferObject(MetalContext& context, uint32_t byteCount, bool wrapsExternalBuffer)
+        : HwBufferObject(byteCount), buffer(std::make_unique<MetalBuffer>(context, byteCount, wrapsExternalBuffer)) {}
 
 void MetalBufferObject::updateBuffer(void* data, size_t size, uint32_t byteOffset) {
     assert_invariant(byteOffset + size <= byteCount);

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -185,6 +185,12 @@ void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor
     scheduleDestroy(std::move(p));
 }
 
+void NoopDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, void* externalBuffer) {
+}
+
+void NoopDriver::setExternalBuffer(Handle<HwBufferObject> boh, void* externalBuffer) {
+}
+
 void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
 }

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -61,6 +61,9 @@ void NoopDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
 
 }
 
+void NoopDriver::setSwapInterval(Handle<HwSwapChain> sch, int32_t interval) {
+}
+
 void NoopDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3090,6 +3090,10 @@ void OpenGLDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
 
 }
 
+void OpenGLDriver::setSwapInterval(Handle<HwSwapChain> sch, int32_t interval) {
+    mPlatform.setSwapInterval(interval);
+}
+
 void OpenGLDriver::setPresentationTime(int64_t monotonic_clock_ns) {
     mPlatform.setPresentationTime(monotonic_clock_ns);
 }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -493,37 +493,45 @@ void OpenGLDriver::createIndexBufferR(
         Handle<HwIndexBuffer> ibh,
         ElementType elementType,
         uint32_t indexCount,
-        BufferUsage usage) {
+        BufferUsage usage, 
+        bool wrapsExternalBuffer) {
     DEBUG_MARKER()
 
     auto& gl = mContext;
     uint8_t elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
     GLIndexBuffer* ib = construct<GLIndexBuffer>(ibh, elementSize, indexCount);
-    glGenBuffers(1, &ib->gl.buffer);
-    GLsizeiptr size = elementSize * indexCount;
-    gl.bindVertexArray(nullptr);
-    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, nullptr, getBufferUsage(usage));
-    CHECK_GL_ERROR(utils::slog.e)
+    glGenBuffers(1, &ib->gl.id);
+    ib->gl.isExternal = wrapsExternalBuffer;
+    if (!wrapsExternalBuffer) {
+        GLsizeiptr size = elementSize * indexCount;
+        gl.bindVertexArray(nullptr);
+        gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.id);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, nullptr, getBufferUsage(usage));
+        CHECK_GL_ERROR(utils::slog.e)
+    }
 }
 
 void OpenGLDriver::createBufferObjectR(
         Handle<HwBufferObject> boh,
         uint32_t byteCount,
-        BufferObjectBinding bindingType) {
+        BufferObjectBinding bindingType,
+        bool wrapsExternalBuffer) {   
     DEBUG_MARKER()
 
     auto& gl = mContext;
     GLBufferObject* bo = construct<GLBufferObject>(boh, byteCount);
     glGenBuffers(1, &bo->gl.id);
-    gl.bindVertexArray(nullptr);
+    bo->gl.isExternal = wrapsExternalBuffer;
+    if (!wrapsExternalBuffer) {
+        gl.bindVertexArray(nullptr);
 
-    assert_invariant(byteCount > 0);
-    assert_invariant(bindingType == BufferObjectBinding::VERTEX);
+        assert_invariant(byteCount > 0);
+        assert_invariant(bindingType == BufferObjectBinding::VERTEX);
 
-    gl.bindBuffer(GL_ARRAY_BUFFER, bo->gl.id);
-    glBufferData(GL_ARRAY_BUFFER, byteCount, nullptr, GL_STATIC_DRAW);
-    CHECK_GL_ERROR(utils::slog.e)
+        gl.bindBuffer(GL_ARRAY_BUFFER, bo->gl.id);
+        glBufferData(GL_ARRAY_BUFFER, byteCount, nullptr, GL_STATIC_DRAW);
+        CHECK_GL_ERROR(utils::slog.e)
+    }
 }
 
 void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph, int) {
@@ -1289,7 +1297,9 @@ void OpenGLDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     if (ibh) {
         auto& gl = mContext;
         GLIndexBuffer const* ib = handle_cast<const GLIndexBuffer*>(ibh);
-        gl.deleteBuffers(1, &ib->gl.buffer, GL_ELEMENT_ARRAY_BUFFER);
+        if (!ib->gl.isExternal) {
+            gl.deleteBuffers(1, &ib->gl.id, GL_ELEMENT_ARRAY_BUFFER);
+        }
         destruct(ibh, ib);
     }
 }
@@ -1300,7 +1310,9 @@ void OpenGLDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
     if (boh) {
         auto& gl = mContext;
         GLBufferObject const* bo = handle_cast<const GLBufferObject*>(boh);
-        gl.deleteBuffers(1, &bo->gl.id, GL_ARRAY_BUFFER);
+        if (!bo->gl.isExternal) {
+            gl.deleteBuffers(1, &bo->gl.id, GL_ARRAY_BUFFER);
+        }
         destruct(boh, bo);
     }
 }
@@ -1708,6 +1720,44 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
 // Updating driver objects
 // ------------------------------------------------------------------------------------------------
 
+void OpenGLDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, void* externalBuffer) {
+#ifdef GL_EXT_external_buffer
+    DEBUG_MARKER()
+
+    auto& gl = mContext;
+    GLIndexBuffer* ib = handle_cast<GLIndexBuffer*>(ibh);
+
+    assert_invariant(ib->gl.isExternal);
+
+    gl.bindVertexArray(nullptr);
+    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.id);
+    glBufferStorageExternalEXT(GL_ELEMENT_ARRAY_BUFFER, 0, ib->count * ib->elementSize, externalBuffer, 0);
+
+    CHECK_GL_ERROR(utils::slog.e)
+#else
+    assert(false && "You need GL_EXT_external_buffer for setting external index buffers!");
+#endif
+}
+
+void OpenGLDriver::setExternalBuffer(Handle<HwBufferObject> boh, void* externalBuffer) {
+#ifdef GL_EXT_external_buffer
+    DEBUG_MARKER()
+
+    auto& gl = mContext;
+    GLBufferObject* bo = handle_cast<GLBufferObject*>(boh);
+
+    assert_invariant(bo->gl.isExternal);
+
+    gl.bindVertexArray(nullptr);
+    gl.bindBuffer(GL_ARRAY_BUFFER, bo->gl.id);
+    glBufferStorageExternalEXT(GL_ARRAY_BUFFER, 0, bo->byteCount, externalBuffer, 0);
+
+    CHECK_GL_ERROR(utils::slog.e)
+#else
+    assert(false && "You need GL_EXT_external_buffer for setting external buffers!");
+#endif
+}
+
 void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
         uint32_t index, Handle<HwBufferObject> boh) {
    DEBUG_MARKER()
@@ -1738,7 +1788,9 @@ void OpenGLDriver::updateIndexBuffer(
     assert_invariant(ib->elementSize == 2 || ib->elementSize == 4);
 
     gl.bindVertexArray(nullptr);
-    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
+    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.id);
+    assert_invariant(!ib->gl.isExternal);
+
     glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
 
     scheduleDestroy(std::move(p));
@@ -2515,7 +2567,7 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         updateVertexArrayObject(rp, eb);
 
         // this records the index buffer into the currently bound VAO
-        gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
+        gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.id);
 
         CHECK_GL_ERROR(utils::slog.e)
     }

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -71,12 +71,15 @@ public:
         backend::BufferUsage usage = {};
     };
 
+    struct GLBufferHandle {
+        GLuint id = 0;
+        bool isExternal = false;
+    };
+
     struct GLBufferObject : public backend::HwBufferObject {
         using HwBufferObject::HwBufferObject;
         GLBufferObject(uint32_t size) noexcept : HwBufferObject(size) {}
-        struct {
-            GLuint id = 0;
-        } gl;
+        GLBufferHandle gl;
     };
 
     struct GLVertexBuffer : public backend::HwVertexBuffer {
@@ -89,9 +92,7 @@ public:
 
     struct GLIndexBuffer : public backend::HwIndexBuffer {
         using HwIndexBuffer::HwIndexBuffer;
-        struct {
-            GLuint buffer{};
-        } gl;
+        GLBufferHandle gl;
     };
 
     struct GLUniformBuffer : public backend::HwUniformBuffer {

--- a/filament/backend/src/opengl/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaGL.h
@@ -47,6 +47,7 @@ public:
         return backend::FenceStatus::ERROR;
     }
 
+    void setSwapInterval(int32_t interval) noexcept final {}
     void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept final {}
 
     Stream* createStream(void* nativeStream) noexcept final { return nullptr; }

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.h
@@ -48,6 +48,7 @@ public:
         return backend::FenceStatus::ERROR;
     }
 
+    void setSwapInterval(int32_t interval) noexcept final override {}
     void setPresentationTime(int64_t time) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final { return nullptr; }

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -20,9 +20,6 @@
 #include "OpenGLContext.h"
 #include "OpenGLDriverFactory.h"
 
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-
 #include <utils/compiler.h>
 #include <utils/Log.h>
 
@@ -370,6 +367,12 @@ void PlatformEGL::createExternalImageTexture(void* texture) noexcept {
 void PlatformEGL::destroyExternalImage(void* texture) noexcept {
     auto* t = (OpenGLDriver::GLTexture*) texture;
     glDeleteTextures(1, &t->gl.id);
+}
+
+void PlatformEGL::setSwapInterval(int32_t interval) noexcept {
+    if (eglSwapInterval(mEGLDisplay, interval) == EGL_FALSE) {
+        logEglError("eglSwapInterval");
+    }
 }
 
 void PlatformEGL::initializeGlExtensions() noexcept {

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -54,6 +54,7 @@ public:
 
     int getOSVersion() const noexcept override { return 0; }
 
+    void setSwapInterval(int32_t interval) noexcept override;
     void setPresentationTime(int64_t presentationTimeInNanosecond) noexcept override {}
 
     Stream* createStream(void* nativeStream) noexcept override { return nullptr; }

--- a/filament/backend/src/opengl/PlatformGLX.h
+++ b/filament/backend/src/opengl/PlatformGLX.h
@@ -47,6 +47,7 @@ public:
     void destroyFence(Fence* fence) noexcept override;
     backend::FenceStatus waitFence(Fence* fence, uint64_t timeout) noexcept override;
 
+    void setSwapInterval(int32_t interval) noexcept final override {}
     void setPresentationTime(int64_t time) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final override { return nullptr; }

--- a/filament/backend/src/opengl/PlatformWGL.h
+++ b/filament/backend/src/opengl/PlatformWGL.h
@@ -43,6 +43,7 @@ public:
     void destroyFence(Fence* fence) noexcept override;
     backend::FenceStatus waitFence(Fence* fence, uint64_t timeout) noexcept override;
 
+    void setSwapInterval(int32_t interval) noexcept final override {}
     void setPresentationTime(int64_t time) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final override { return nullptr; }

--- a/filament/backend/src/opengl/PlatformWebGL.h
+++ b/filament/backend/src/opengl/PlatformWebGL.h
@@ -44,6 +44,7 @@ public:
     void destroyFence(Fence* fence) noexcept final override;
     backend::FenceStatus waitFence(Fence* fence, uint64_t timeout) noexcept final override;
 
+    void setSwapInterval(int32_t interval) noexcept final override {}
     void setPresentationTime(int64_t time) noexcept final override {}
 
     Stream* createStream(void* nativeStream) noexcept final override { return nullptr; }

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -48,6 +48,10 @@ PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
 #ifdef GL_EXT_clip_control
 PFNGLCLIPCONTROLEXTPROC glClipControl;
 #endif
+#ifdef GL_EXT_external_buffer
+PFNGLBUFFERSTORAGEEXTERNALEXTPROC glBufferStorageExternalEXT;
+PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC glNamedBufferStorageExternalEXT;
+#endif
 
 static std::once_flag sGlExtInitialized;
 
@@ -108,6 +112,13 @@ void importGLESExtensionsEntryPoints() {
     glClipControl =
             (PFNGLCLIPCONTROLEXTPROC)eglGetProcAddress(
                     "glClipControlEXT");
+#endif
+
+#ifdef GL_EXT_external_buffer
+     glBufferStorageExternalEXT = (PFNGLBUFFERSTORAGEEXTERNALEXTPROC)eglGetProcAddress(
+        "glBufferStorageExternalEXT");
+     glNamedBufferStorageExternalEXT = (PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC)eglGetProcAddress(
+        "glNamedBufferStorageExternalEXT");
 #endif
 }
 

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -61,6 +61,10 @@
         #define GL_ZERO_TO_ONE GL_ZERO_TO_ONE_EXT
         #endif
 #endif
+#ifdef GL_EXT_external_buffer
+        extern PFNGLBUFFERSTORAGEEXTERNALEXTPROC glBufferStorageExternalEXT;
+        extern PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC glNamedBufferStorageExternalEXT;
+#endif
     }
 
     // Prevent lots of #ifdef's between desktop and mobile by providing some suffix-free constants:

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -379,6 +379,9 @@ void VulkanDriver::setFrameCompletedCallback(Handle<HwSwapChain> sch,
 
 }
 
+void VulkanDriver::setSwapInterval(Handle<HwSwapChain> sch, int32_t interval) {
+}
+
 void VulkanDriver::setPresentationTime(int64_t monotonic_clock_ns) {
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -449,8 +449,8 @@ void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     }
 }
 
-void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh,
-        ElementType elementType, uint32_t indexCount, BufferUsage usage) {
+void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
+        uint32_t indexCount, BufferUsage usage, bool wrapsExternalBuffer) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto indexBuffer = construct_handle<VulkanIndexBuffer>(mHandleMap, ibh, mContext, mStagePool,
             elementSize, indexCount);
@@ -466,8 +466,8 @@ void VulkanDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     }
 }
 
-void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh,
-        uint32_t byteCount, BufferObjectBinding bindingType) {
+void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
+        BufferObjectBinding bindingType, bool wrapsExternalBuffer) {
     auto bufferObject = construct_handle<VulkanBufferObject>(mHandleMap, boh, mContext, mStagePool,
             byteCount);
     mDisposer.createDisposable(bufferObject, [this, boh] () {
@@ -837,6 +837,14 @@ math::float2 VulkanDriver::getClipSpaceParams() {
 
 uint8_t VulkanDriver::getMaxDrawBuffers() {
     return backend::MRT::MIN_SUPPORTED_RENDER_TARGET_COUNT; // TODO: query real value
+}
+
+void VulkanDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, void* externalBuffer) {
+    ASSERT_PRECONDITION(false, "setExternalIndexBuffer() is not implemented for backend!");
+}
+
+void VulkanDriver::setExternalBuffer(Handle<HwBufferObject> boh, void* externalBuffer) {
+    ASSERT_PRECONDITION(false, "setExternalBuffer() is not implemented for backend!");
 }
 
 void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -54,7 +54,7 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     enabledAttributes.set(VertexAttribute::POSITION);
 
     const size_t size = sizeof(math::float2) * 3;
-    mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX);
+    mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX, false);
     mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes,
             BufferUsage::STATIC);
     mDriverApi.setVertexBufferObject(mVertexBuffer, 0, mBufferObject);
@@ -62,7 +62,7 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);
 
     mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount,
-            BufferUsage::STATIC);
+            BufferUsage::STATIC, false);
     BufferDescriptor indexBufferDesc(gIndices, sizeof(short) * 3, nullptr);
     mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(indexBufferDesc), 0);
 

--- a/filament/include/filament/Engine.h
+++ b/filament/include/filament/Engine.h
@@ -172,6 +172,7 @@ public:
      *                          when creating filament's internal context.
      *                          Setting this parameter will force filament to use the OpenGL
      *                          implementation (instead of Vulkan for instance).
+     *  @param nativeDevice     A platform-dependant native graphics device.
      *
      *
      * @return A pointer to the newly created Engine, or nullptr if the Engine couldn't be created.
@@ -187,7 +188,7 @@ public:
      * This method is thread-safe.
      */
     static Engine* create(Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+            Platform* platform = nullptr, void* sharedGLContext = nullptr, void* nativeDevice = nullptr);
 
 #if UTILS_HAS_THREADING
     /**
@@ -229,10 +230,11 @@ public:
      *                          when creating filament's internal context.
      *                          Setting this parameter will force filament to use the OpenGL
      *                          implementation (instead of Vulkan for instance).
+     *  @param nativeDevice     A platform-dependant native graphics device.
      */
     static void createAsync(CreateCallback callback, void* user,
-            Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+            Backend backend = Backend::DEFAULT, Platform* platform = nullptr,
+            void* sharedGLContext = nullptr, void* nativeDevice = nullptr);
 
     /**
      * Retrieve an Engine* from createAsync(). This must be called from the same thread than

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -83,6 +83,16 @@ public:
         Builder& bufferType(IndexType indexType) noexcept;
 
         /**
+        * Allows buffers to wrap external (backend-specific) buffers.
+        *
+        * If external buffer mode is enabled, clients must call setExternalBuffer rather than
+        * setBuffer.
+        *
+        * @param enabled If true, enables external buffer mode.  False by default.
+        */
+        Builder& enableExternalBuffer(bool enabled = true) noexcept;
+
+        /**
          * Creates the IndexBuffer object and returns a pointer to it. After creation, the index
          * buffer is uninitialized. Use IndexBuffer::setBuffer() to initialize the IndexBuffer.
          *
@@ -112,6 +122,17 @@ public:
      * @param byteOffset Offset in *bytes* into the IndexBuffer
      */
     void setBuffer(Engine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
+
+
+    /**
+     * Wraps the given external buffer (stores a strong reference to it).
+     *
+     * To use this, you must first call enableExternalBuffer() on the Builder.
+     *
+     * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
+     * @param externalBuffer Pointer to the external buffer that will be used in this buffer slot.
+     */
+    void setExternalBuffer(Engine& engine, void* externalBuffer);
 
     /**
      * Returns the size of this IndexBuffer in elements.

--- a/filament/include/filament/SwapChain.h
+++ b/filament/include/filament/SwapChain.h
@@ -180,6 +180,8 @@ public:
 
     void* getNativeWindow() const noexcept;
 
+    void setSwapInterval(int32_t interval);
+
     /**
      * FrameScheduledCallback is a callback function that notifies an application when Filament has
      * completed processing a frame and that frame is ready to be scheduled for presentation.

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -99,6 +99,16 @@ public:
         Builder& enableBufferObjects(bool enabled = true) noexcept;
 
         /**
+         * Allows buffers to wrap external (backend-specific) buffers.
+         *
+         * If external buffer mode is enabled, clients must call setExternalBufferAt rather than
+         * setBufferAt.
+         *
+         * @param enabled If true, enables external buffer mode.  False by default.
+         */
+        Builder& enableExternalBuffer(bool enabled = true) noexcept;
+
+        /**
          * Sets up an attribute for this vertex buffer set.
          *
          * Using \p byteOffset and \p byteStride, attributes can be interleaved in the same buffer.
@@ -194,6 +204,18 @@ public:
      * @param bufferObject The handle to the GPU data that will be used in this buffer slot.
      */
     void setBufferObjectAt(Engine& engine, uint8_t bufferIndex, BufferObject const* bufferObject);
+
+    /**
+     * Wraps the given external buffer (stores a strong reference to it).
+     *
+     * To use this, you must first call enableExternalBuffer() on the Builder.
+     *
+     * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
+     * @param bufferIndex Index of the buffer to initialize. Must be between 0
+     *                    and Builder::bufferCount() - 1.
+     * @param externalBuffer Pointer to the external buffer that will be used in this buffer slot.
+     */
+    void setExternalBufferAt(Engine& engine, uint8_t bufferIndex, void* externalBuffer);
 };
 
 } // namespace filament

--- a/filament/src/BufferObject.cpp
+++ b/filament/src/BufferObject.cpp
@@ -54,7 +54,7 @@ BufferObject* BufferObject::Builder::build(Engine& engine) {
 FBufferObject::FBufferObject(FEngine& engine, const BufferObject::Builder& builder)
         : mByteCount(builder->mByteCount), mBindingType(builder->mBindingType) {
     FEngine::DriverApi& driver = engine.getDriverApi();
-    mHandle = driver.createBufferObject(builder->mByteCount, builder->mBindingType);
+    mHandle = driver.createBufferObject(builder->mByteCount, builder->mBindingType, false);
 }
 
 void FBufferObject::terminate(FEngine& engine) {

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -90,7 +90,7 @@ public:
 
 private:
     // TODO: these should be settings of the engine
-    static constexpr size_t CACHE_CAPACITY = 640u << 20u;   // 640 MiB
+    static constexpr size_t CACHE_CAPACITY = 150u << 20u;   // 150 MiB (should cover at least 4K resolution)
     static constexpr size_t CACHE_MAX_AGE  = 30u;
 
     struct TextureKey {

--- a/filament/src/ResourceAllocator.h
+++ b/filament/src/ResourceAllocator.h
@@ -90,7 +90,7 @@ public:
 
 private:
     // TODO: these should be settings of the engine
-    static constexpr size_t CACHE_CAPACITY = 64u << 20u;   // 64 MiB
+    static constexpr size_t CACHE_CAPACITY = 640u << 20u;   // 640 MiB
     static constexpr size_t CACHE_MAX_AGE  = 30u;
 
     struct TextureKey {

--- a/filament/src/SwapChain.cpp
+++ b/filament/src/SwapChain.cpp
@@ -34,6 +34,10 @@ void FSwapChain::terminate(FEngine& engine) noexcept {
     engine.getDriverApi().destroySwapChain(mSwapChain);
 }
 
+void FSwapChain::setSwapInterval(int32_t interval) {
+    mEngine.getDriverApi().setSwapInterval(mSwapChain, interval);
+}
+
 void FSwapChain::setFrameScheduledCallback(FrameScheduledCallback callback, void* user) {
     mEngine.getDriverApi().setFrameScheduledCallback(mSwapChain, callback, user);
 }
@@ -44,6 +48,10 @@ void FSwapChain::setFrameCompletedCallback(FrameCompletedCallback callback, void
 
 void* SwapChain::getNativeWindow() const noexcept {
     return upcast(this)->getNativeWindow();
+}
+
+void SwapChain::setSwapInterval(int32_t interval) {
+    upcast(this)->setSwapInterval(interval);
 }
 
 void SwapChain::setFrameScheduledCallback(FrameScheduledCallback callback, void* user) {

--- a/filament/src/details/Engine.h
+++ b/filament/src/details/Engine.h
@@ -129,13 +129,12 @@ public:
     static constexpr size_t CONFIG_COMMAND_BUFFERS_SIZE         = filament::CONFIG_COMMAND_BUFFERS_SIZE;
 
 public:
-    static FEngine* create(Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+    static FEngine* create(Backend backend = Backend::DEFAULT, Platform* platform = nullptr,
+            void* sharedGLContext = nullptr, void* nativeDevice = nullptr);
 
 #if UTILS_HAS_THREADING
-    static void createAsync(CreateCallback callback, void* user,
-            Backend backend = Backend::DEFAULT,
-            Platform* platform = nullptr, void* sharedGLContext = nullptr);
+    static void createAsync(CreateCallback callback, void* user, Backend backend = Backend::DEFAULT,
+            Platform* platform = nullptr, void* sharedGLContext = nullptr, void* nativeDevice = nullptr);
 
     static FEngine* getEngine(void* token);
 #endif
@@ -327,7 +326,7 @@ public:
     }
 
 private:
-    FEngine(Backend backend, Platform* platform, void* sharedGLContext);
+    FEngine(Backend backend, Platform* platform, void* sharedGLContext, void* nativeDevice);
     void init();
     void shutdown();
 
@@ -346,6 +345,7 @@ private:
     Platform* mPlatform = nullptr;
     bool mOwnPlatform = false;
     void* mSharedGLContext = nullptr;
+    void* mNativeDevice = nullptr;
     bool mTerminated = false;
     backend::Handle<backend::HwRenderPrimitive> mFullScreenTriangleRph;
     FVertexBuffer* mFullScreenTriangleVb = nullptr;

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -42,10 +42,13 @@ public:
 
     void setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
 
+    void setExternalBuffer(FEngine& engine, void* externalBuffer);
+
 private:
     friend class IndexBuffer;
     backend::Handle<backend::HwIndexBuffer> mHandle;
     uint32_t mIndexCount;
+    bool mExternalBuffersEnabled = false;
 };
 
 FILAMENT_UPCAST(IndexBuffer)

--- a/filament/src/details/SwapChain.h
+++ b/filament/src/details/SwapChain.h
@@ -59,6 +59,8 @@ public:
       return mSwapChain;
     }
 
+    void setSwapInterval(int32_t interval);
+
     void setFrameScheduledCallback(FrameScheduledCallback callback, void* user);
 
     void setFrameCompletedCallback(FrameCompletedCallback callback, void* user);

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -60,6 +60,9 @@ public:
     void setBufferObjectAt(FEngine& engine, uint8_t bufferIndex,
             FBufferObject const * bufferObject);
 
+    void setExternalBufferAt(FEngine& engine, uint8_t bufferIndex,
+            void* externalBuffer);
+
 private:
     friend class VertexBuffer;
 
@@ -74,6 +77,7 @@ private:
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;
     bool mBufferObjectsEnabled = false;
+    bool mExternalBuffersEnabled = false;
 };
 
 FILAMENT_UPCAST(VertexBuffer)

--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -172,7 +172,7 @@ target_include_directories(gltfio_core PUBLIC ${PUBLIC_HDR_DIR})
 target_compile_definitions(gltfio_core PUBLIC -DGLTFIO_DRACO_SUPPORTED=1)
 target_link_libraries(gltfio_core PUBLIC dracodec)
 
-if (NOT WEBGL AND NOT ANDROID AND NOT IOS)
+if (NOT WEBGL AND NOT ANDROID)
 
     # ==================================================================================================
     # Link the core library with additional dependencies to create the "full" library

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -478,6 +478,10 @@ static Material* createMaterial(Engine* engine, const MaterialKey& config, const
         builder.shading(Shading::LIT);
     }
 
+#if defined(__EMSCRIPTEN__) || defined(ANDROID) || defined(IOS) || defined(FILAMENT_USE_EXTERNAL_GLES3)
+    builder.platform(MaterialBuilderBase::Platform::MOBILE);
+#endif
+
     Package pkg = builder.build(engine->getJobSystem());
     return Material::Builder().package(pkg.getData(), pkg.getSize()).build(*engine);
 }

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -45,7 +45,7 @@
 
 #include <string>
 
-#if defined(__EMSCRIPTEN__) || defined(ANDROID) || defined(IOS)
+#if defined(__EMSCRIPTEN__) || defined(ANDROID)
 #define USE_FILESYSTEM 0
 #else
 #define USE_FILESYSTEM 1


### PR DESCRIPTION
Contains some changes necessary to run Filament on the iPad. Namely:
 - Support for passing in external (native Metal/D3D11) buffers and device to Filament. This is needed to share VB/IB data between Shapr3D and Filament (because duplicating them would waste too much memory).
  - Increase some hardcoded limits to avoid OOM crashes.
  - GLTF import for iOS (originally `gltf` lib was not build for mobile platforms).
  
  I tested on my iPad Pro 3rd Gen (iOS 13.4) in Debug and Release.