### PR TITLE
[GFX-723] Ignore channel order of imported textures (Metal)

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -267,7 +267,7 @@ void MetalDriver::importTextureR(Handle<HwTexture> th, intptr_t i,
             "Imported id<MTLTexture> levels (%d) != Filament texture levels (%d)",
             metalTexture.mipmapLevelCount, levels);
     MTLPixelFormat filamentMetalFormat = getMetalFormat(mContext, format);
-    ASSERT_PRECONDITION(metalTexture.pixelFormat == filamentMetalFormat,
+    ASSERT_PRECONDITION(metalFormatOrderInvariantEqual(metalTexture.pixelFormat, filamentMetalFormat),
             "Imported id<MTLTexture> format (%d) != Filament texture format (%d)",
             metalTexture.pixelFormat, filamentMetalFormat);
     MTLTextureType filamentMetalType = getMetalType(target);

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -177,6 +177,27 @@ inline MTLPixelFormat getMetalFormat(PixelDataFormat format, PixelDataType type)
     return MTLPixelFormatInvalid;
 }
 
+inline bool metalFormatOrderInvariantEqual(MTLPixelFormat lhs, MTLPixelFormat rhs) {
+    if (lhs == rhs) {
+        return true;
+    }
+
+    if (lhs == MTLPixelFormatBGRA8Unorm && rhs == MTLPixelFormatRGBA8Unorm) {
+        return true;
+    }
+    if (lhs == MTLPixelFormatBGRA8Unorm_sRGB && rhs == MTLPixelFormatRGBA8Unorm_sRGB) {
+        return true;
+    }
+    if (lhs == MTLPixelFormatRGBA8Unorm && rhs == MTLPixelFormatBGRA8Unorm) {
+        return true;
+    }
+    if (lhs == MTLPixelFormatRGBA8Unorm_sRGB && rhs == MTLPixelFormatBGRA8Unorm_sRGB) {
+        return true;
+    }
+
+    return false;
+}
+
 inline MTLPixelFormat getMetalFormatLinear(MTLPixelFormat format) {
     switch (format) {
         case MTLPixelFormatR8Unorm_sRGB: return MTLPixelFormatR8Unorm;


### PR DESCRIPTION
## Jira ticket URL
https://shapr3d.atlassian.net/browse/GFX-723

## Short description 📖
The [`import()` API on `filament::Texture`](https://github.com/shapr3d/filament/blob/8c8871addadbf23e551c184c54fcc516d71866ad/filament/include/filament/Texture.h#L238) allows a Metal texture object to be injected into a Filament texture. After import, the driver checks that provided properties of the texture match the actual values. 

This limits the possible formats of importable Metal textures, because certain formats such as BGRA8 are [not available in Filament](https://github.com/shapr3d/filament/blob/8c8871addadbf23e551c184c54fcc516d71866ad/filament/backend/include/backend/DriverEnums.h#L448). This PR loosens the assert condition to a channel order invariant equality. Since the two formats behave identically when it comes to shader reads and writes, BGRA textures are now importable as RGBA.

## Testing

### How did you test it? 🤔
Manual 💁‍♂️
Tested by importing a `.bgra8Unorm` texture of a `CAMetalDrawable` object, and rendered a scene to it.