### PR TITLE
[GFX-826] Add gradient support to Skybox class, material definition and viewer UI

### DIFF
--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -64,6 +64,12 @@ class UTILS_PUBLIC Skybox : public FilamentAPI {
     struct BuilderDetails;
 
 public:
+    enum SkyboxType {
+        COLOR = 0,
+        GRADIENT = 1,
+        ENVIRONMENT = 2
+    };
+
     //! Use Builder to construct an Skybox object instance
     class Builder : public BuilderBase<BuilderDetails> {
         friend struct BuilderDetails;
@@ -131,6 +137,11 @@ public:
         Builder& color(math::float4 color) noexcept;
 
         /**
+        * Sets the skybox type, between solid color, gradient and environment.
+        */
+        Builder& type(SkyboxType type) noexcept;
+
+        /**
          * Creates the Skybox object and returns a pointer to it.
          *
          * @param engine Reference to the filament::Engine to associate this Skybox with.
@@ -144,6 +155,8 @@ public:
     };
 
     void setColor(math::float4 color) noexcept;
+
+    void setType(SkyboxType type) noexcept;
 
     /**
      * Sets bits in a visibility mask. By default, this is 0x1.

--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -128,7 +128,7 @@ public:
         /**
          * Sets the skybox to a constant color. Default is opaque black.
          *
-         * Ignored if an environment is set.
+         * Applied when the type is set to COLOR or GRADIENT.
          *
          * @param color
          *

--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -64,7 +64,7 @@ class UTILS_PUBLIC Skybox : public FilamentAPI {
     struct BuilderDetails;
 
 public:
-    enum SkyboxType {
+    enum class SkyboxType : uint8_t {
         COLOR = 0,
         GRADIENT = 1,
         ENVIRONMENT = 2

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -44,6 +44,7 @@ struct Skybox::BuilderDetails {
     float4 mColor{0, 0, 0, 1};
     float mIntensity = FIndirectLight::DEFAULT_INTENSITY;
     bool mShowSun = false;
+    SkyboxType mType = Skybox::ENVIRONMENT;
 };
 
 using BuilderType = Skybox;
@@ -67,6 +68,11 @@ Skybox::Builder& Skybox::Builder::intensity(float envIntensity) noexcept {
 
 Skybox::Builder& Skybox::Builder::color(math::float4 color) noexcept {
     mImpl->mColor = color;
+    return *this;
+}
+
+Skybox::Builder& Skybox::Builder::type(SkyboxType type) noexcept {
+    mImpl->mType = type;
     return *this;
 }
 
@@ -101,7 +107,7 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
     FTexture const* texture = mSkyboxTexture ? mSkyboxTexture : engine.getDummyCubemap();
     pInstance->setParameter("skybox", texture, sampler);
     pInstance->setParameter("showSun", builder->mShowSun);
-    pInstance->setParameter("constantColor", mSkyboxTexture == nullptr);
+    pInstance->setParameter("skyboxType", (int)mType);
     pInstance->setParameter("color", builder->mColor);
 
     mSkybox = engine.getEntityManager().create();
@@ -143,6 +149,11 @@ void FSkybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
     mLayerMask = (mLayerMask & ~select) | (values & select);
 }
 
+void FSkybox::setType(SkyboxType type) noexcept {
+    mType = type;
+    mSkyboxMaterialInstance->setParameter("skyboxType", (int)mType);
+}
+
 void FSkybox::setColor(math::float4 color) noexcept {
     mSkyboxMaterialInstance->setParameter("color", color);
 }
@@ -169,6 +180,10 @@ float Skybox::getIntensity() const noexcept {
 
 void Skybox::setColor(math::float4 color) noexcept {
     upcast(this)->setColor(color);
+}
+
+void Skybox::setType(SkyboxType type) noexcept {
+    upcast(this)->setType(type);
 }
 
 Texture const* Skybox::getTexture() const noexcept {

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -44,7 +44,7 @@ struct Skybox::BuilderDetails {
     float4 mColor{0, 0, 0, 1};
     float mIntensity = FIndirectLight::DEFAULT_INTENSITY;
     bool mShowSun = false;
-    SkyboxType mType = Skybox::ENVIRONMENT;
+    SkyboxType mType = Skybox::SkyboxType::ENVIRONMENT;
 };
 
 using BuilderType = Skybox;
@@ -107,7 +107,7 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
     FTexture const* texture = mSkyboxTexture ? mSkyboxTexture : engine.getDummyCubemap();
     pInstance->setParameter("skybox", texture, sampler);
     pInstance->setParameter("showSun", builder->mShowSun);
-    pInstance->setParameter("skyboxType", (int)mType);
+    pInstance->setParameter("skyboxType", (uint32_t)builder->mType);
     pInstance->setParameter("color", builder->mColor);
 
     mSkybox = engine.getEntityManager().create();
@@ -150,8 +150,7 @@ void FSkybox::setLayerMask(uint8_t select, uint8_t values) noexcept {
 }
 
 void FSkybox::setType(SkyboxType type) noexcept {
-    mType = type;
-    mSkyboxMaterialInstance->setParameter("skyboxType", (int)mType);
+    mSkyboxMaterialInstance->setParameter("skyboxType", (uint32_t)type);
 }
 
 void FSkybox::setColor(math::float4 color) noexcept {

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -68,7 +68,6 @@ private:
     FRenderableManager& mRenderableManager;
     float mIntensity = 0.0f;
     uint8_t mLayerMask = 0x1;
-    SkyboxType mType = Skybox::ENVIRONMENT;
 };
 
 FILAMENT_UPCAST(Skybox)

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -51,6 +51,8 @@ public:
 
     FTexture const* getTexture() const noexcept { return mSkyboxTexture; }
 
+    void setType(SkyboxType type) noexcept;
+
     void setColor(math::float4 color) noexcept;
 
     // commits UBOs
@@ -66,6 +68,7 @@ private:
     FRenderableManager& mRenderableManager;
     float mIntensity = 0.0f;
     uint8_t mLayerMask = 0x1;
+    SkyboxType mType = Skybox::ENVIRONMENT;
 };
 
 FILAMENT_UPCAST(Skybox)

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -114,7 +114,7 @@ fragment {
             sky.rgb *= frameUniforms.iblLuminance;
         }
 
-        if (materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0f) {
+        if (materialParams.skyboxType == 2 && materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0f) {
             float3 direction = normalize(variable_eyeDirection.xyz);
             // Assume the sun is a sphere
             float3 sun = frameUniforms.lightColorIntensity.rgb *

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -30,6 +30,10 @@ material {
 
 fragment {
 
+#define SHAPR_SKYBOX_TYPE_SOLID_COLOR 0
+#define SHAPR_SKYBOX_TYPE_GRADIENT 1
+#define SHAPR_SKYBOX_TYPE_ENVIRONMENT 2
+
     float3 approxInverseSRGB(float3 srgb) {
         return pow(srgb, vec3(2.2));
     }
@@ -70,33 +74,33 @@ fragment {
     }
 
     float computeGradient(float t) {
-        const float DIMMING_FACTOR = 0.6;
-        const float GRAD_START_HIGH = 0.9;
-        const float GRAD_LOCATION = 0.4;
-        const float GRAD_START_LOW = 0.2;
+        const float dimmingFactor = 0.6;
+        const float gradientStartHigh = 0.9;
+        const float gradientLocation = 0.4;
+        const float gradientStartLow = 0.2;
 
         float grad;
-        if (t >= GRAD_LOCATION) {
-            grad = DIMMING_FACTOR + (t - GRAD_LOCATION) * (1.0 / (GRAD_START_HIGH - GRAD_LOCATION)) * (1.0 - DIMMING_FACTOR);
+        if (t >= gradientLocation) {
+            grad = dimmingFactor + (t - gradientLocation) * (1.0 / (gradientStartHigh - gradientLocation)) * (1.0 - dimmingFactor);
         } else {
-            grad = 1.0 - (t - GRAD_START_LOW) * (1.0 / (GRAD_LOCATION - GRAD_START_LOW)) * (1.0 - DIMMING_FACTOR);
+            grad = 1.0 - (t - gradientStartLow) * (1.0 / (gradientLocation - gradientStartLow)) * (1.0 - dimmingFactor);
         }
         return saturate(grad);
     }
 
     float3 shaprSkyGradient() {
-        const float SHAPR_THRESH = 0.5;
+        const float shaprThreshold = 0.5;
 
         float upDirectionMapped = normalize(variable_eyeDirection).y * 0.5 + 0.5;
         float3 colorRGB = approxInverseSRGB(materialParams.color.rgb);
         float3 colorOklab = linear_srgb_to_oklab(colorRGB);
-        if (colorOklab.r > SHAPR_THRESH) {
+        if (colorOklab.r > shaprThreshold) {
             // oklab.r is the luminance channel
             colorOklab.r *= computeGradient(upDirectionMapped);
         } else {
-            const float SHAPR_DARK_COLORS_BIAS = 2.0;
+            const float shaprDarkColorsBias = 2.0;
             // oklab.r is the luminance channel
-            colorOklab.r *= (SHAPR_DARK_COLORS_BIAS - computeGradient(upDirectionMapped));
+            colorOklab.r *= (shaprDarkColorsBias - computeGradient(upDirectionMapped));
         }
         return oklab_to_linear_srgb(colorOklab);
     }
@@ -104,14 +108,16 @@ fragment {
     void material(inout MaterialInputs material) {
         prepareMaterial(material);
         float4 sky;
-        if (materialParams.skyboxType == 0) {
+        if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_SOLID_COLOR) {
             sky = float4(approxInverseSRGB(materialParams.color.rgb), materialParams.color.a);
-        } else if (materialParams.skyboxType == 1) {
+        } else if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_GRADIENT) {
             float3 shaprSkyColor = shaprSkyGradient();
             sky = float4(shaprSkyColor, 1.0);
-        } else {
+        } else if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_ENVIRONMENT) {
             sky = float4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);
             sky.rgb *= frameUniforms.iblLuminance;
+        } else {
+            sky = float4(1.0, 0.0, 1.0, 1.0);
         }
 
         if (materialParams.skyboxType == 2 && materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0f) {

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -84,7 +84,7 @@ fragment {
         return saturate(grad);
     }
 
-    float3 shaprSky_general() {
+    float3 shaprSkyGradient() {
         float SHAPR_THRESH = 0.5;
 
         float upDirection = normalize(variable_eyeDirection).y;
@@ -106,7 +106,7 @@ fragment {
         if (materialParams.skyboxType == 0) {
             sky = float4(approxInverseSRGB(materialParams.color.rgb), materialParams.color.a);
         } else if (materialParams.skyboxType == 1) {
-            float3 shaprSkyColor = shaprSky_general();
+            float3 shaprSkyColor = shaprSkyGradient();
             sky = float4(shaprSkyColor, 1.0);
         } else {
             sky = float4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -70,10 +70,10 @@ fragment {
     }
 
     float computeGradient(float t) {
-        float DIMMING_FACTOR = 0.6;
-        float GRAD_START_HIGH = 0.9;
-        float GRAD_LOCATION = 0.4;
-        float GRAD_START_LOW = 0.2;
+        const float DIMMING_FACTOR = 0.6;
+        const float GRAD_START_HIGH = 0.9;
+        const float GRAD_LOCATION = 0.4;
+        const float GRAD_START_LOW = 0.2;
 
         float grad;
         if (t >= GRAD_LOCATION) {
@@ -85,19 +85,20 @@ fragment {
     }
 
     float3 shaprSkyGradient() {
-        float SHAPR_THRESH = 0.5;
+        const float SHAPR_THRESH = 0.5;
 
-        float upDirection = normalize(variable_eyeDirection).y;
+        float upDirectionMapped = normalize(variable_eyeDirection).y * 0.5 + 0.5;
         float3 colorRGB = approxInverseSRGB(materialParams.color.rgb);
-        float3 colorConverted = linear_srgb_to_oklab(colorRGB);
-        if (colorConverted.r > SHAPR_THRESH) {
-            colorConverted.r *= computeGradient(upDirection * 0.5 + 0.5);
+        float3 colorOklab = linear_srgb_to_oklab(colorRGB);
+        if (colorOklab.r > SHAPR_THRESH) {
+            // oklab.r is the luminance channel
+            colorOklab.r *= computeGradient(upDirectionMapped);
         } else {
-            float SHAPR_DARK_COLORS_BIAS = 2.0;
-
-            colorConverted.r *= (SHAPR_DARK_COLORS_BIAS - computeGradient(upDirection * 0.5 + 0.5));
+            const float SHAPR_DARK_COLORS_BIAS = 2.0;
+            // oklab.r is the luminance channel
+            colorOklab.r *= (SHAPR_DARK_COLORS_BIAS - computeGradient(upDirectionMapped));
         }
-        return oklab_to_linear_srgb(colorConverted);
+        return oklab_to_linear_srgb(colorOklab);
     }
 
     void material(inout MaterialInputs material) {

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -7,7 +7,7 @@ material {
         },
         {
            type : int,
-           name : constantColor
+           name : skyboxType
         },
         {
            type : samplerCubemap,
@@ -29,26 +29,107 @@ material {
 }
 
 fragment {
+
+    float3 approxInverseSRGB(float3 srgb) {
+        return pow(srgb, vec3(2.2));
+    }
+
+    // Conversion code from: https://bottosson.github.io/posts/oklab/
+    float3 linear_srgb_to_oklab(float3 c) 
+    {
+        float l = 0.4122214708 * c.r + 0.5363325363 * c.g + 0.0514459929 * c.b;
+        float m = 0.2119034982 * c.r + 0.6806995451 * c.g + 0.1073969566 * c.b;
+        float s = 0.0883024619 * c.r + 0.2817188376 * c.g + 0.6299787005 * c.b;
+
+        float l_ = pow(l, 1.0/3.0);
+        float m_ = pow(m, 1.0/3.0);
+        float s_ = pow(s, 1.0/3.0);
+
+        return float3(
+            0.2104542553*l_ + 0.7936177850*m_ - 0.0040720468*s_,
+            1.9779984951*l_ - 2.4285922050*m_ + 0.4505937099*s_,
+            0.0259040371*l_ + 0.7827717662*m_ - 0.8086757660*s_
+        );
+    }
+
+    float3 oklab_to_linear_srgb(float3 c) 
+    {
+        float l_ = c.r + 0.3963377774 * c.g + 0.2158037573 * c.b;
+        float m_ = c.r - 0.1055613458 * c.g - 0.0638541728 * c.b;
+        float s_ = c.r - 0.0894841775 * c.g - 1.2914855480 * c.b;
+
+        float l = l_*l_*l_;
+        float m = m_*m_*m_;
+        float s = s_*s_*s_;
+
+        return float3(
+            +4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+            -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+            -0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s
+        );
+    }
+
+    float computeGradient(float t) {
+        float DIMMING_FACTOR = 0.6;
+        float GRAD_START_HIGH = 0.9;
+        float GRAD_LOCATION = 0.4;
+        float GRAD_START_LOW = 0.2;
+
+        float grad;
+        if (t >= GRAD_LOCATION) {
+            grad = DIMMING_FACTOR + (t - GRAD_LOCATION) * (1.0 / (GRAD_START_HIGH - GRAD_LOCATION)) * (1.0 - DIMMING_FACTOR);
+        } else {
+            grad = 1.0 - (t - GRAD_START_LOW) * (1.0 / (GRAD_LOCATION - GRAD_START_LOW)) * (1.0 - DIMMING_FACTOR);
+        }
+        return saturate(grad);
+    }
+
+    float3 shaprSky_general() {
+        float SHAPR_THRESH = 0.5;
+
+        float upDirection = normalize(variable_eyeDirection).y;
+        float3 colorRGB = approxInverseSRGB(materialParams.color.rgb);
+        float3 colorConverted = linear_srgb_to_oklab(colorRGB);
+        if (colorConverted.r > SHAPR_THRESH) {
+            colorConverted.r *= computeGradient(upDirection * 0.5 + 0.5);
+        } else {
+            float SHAPR_DARK_COLORS_BIAS = 2.0;
+
+            colorConverted.r *= (SHAPR_DARK_COLORS_BIAS - computeGradient(upDirection * 0.5 + 0.5));
+        }
+        return oklab_to_linear_srgb(colorConverted);
+    }
+
     void material(inout MaterialInputs material) {
         prepareMaterial(material);
-        vec4 sky;
-        if (materialParams.constantColor != 0) {
-            sky = materialParams.color;
+        float4 sky;
+        if (materialParams.skyboxType == 0) {
+            sky = float4(approxInverseSRGB(materialParams.color.rgb), materialParams.color.a);
+        } else if (materialParams.skyboxType == 1) {
+            float3 shaprSkyColor = shaprSky_general();
+            sky = float4(shaprSkyColor, 1.0);
         } else {
-            sky = vec4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);
+            sky = float4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);
             sky.rgb *= frameUniforms.iblLuminance;
         }
+
         if (materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0f) {
-            vec3 direction = normalize(variable_eyeDirection.xyz);
+            float3 direction = normalize(variable_eyeDirection.xyz);
             // Assume the sun is a sphere
-            vec3 sun = frameUniforms.lightColorIntensity.rgb *
+            float3 sun = frameUniforms.lightColorIntensity.rgb *
                     (frameUniforms.lightColorIntensity.a * (4.0 * PI));
             float cosAngle = dot(direction, frameUniforms.lightDirection);
             float x = (cosAngle - frameUniforms.sun.x) * frameUniforms.sun.z;
             float gradient = pow(1.0 - saturate(x), frameUniforms.sun.w);
             sky.rgb = sky.rgb + gradient * sun;
         }
-        material.baseColor = sky;
+
+        if (materialParams.skyboxType != 2) {
+            material.baseColor = float4(0.0);
+            material.postLightingColor = sky;
+        } else {
+            material.baseColor = sky;
+        }
     }
 }
 

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -189,7 +189,7 @@ struct LightSettings {
     math::float3 sunlightColor = filament::Color::toLinear<filament::ACCURATE>({ 0.98, 0.92, 0.89});
     float iblIntensity = 30000.0f;
     float iblRotation = 0.0f;
-    Skybox::SkyboxType skyboxType = Skybox::ENVIRONMENT;
+    Skybox::SkyboxType skyboxType = Skybox::SkyboxType::ENVIRONMENT;
 };
 
 struct ViewerOptions {

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -23,6 +23,7 @@
 #include <filament/MaterialInstance.h>
 #include <filament/Scene.h>
 #include <filament/View.h>
+#include <filament/Skybox.h>
 
 #include <utils/compiler.h>
 
@@ -188,6 +189,7 @@ struct LightSettings {
     math::float3 sunlightColor = filament::Color::toLinear<filament::ACCURATE>({ 0.98, 0.92, 0.89});
     float iblIntensity = 30000.0f;
     float iblRotation = 0.0f;
+    Skybox::SkyboxType skyboxType = Skybox::ENVIRONMENT;
 };
 
 struct ViewerOptions {

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -965,6 +965,10 @@ void applySettings(const LightSettings& settings, IndirectLight* ibl, utils::Ent
         ibl->setIntensity(settings.iblIntensity);
         ibl->setRotation(math::mat3f::rotation(settings.iblRotation, math::float3 { 0, 1, 0 }));
     }
+    if (scene->getSkybox())
+    {
+        scene->getSkybox()->setType(settings.skyboxType);
+    }
     for (size_t i = 0; i < sceneLightCount; i++) {
         light = lm->getInstance(sceneLights[i]);
         if (lm->isSpotLight(light)) {
@@ -990,6 +994,7 @@ void applySettings(const ViewerOptions& settings, Camera* camera, Skybox* skybox
     }
     if (skybox) {
         skybox->setLayerMask(0xff, settings.skyboxEnabled ? 0xff : 0x00);
+        skybox->setColor(math::float4(settings.backgroundColor, 1.0f));
     }
     if (camera) {
         camera->setExposure(

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -467,6 +467,9 @@ void SimpleViewer::updateIndirectLight() {
         mIndirectLight->setIntensity(mSettings.lighting.iblIntensity);
         mIndirectLight->setRotation(mat3f::rotation(mSettings.lighting.iblRotation, float3{ 0, 1, 0 }));
     }
+    if (mScene->getSkybox()) {
+        mScene->getSkybox()->setType(mSettings.lighting.skyboxType);
+    }
 }
 
 void SimpleViewer::applyAnimation(double currentTime) {
@@ -805,7 +808,10 @@ void SimpleViewer::updateUserInterface() {
         ImGui::Checkbox("Scale to unit cube", &mSettings.viewer.autoScaleEnabled);
         updateRootTransform();
 
-        ImGui::Checkbox("Show skybox", &mSettings.viewer.skyboxEnabled);
+        int skyboxType = (int)mSettings.lighting.skyboxType;
+        ImGui::Combo("Skybox type", &skyboxType,
+            "Solid color\0Gradient\0Environment\0\0");
+        mSettings.lighting.skyboxType = (decltype(mSettings.lighting.skyboxType))skyboxType;
         ImGui::ColorEdit3("Background color", &mSettings.viewer.backgroundColor.r);
 
         // We do not yet support ground shadow in remote mode (i.e. when mAsset is null)


### PR DESCRIPTION
## Jira ticket URL (Why?)
<!---
Use the Jira ticket id as text in PROJ-XXX format and append it to the end of the link.
If there are multiple tickets, list all.
-->
[GFX-826](https://shapr3d.atlassian.net/browse/GFX-826) Modify Filament's Skybox class to support gradients
[GFX-827](https://shapr3d.atlassian.net/browse/GFX-827) Modify Filament's skybox material to support gradients

## Short description (What? How?) 📖
Added a combo box under the "Scene" header to choose background (solid color, gradient, environment). Modified the `Skybox` classes and material definition to support rendering a gradient.
![image](https://user-images.githubusercontent.com/91476779/144207347-b5392375-f7bc-4b6f-88e4-02f08df0a9b0.png)
Right now it uses oklab color space to do the blending, as there is available example code to convert from/to linear sRGB, and was very simple to integrate.

## Testing

### Design review 🎨
Will be reviewed and fine tuned when integrated into Shapr3D Visualization tool.

### Affected areas 🧭
Filament Skybox classes and skybox.mat material definition.

### Special use-cases to test 🧷
Gradient background in GLTF Viewer (in this branch), with color picker for choosing blend color.
![image](https://user-images.githubusercontent.com/91476779/144207824-32729324-b391-418d-8e6e-c8bc077d99ee.png)


### How did you test it? 🤔
Manual 💁‍♂️
Chose gradient as background, and tried out a bunch of colors.
