### PR TITLE
[GFX-848] Add checkerboard generation support to the modified skybox material in Filament

### DIFF
--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -67,7 +67,8 @@ public:
     enum class SkyboxType : uint8_t {
         COLOR = 0,
         GRADIENT = 1,
-        ENVIRONMENT = 2
+        ENVIRONMENT = 2,
+        CHECKERBOARD = 3
     };
 
     //! Use Builder to construct an Skybox object instance
@@ -137,7 +138,7 @@ public:
         Builder& color(math::float4 color) noexcept;
 
         /**
-        * Sets the skybox type, between solid color, gradient and environment.
+        * Sets the skybox type, between solid color, gradient, environment and checkerboard.
         */
         Builder& type(SkyboxType type) noexcept;
 

--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -143,6 +143,12 @@ public:
         Builder& type(SkyboxType type) noexcept;
 
         /**
+        * Sets the UI scale factor for the checkerboard pattern. The pattern has 8x8 pixel squares,
+        * when the scale is 1. The default value is 1.
+        */
+        Builder& uiScale(float scale) noexcept;
+
+        /**
          * Creates the Skybox object and returns a pointer to it.
          *
          * @param engine Reference to the filament::Engine to associate this Skybox with.
@@ -158,6 +164,8 @@ public:
     void setColor(math::float4 color) noexcept;
 
     void setType(SkyboxType type) noexcept;
+
+    void setUiScale(float scale) noexcept;
 
     /**
      * Sets bits in a visibility mask. By default, this is 0x1.

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -45,6 +45,7 @@ struct Skybox::BuilderDetails {
     float mIntensity = FIndirectLight::DEFAULT_INTENSITY;
     bool mShowSun = false;
     SkyboxType mType = Skybox::SkyboxType::ENVIRONMENT;
+    float mUiScale = 1.0f;
 };
 
 using BuilderType = Skybox;
@@ -73,6 +74,11 @@ Skybox::Builder& Skybox::Builder::color(math::float4 color) noexcept {
 
 Skybox::Builder& Skybox::Builder::type(SkyboxType type) noexcept {
     mImpl->mType = type;
+    return *this;
+}
+
+Skybox::Builder& Skybox::Builder::uiScale(float scale) noexcept {
+    mImpl->mUiScale = scale;
     return *this;
 }
 
@@ -109,6 +115,7 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
     pInstance->setParameter("showSun", builder->mShowSun);
     pInstance->setParameter("skyboxType", (uint32_t)builder->mType);
     pInstance->setParameter("color", builder->mColor);
+    pInstance->setParameter("uiScaleFactor", builder->mUiScale);
 
     mSkybox = engine.getEntityManager().create();
 
@@ -157,6 +164,10 @@ void FSkybox::setColor(math::float4 color) noexcept {
     mSkyboxMaterialInstance->setParameter("color", color);
 }
 
+void FSkybox::setUiScale(float scale) noexcept {
+    mSkyboxMaterialInstance->setParameter("uiScaleFactor", scale);
+}
+
 void FSkybox::commit(backend::DriverApi& driver) noexcept {
     mSkyboxMaterialInstance->commit(driver);
 }
@@ -183,6 +194,10 @@ void Skybox::setColor(math::float4 color) noexcept {
 
 void Skybox::setType(SkyboxType type) noexcept {
     upcast(this)->setType(type);
+}
+
+void Skybox::setUiScale(float scale) noexcept {
+    upcast(this)->setUiScale(scale);
 }
 
 Texture const* Skybox::getTexture() const noexcept {

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -55,6 +55,8 @@ public:
 
     void setColor(math::float4 color) noexcept;
 
+    void setUiScale(float scale) noexcept;
+
     // commits UBOs
     void commit(backend::DriverApi& driver) noexcept;
 

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -40,17 +40,24 @@ fragment {
         return pow(srgb, vec3(2.2));
     }
 
-    float3 shaprCheckerboardPattern(float2 positionScreenPixelSpace) {
+    // Creates a checkerboard pattern of repeats fields in uv (must be in [0,1])
+    // Source: https://github.com/mattdesl/glsl-checker
+    float checker(float2 uv, float2 repeats) {
+        float cx = floor(repeats.x * uv.x);
+        float cy = floor(repeats.y * uv.y); 
+        float result = mod(cx + cy, 2.0);
+        return sign(result);
+    }
+
+    float3 shaprCheckerboardPattern(float2 positionScaledClipSpace) {
         const float colorLight = 1.0;
         const float colorDark = 0.53;
 
-        const float squareSizePixels = 8.0;
+        // Size of a square in pixels
+        const float2 squareSizePixels = float2(8.0, 8.0);
 
-        float2 sinParam = positionScreenPixelSpace / squareSizePixels * PI;
-        int2 patterns = int2(saturate(1000.0 * sin(sinParam)));
-        float finalPatternValue = float(patterns.x ^ patterns.y);
-
-        float resultColor = finalPatternValue > 0.5 ? colorLight : colorDark;
+        float pattern = checker(positionScaledClipSpace, getResolution().xy / squareSizePixels);
+        float resultColor = mix(colorLight, colorDark, pattern);
         return float3(resultColor, resultColor, resultColor);
     }
 
@@ -133,8 +140,7 @@ fragment {
             sky = float4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);
             sky.rgb *= frameUniforms.iblLuminance;
         } else if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_CHECKERBOARD) {
-            float2 pixelPosition = (variable_clipPos.xy * 0.5 + 0.5) * getResolution().xy;
-            float3 checkerboardColor = shaprCheckerboardPattern(pixelPosition);
+            float3 checkerboardColor = shaprCheckerboardPattern(variable_clipPos.xy * 0.5 + 0.5);
             sky = float4(checkerboardColor, 1.0);
         } else {
             sky = float4(1.0, 0.0, 1.0, 1.0);

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -19,7 +19,8 @@ material {
         }
     ],
     variables : [
-         eyeDirection
+         eyeDirection,
+         clipPos
     ],
     vertexDomain : device,
     depthWrite : false,
@@ -33,9 +34,24 @@ fragment {
 #define SHAPR_SKYBOX_TYPE_SOLID_COLOR 0
 #define SHAPR_SKYBOX_TYPE_GRADIENT 1
 #define SHAPR_SKYBOX_TYPE_ENVIRONMENT 2
+#define SHAPR_SKYBOX_TYPE_CHECKERBOARD 3
 
     float3 approxInverseSRGB(float3 srgb) {
         return pow(srgb, vec3(2.2));
+    }
+
+    float3 shaprCheckerboardPattern(float2 positionScreenPixelSpace) {
+        const float colorLight = 1.0;
+        const float colorDark = 0.53;
+
+        const float squareSizePixels = 8.0;
+
+        float2 sinParam = positionScreenPixelSpace / squareSizePixels * PI;
+        int2 patterns = int2(saturate(1000.0 * sin(sinParam)));
+        float finalPatternValue = float(patterns.x ^ patterns.y);
+
+        float resultColor = finalPatternValue > 0.5 ? colorLight : colorDark;
+        return float3(resultColor, resultColor, resultColor);
     }
 
     // Conversion code from: https://bottosson.github.io/posts/oklab/
@@ -116,11 +132,15 @@ fragment {
         } else if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_ENVIRONMENT) {
             sky = float4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);
             sky.rgb *= frameUniforms.iblLuminance;
+        } else if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_CHECKERBOARD) {
+            float2 pixelPosition = (variable_clipPos.xy * 0.5 + 0.5) * getResolution().xy;
+            float3 checkerboardColor = shaprCheckerboardPattern(pixelPosition);
+            sky = float4(checkerboardColor, 1.0);
         } else {
             sky = float4(1.0, 0.0, 1.0, 1.0);
         }
 
-        if (materialParams.skyboxType == 2 && materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0f) {
+        if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_ENVIRONMENT && materialParams.showSun != 0 && frameUniforms.sun.w >= 0.0f) {
             float3 direction = normalize(variable_eyeDirection.xyz);
             // Assume the sun is a sphere
             float3 sun = frameUniforms.lightColorIntensity.rgb *
@@ -131,7 +151,7 @@ fragment {
             sky.rgb = sky.rgb + gradient * sun;
         }
 
-        if (materialParams.skyboxType != 2) {
+        if (materialParams.skyboxType != SHAPR_SKYBOX_TYPE_ENVIRONMENT) {
             material.baseColor = float4(0.0);
             material.postLightingColor = sky;
         } else {
@@ -145,5 +165,6 @@ vertex {
         float3 p = getPosition().xyz;
         float3 unprojected = mulMat4x4Float3(getViewFromClipMatrix(), p).xyz;
         material.eyeDirection.xyz = mulMat3x3Float3(getWorldFromViewMatrix(), unprojected);
+        material.clipPos.xy = p.xy;
     }
 }

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -16,11 +16,14 @@ material {
         {
            type : float4,
            name : color
+        },
+        {
+           type : float,
+           name : uiScaleFactor
         }
     ],
     variables : [
-         eyeDirection,
-         clipPos
+         eyeDirection
     ],
     vertexDomain : device,
     depthWrite : false,
@@ -54,7 +57,7 @@ fragment {
         const float colorDark = 0.53;
 
         // Size of a square in pixels
-        const float2 squareSizePixels = float2(8.0, 8.0);
+        float2 squareSizePixels = float2(8.0, 8.0) * max(materialParams.uiScaleFactor, 1.0);
 
         float pattern = checker(positionScaledClipSpace, getResolution().xy / squareSizePixels);
         float resultColor = mix(colorLight, colorDark, pattern);
@@ -140,7 +143,7 @@ fragment {
             sky = float4(textureLod(materialParams_skybox, variable_eyeDirection.xyz, 0.0).rgb, 1.0);
             sky.rgb *= frameUniforms.iblLuminance;
         } else if (materialParams.skyboxType == SHAPR_SKYBOX_TYPE_CHECKERBOARD) {
-            float3 checkerboardColor = shaprCheckerboardPattern(variable_clipPos.xy * 0.5 + 0.5);
+            float3 checkerboardColor = shaprCheckerboardPattern(getNormalizedViewportCoord().xy);
             sky = float4(checkerboardColor, 1.0);
         } else {
             sky = float4(1.0, 0.0, 1.0, 1.0);
@@ -171,6 +174,5 @@ vertex {
         float3 p = getPosition().xyz;
         float3 unprojected = mulMat4x4Float3(getViewFromClipMatrix(), p).xyz;
         material.eyeDirection.xyz = mulMat3x3Float3(getWorldFromViewMatrix(), unprojected);
-        material.clipPos.xy = p.xy;
     }
 }

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -810,7 +810,7 @@ void SimpleViewer::updateUserInterface() {
 
         int skyboxType = (int)mSettings.lighting.skyboxType;
         ImGui::Combo("Skybox type", &skyboxType,
-            "Solid color\0Gradient\0Environment\0\0");
+            "Solid color\0Gradient\0Environment\0Checkerboard\0\0");
         mSettings.lighting.skyboxType = (decltype(mSettings.lighting.skyboxType))skyboxType;
         ImGui::ColorEdit3("Background color", &mSettings.viewer.backgroundColor.r);
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-848](https://shapr3d.atlassian.net/browse/GFX-848)

## Short description (What? How?) 📖
Added a checkerboard generation function, and screen space pixel position based usage of it in `skybox.mat` and related C++ code.

Note that Filament's tone mapping blends the patterns corners slightly. I don't think it's visible/noticeable in 1:1 zoom, but here's an example with a 19x zoom.
![image](https://user-images.githubusercontent.com/91476779/145023570-c23f24cc-8b9b-481e-b2bf-db3313aab185.png)

## Testing

### Design review 🎨
Not applicable yet

### Affected areas 🧭
Filament skybox-related code

### Special use-cases to test 🧷
gltf viewer environments, no shapr changes

### How did you test it? 🤔
Manual 💁‍♂️
Using gltf viewer, set the environment type to the new "Checkerboard" option.
