### PR TITLE
[GFX-807] Migrate GltfViewer changes back to Shapr3D Filament fork

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -49,7 +49,7 @@ static constexpr uint64_t SWAP_CHAIN_CONFIG_ENABLE_XCB = 0x4;
 static constexpr uint64_t SWAP_CHAIN_CONFIG_APPLE_CVPIXELBUFFER = 0x8;
 
 static constexpr size_t MAX_VERTEX_ATTRIBUTE_COUNT = 16; // This is guaranteed by OpenGL ES.
-static constexpr size_t MAX_SAMPLER_COUNT = 16;          // Matches the Adreno Vulkan driver.
+static constexpr size_t MAX_SAMPLER_COUNT = 17;          // Does not match the Adreno Vulkan driver but does satisfy authoring shader sampler needs
 static constexpr size_t MAX_VERTEX_BUFFER_COUNT = 16;    // Max number of bound buffer objects.
 
 static_assert(MAX_VERTEX_BUFFER_COUNT <= MAX_VERTEX_ATTRIBUTE_COUNT,

--- a/filament/src/components/LightManager.cpp
+++ b/filament/src/components/LightManager.cpp
@@ -230,7 +230,7 @@ void FLightManager::terminate() noexcept {
 void FLightManager::setShadowOptions(Instance i, ShadowOptions const& options) noexcept {
     ShadowParams& params = mManager[i].shadowParams;
     params.options = options;
-    params.options.mapSize = clamp(options.mapSize, 8u, 2048u);
+    params.options.mapSize = clamp(options.mapSize, 8u, 4096u);
     params.options.shadowCascades = clamp<uint8_t>(options.shadowCascades, 1, CONFIG_MAX_SHADOW_CASCADES);
     params.options.constantBias = clamp(options.constantBias, 0.0f, 2.0f);
     params.options.normalBias = clamp(options.normalBias, 0.0f, 3.0f);

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -188,6 +188,15 @@ std::string shaderFromKey(const MaterialKey& config) {
                 )SHADER";
             }
         }
+
+        // At this point, material roughness is established and now we can compute the reflectance attribute. Our experiments show
+        // that it has to depend on roughness: if it is set to a constant nonzero value, then full rough (=1) surfaces become
+        // unrealistically reflective. However, if reflective is zero, then unrough (=0) parts of the surface that face the camera
+        // won't reflect the environment correctly (=at all). As a heuristic fix, let's make these two complementary to each other:
+        shader += R"SHADER(
+                        material.reflectance = clamp( 1.0 - material.roughness, 0.0, 1.0 );
+                    )SHADER";
+
         if (config.hasOcclusionTexture) {
             shader += "highp float2 aoUV = ${ao};\n";
             if (config.hasTextureTransforms) {

--- a/libs/gltfio/src/MaterialGenerator.cpp
+++ b/libs/gltfio/src/MaterialGenerator.cpp
@@ -150,6 +150,11 @@ std::string shaderFromKey(const MaterialKey& config) {
     }
 
     if (!config.unlit) {
+        // This is a custom Shapr3D property that controls specular reflectance of materials on all lighting paths
+        shader += R"SHADER(
+                material.specularIntensity = 1.0;
+            )SHADER";
+
         if (config.useSpecularGlossiness) {
             shader += R"SHADER(
                 material.glossiness = materialParams.glossinessFactor;

--- a/shaders/src/light_directional.fs
+++ b/shaders/src/light_directional.fs
@@ -81,6 +81,6 @@ void evaluateDirectionalLight(const MaterialInputs material,
 #if defined(MATERIAL_HAS_CUSTOM_SURFACE_SHADING)
     color.rgb += customSurfaceShading(material, pixel, light, visibility);
 #else
-    color.rgb += surfaceShading(pixel, light, visibility);
+    color.rgb += surfaceShading(material, pixel, light, visibility);
 #endif
 }

--- a/shaders/src/light_punctual.fs
+++ b/shaders/src/light_punctual.fs
@@ -233,7 +233,7 @@ void evaluatePunctualLights(const MaterialInputs material,
 #if defined(MATERIAL_HAS_CUSTOM_SURFACE_SHADING)
         color.rgb += customSurfaceShading(material, pixel, light, visibility);
 #else
-        color.rgb += surfaceShading(pixel, light, visibility);
+        color.rgb += surfaceShading(material, pixel, light, visibility);
 #endif
     }
 }

--- a/shaders/src/material_inputs.fs
+++ b/shaders/src/material_inputs.fs
@@ -11,6 +11,7 @@
 
 struct MaterialInputs {
     vec4  baseColor;
+    bool  useWard;
 #if !defined(SHADING_MODEL_UNLIT)
 #if !defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
     float roughness;
@@ -93,6 +94,7 @@ struct MaterialInputs {
 
 void initMaterial(out MaterialInputs material) {
     material.baseColor = vec4(1.0);
+    material.useWard = false;
 #if !defined(SHADING_MODEL_UNLIT)
 #if !defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
     material.roughness = 1.0;

--- a/shaders/src/material_inputs.fs
+++ b/shaders/src/material_inputs.fs
@@ -22,6 +22,7 @@ struct MaterialInputs {
     float ambientOcclusion;
 #endif
     vec4  emissive;
+    float specularIntensity;
 
 #if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SUBSURFACE) && !defined(SHADING_MODEL_UNLIT)
     vec3 sheenColor;
@@ -103,6 +104,7 @@ void initMaterial(out MaterialInputs material) {
     material.ambientOcclusion = 1.0;
 #endif
     material.emissive = vec4(vec3(0.0), 1.0);
+    material.specularIntensity = 1.0;
 
 #if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SUBSURFACE) && !defined(SHADING_MODEL_UNLIT)
 #if defined(MATERIAL_HAS_SHEEN_COLOR)

--- a/shaders/src/material_inputs.fs
+++ b/shaders/src/material_inputs.fs
@@ -99,7 +99,7 @@ void initMaterial(out MaterialInputs material) {
 #endif
 #if !defined(SHADING_MODEL_CLOTH) && !defined(SHADING_MODEL_SPECULAR_GLOSSINESS)
     material.metallic = 0.0;
-    material.reflectance = 0.5;
+    material.reflectance = 0.0;
 #endif
     material.ambientOcclusion = 1.0;
 #endif

--- a/shaders/src/shading_model_cloth.fs
+++ b/shaders/src/shading_model_cloth.fs
@@ -9,7 +9,7 @@
  * computation of these events is not physically based but can add necessary
  * details to a material.
  */
-vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion) {
+vec3 surfaceShading(const MaterialInputs material, const PixelParams pixel, const Light light, float occlusion) {
     vec3 h = normalize(shading_view + light.l);
     float NoL = light.NoL;
     float NoH = saturate(dot(shading_normal, h));
@@ -20,7 +20,7 @@ vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion)
     float V = visibilityCloth(shading_NoV, NoL);
     vec3  F = pixel.f0;
     // Ignore pixel.energyCompensation since we use a different BRDF here
-    vec3 Fr = (D * V) * F;
+    vec3 Fr = material.specularIntensity * (D * V) * F;
 
     // diffuse BRDF
     float diffuse = diffuse(pixel.roughness, shading_NoV, NoL, LoH);

--- a/shaders/src/shading_model_standard.fs
+++ b/shaders/src/shading_model_standard.fs
@@ -98,7 +98,7 @@ vec3 diffuseLobe(const PixelParams pixel, float NoV, float NoL, float LoH) {
  * on the Cook-Torrance microfacet model, it uses cheaper terms than the surface
  * BRDF's specular lobe (see brdf.fs).
  */
-vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion) {
+vec3 surfaceShading(const MaterialInputs material, const PixelParams pixel, const Light light, float occlusion) {
     vec3 h = normalize(shading_view + light.l);
 
     float NoV = shading_NoV;
@@ -106,7 +106,7 @@ vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion)
     float NoH = saturate(dot(shading_normal, h));
     float LoH = saturate(dot(light.l, h));
 
-    vec3 Fr = specularLobe(pixel, light, h, NoV, NoL, NoH, LoH);
+    vec3 Fr = material.specularIntensity * specularLobe(pixel, light, h, NoV, NoL, NoH, LoH);
     vec3 Fd = diffuseLobe(pixel, NoV, NoL, LoH);
 #if defined(HAS_REFRACTION)
     Fd *= (1.0 - pixel.transmission);

--- a/shaders/src/shading_model_subsurface.fs
+++ b/shaders/src/shading_model_subsurface.fs
@@ -17,7 +17,7 @@ vec3 surfaceShading(const MaterialInputs material, const PixelParams pixel, cons
         // specular BRDF
         float D = distribution(pixel.roughness, NoH, h);
         float V = visibility(pixel.roughness, shading_NoV, NoL);
-        vec3  F = fresnel(pixel.f0, LoH);
+        vec3  F = material.specularIntensity * fresnel(pixel.f0, LoH);
         Fr = (D * V) * F * pixel.energyCompensation;
     }
 
@@ -25,7 +25,6 @@ vec3 surfaceShading(const MaterialInputs material, const PixelParams pixel, cons
     vec3 Fd = pixel.diffuseColor * diffuse(pixel.roughness, shading_NoV, NoL, LoH);
 
     // NoL does not apply to transmitted light
-    Fr *= material.specularIntensity;
     vec3 color = (Fd + Fr) * (NoL * occlusion);
 
     // subsurface scattering

--- a/shaders/src/shading_model_subsurface.fs
+++ b/shaders/src/shading_model_subsurface.fs
@@ -5,7 +5,7 @@
  * scattering. The BTDF itself is not physically based and does not represent a
  * correct interpretation of transmission events.
  */
-vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion) {
+vec3 surfaceShading(const MaterialInputs material, const PixelParams pixel, const Light light, float occlusion) {
     vec3 h = normalize(shading_view + light.l);
 
     float NoL = light.NoL;
@@ -25,6 +25,7 @@ vec3 surfaceShading(const PixelParams pixel, const Light light, float occlusion)
     vec3 Fd = pixel.diffuseColor * diffuse(pixel.roughness, shading_NoV, NoL, LoH);
 
     // NoL does not apply to transmitted light
+    Fr *= material.specularIntensity;
     vec3 color = (Fd + Fr) * (NoL * occlusion);
 
     // subsurface scattering


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-807](https://shapr3d.atlassian.net/browse/GFX-807)

## Short description (What? How?) 📖
There have been a number of changes that we made to Filament based on artist feedback. This PR contains the most important ones to reach our M6 milestone:
* specular intensity scaler for indirect and direct lighting
* make reflectance a function of roughness by default and for on-the-fly generated shaders as well
* allow up to 4K shadowmaps
* increase the number of samplers so that we can use the authoring übershaders

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
These changes alter specular response mildly. 

### Special use-cases to test 🧷
N/A

### How did you test it? 🤔
Manual 💁‍♂️
Used GltfViewer and the damanged helmet asset to check for regressions and see if the additions work as intended. 