### PR TITLE
Filament [GFX-893] Change gradient direction from Y to Z for Shapr (will break gltf viewer)

### DIFF
--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -71,6 +71,11 @@ public:
         CHECKERBOARD = 3
     };
 
+    enum class UpDirectionAxis : uint8_t {
+        Y_UP = 0,
+        Z_UP = 1
+    };
+
     //! Use Builder to construct an Skybox object instance
     class Builder : public BuilderBase<BuilderDetails> {
         friend struct BuilderDetails;
@@ -149,6 +154,12 @@ public:
         Builder& uiScale(float scale) noexcept;
 
         /**
+        * Sets the axis that points upwards. Required for supporting Filament's Y up and Shapr's
+        * Z up with the same material/shader.
+        */
+        Builder& upDirectionAxis(UpDirectionAxis axis) noexcept;
+
+        /**
          * Creates the Skybox object and returns a pointer to it.
          *
          * @param engine Reference to the filament::Engine to associate this Skybox with.
@@ -166,6 +177,8 @@ public:
     void setType(SkyboxType type) noexcept;
 
     void setUiScale(float scale) noexcept;
+
+    void setUpDirectionAxis(UpDirectionAxis axis) noexcept;
 
     /**
      * Sets bits in a visibility mask. By default, this is 0x1.

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -46,6 +46,7 @@ struct Skybox::BuilderDetails {
     bool mShowSun = false;
     SkyboxType mType = Skybox::SkyboxType::ENVIRONMENT;
     float mUiScale = 1.0f;
+    UpDirectionAxis mUpDirectionAxis = UpDirectionAxis::Y_UP;
 };
 
 using BuilderType = Skybox;
@@ -87,6 +88,11 @@ Skybox::Builder& Skybox::Builder::showSun(bool show) noexcept {
     return *this;
 }
 
+Skybox::Builder& Skybox::Builder::upDirectionAxis(UpDirectionAxis axis) noexcept {
+    mImpl->mUpDirectionAxis = axis;
+    return *this;
+}
+
 Skybox* Skybox::Builder::build(Engine& engine) {
     FTexture* cubemap = upcast(mImpl->mEnvironmentMap);
 
@@ -116,6 +122,7 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
     pInstance->setParameter("skyboxType", (uint32_t)builder->mType);
     pInstance->setParameter("color", builder->mColor);
     pInstance->setParameter("uiScaleFactor", builder->mUiScale);
+    pInstance->setParameter("upDirectionAxis", (uint32_t)builder->mUpDirectionAxis);
 
     mSkybox = engine.getEntityManager().create();
 
@@ -168,6 +175,10 @@ void FSkybox::setUiScale(float scale) noexcept {
     mSkyboxMaterialInstance->setParameter("uiScaleFactor", scale);
 }
 
+void FSkybox::setUpDirectionAxis(UpDirectionAxis axis) noexcept {
+    mSkyboxMaterialInstance->setParameter("upDirectionAxis", (uint32_t)axis);
+}
+
 void FSkybox::commit(backend::DriverApi& driver) noexcept {
     mSkyboxMaterialInstance->commit(driver);
 }
@@ -198,6 +209,10 @@ void Skybox::setType(SkyboxType type) noexcept {
 
 void Skybox::setUiScale(float scale) noexcept {
     upcast(this)->setUiScale(scale);
+}
+
+void Skybox::setUpDirectionAxis(UpDirectionAxis axis) noexcept {
+    upcast(this)->setUpDirectionAxis(axis);
 }
 
 Texture const* Skybox::getTexture() const noexcept {

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -57,6 +57,8 @@ public:
 
     void setUiScale(float scale) noexcept;
 
+    void setUpDirectionAxis(UpDirectionAxis axis) noexcept;
+
     // commits UBOs
     void commit(backend::DriverApi& driver) noexcept;
 

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -20,6 +20,10 @@ material {
         {
            type : float,
            name : uiScaleFactor
+        },
+        {
+           type : int,
+           name : upDirectionAxis
         }
     ],
     variables : [
@@ -117,7 +121,8 @@ fragment {
     float3 shaprSkyGradient() {
         const float shaprThreshold = 0.5;
 
-        float upDirectionMapped = normalize(variable_eyeDirection).z * 0.5 + 0.5;
+        float upDirectionAlongAxis = materialParams.upDirectionAxis == 0 ? normalize(variable_eyeDirection).y : normalize(variable_eyeDirection).z;
+        float upDirectionMapped = upDirectionAlongAxis * 0.5 + 0.5;
         float3 colorRGB = approxInverseSRGB(materialParams.color.rgb);
         float3 colorOklab = linear_srgb_to_oklab(colorRGB);
         if (colorOklab.r > shaprThreshold) {

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -117,7 +117,7 @@ fragment {
     float3 shaprSkyGradient() {
         const float shaprThreshold = 0.5;
 
-        float upDirectionMapped = normalize(variable_eyeDirection).y * 0.5 + 0.5;
+        float upDirectionMapped = normalize(variable_eyeDirection).z * 0.5 + 0.5;
         float3 colorRGB = approxInverseSRGB(materialParams.color.rgb);
         float3 colorOklab = linear_srgb_to_oklab(colorRGB);
         if (colorOklab.r > shaprThreshold) {


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-893](https://shapr3d.atlassian.net/browse/GFX-893)

## Short description (What? How?) 📖
Shapr uses a Z-up coordinate system, while Filament uses a Y-up one. This means our gradient skybox shader looking fine (having a vertical gradient) in gltf viewer, will not look as intended (the gradient will be horizontal) in Shapr.

Edit: We decided to use a runtime uniform variable to switch between the two, to be able to handle both cases without Filament rebuilds. The default behaviour is Y up. See https://github.com/shapr3d/filament/pull/13/commits/460d1516f80e16571179f7858856fcb0ef22f96a

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Gradient environment rendering

### Special use-cases to test 🧷
N/A

### How did you test it? 🤔
Manual 💁‍♂️
The gradient is now horizontal in gltf viewer.