### PR TITLE
Fix the update of Managed Metal buffers on Mac Catalyst

### DIFF
--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -99,7 +99,7 @@ void MetalBuffer::copyIntoBuffer(void* src, size_t size, size_t byteOffset) {
 
     if (mExternalBuffer) {
         memcpy(static_cast<uint8_t*>(mExternalBuffer.contents), src, size);
-#if !TARGET_OS_IOS
+#if !TARGET_OS_IOS || TARGET_OS_MACCATALYST
         if (mExternalBuffer.storageMode == MTLStorageModeManaged) {
             [mExternalBuffer didModifyRange:NSMakeRange(0, size)];
         }


### PR DESCRIPTION
As @veghbalazs noticed we handled the update of Managed Metal buffers incorrectly on Mac Catalyst. We never updated these buffers via Filament in the M2 proto (and probably won't do it in the future) but for the sake of correctness, we have to handle Catalyst too.