### PR TITLE
[GFX-723] Make `MetalPlatform` header public

### DIFF
--- a/filament/backend/include/backend/MetalPlatform.h
+++ b/filament/backend/include/backend/MetalPlatform.h
@@ -25,7 +25,7 @@
 namespace filament {
 namespace backend {
 
-class MetalPlatform : public DefaultPlatform {
+class UTILS_PUBLIC MetalPlatform : public DefaultPlatform {
 public:
     ~MetalPlatform() override;
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -27,7 +27,7 @@
 #include "MetalState.h"
 #include "MetalTimerQuery.h"
 
-#include "private/backend/MetalPlatform.h"
+#include "backend/MetalPlatform.h"
 
 #include <CoreVideo/CVMetalTexture.h>
 #include <CoreVideo/CVPixelBuffer.h>

--- a/filament/backend/src/metal/MetalPlatform.mm
+++ b/filament/backend/src/metal/MetalPlatform.mm
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "private/backend/MetalPlatform.h"
+#include "backend/MetalPlatform.h"
 
 #include "MetalDriverFactory.h"
 


### PR DESCRIPTION
## Jira ticket URL
https://shapr3d.atlassian.net/browse/GFX-723

## Short description 📖
As discussed in https://github.com/google/filament/pull/4007#discussion_r638145082, `MetalPlatform` is designed to allow users to provide a `MTLDevice` and/or `MTLCommandQueue` of their choice. This PR makes `MetalPlaform.h` file accessible to any user of the Filament library.

We intend to make Filament graphics commands a part of our existing render loop, and the correct ordering of encoded commands must be ensured. Ordering guarantees are only provided within a command queue, therefore rendering code inside and outside Filament must use the same queue.

## Testing

### How did you test it? 🤔
Manual 💁‍♂️
Tested by subclassing `MetalPlatform`, returning our single Metal device and its single queue, then rendered a scene.