### PR TITLE
[GFX-828] Add checkerboard grays, gradient settings uniforms to Filament's skybox

### DIFF
--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -149,6 +149,21 @@ public:
         Builder& uiScale(float scale) noexcept;
 
         /**
+        * Sets the checkerboard pattern's colors. Both are the level of gray between 0 and 1.
+        * 
+        * Defaults to 1.0 and 0.8.
+        */
+        Builder& checkerboardGrays(math::float2 grays) noexcept;
+
+        /**
+        * Sets the gradient's position and dimming factor. Dimming factor is in X, upper limit
+        * is in Y, location is in Z, and lower limit is in W.
+        * 
+        * Defaults are 0.8, 0.93, 0.55, 0.4.
+        */
+        Builder& gradientSettings(math::float4 settings) noexcept;
+
+        /**
          * Creates the Skybox object and returns a pointer to it.
          *
          * @param engine Reference to the filament::Engine to associate this Skybox with.

--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -194,6 +194,8 @@ public:
 
     void setUpDirectionAxis(UpDirectionAxis axis) noexcept;
 
+    void setCheckerboardGrays(math::float2 grays) noexcept;
+
     /**
      * Sets bits in a visibility mask. By default, this is 0x1.
      *

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -193,6 +193,10 @@ void FSkybox::setUpDirectionAxis(UpDirectionAxis axis) noexcept {
     mSkyboxMaterialInstance->setParameter("upDirectionAxis", (uint32_t)axis);
 }
 
+void FSkybox::setCheckerboardGrays(math::float2 grays) noexcept {
+    mSkyboxMaterialInstance->setParameter("checkerboardGrays", grays);
+}
+
 void FSkybox::commit(backend::DriverApi& driver) noexcept {
     mSkyboxMaterialInstance->commit(driver);
 }
@@ -227,6 +231,10 @@ void Skybox::setUiScale(float scale) noexcept {
 
 void Skybox::setUpDirectionAxis(UpDirectionAxis axis) noexcept {
     upcast(this)->setUpDirectionAxis(axis);
+}
+
+void Skybox::setCheckerboardGrays(math::float2 grays) noexcept {
+    upcast(this)->setCheckerboardGrays(grays);
 }
 
 Texture const* Skybox::getTexture() const noexcept {

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -46,6 +46,8 @@ struct Skybox::BuilderDetails {
     bool mShowSun = false;
     SkyboxType mType = Skybox::SkyboxType::ENVIRONMENT;
     float mUiScale = 1.0f;
+    float2 mCheckerboardGrays{1.0, 0.8};
+    float4 mGradientSettings{0.8, 0.93, 0.55, 0.4};
 };
 
 using BuilderType = Skybox;
@@ -79,6 +81,16 @@ Skybox::Builder& Skybox::Builder::type(SkyboxType type) noexcept {
 
 Skybox::Builder& Skybox::Builder::uiScale(float scale) noexcept {
     mImpl->mUiScale = scale;
+    return *this;
+}
+
+Skybox::Builder& Skybox::Builder::checkerboardGrays(math::float2 grays) noexcept {
+    mImpl->mCheckerboardGrays = grays;
+    return *this;
+}
+
+Skybox::Builder& Skybox::Builder::gradientSettings(math::float4 settings) noexcept {
+    mImpl->mGradientSettings = settings;
     return *this;
 }
 
@@ -116,6 +128,8 @@ FSkybox::FSkybox(FEngine& engine, const Builder& builder) noexcept
     pInstance->setParameter("skyboxType", (uint32_t)builder->mType);
     pInstance->setParameter("color", builder->mColor);
     pInstance->setParameter("uiScaleFactor", builder->mUiScale);
+    pInstance->setParameter("checkerboardGrays", builder->mCheckerboardGrays);
+    pInstance->setParameter("gradientSettings", builder->mGradientSettings);
 
     mSkybox = engine.getEntityManager().create();
 

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -47,8 +47,8 @@ struct Skybox::BuilderDetails {
     SkyboxType mType = Skybox::SkyboxType::ENVIRONMENT;
     float mUiScale = 1.0f;
     UpDirectionAxis mUpDirectionAxis = UpDirectionAxis::Y_UP;
-    float2 mCheckerboardGrays{1.0, 0.8};
-    float4 mGradientSettings{0.8, 0.93, 0.55, 0.4};
+    float2 mCheckerboardGrays{1.0f, 0.8f};
+    float4 mGradientSettings{0.8f, 0.93f, 0.55f, 0.4f};
 };
 
 using BuilderType = Skybox;

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -59,6 +59,8 @@ public:
 
     void setUpDirectionAxis(UpDirectionAxis axis) noexcept;
 
+    void setCheckerboardGrays(math::float2 grays) noexcept;
+
     // commits UBOs
     void commit(backend::DriverApi& driver) noexcept;
 

--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -20,6 +20,14 @@ material {
         {
            type : float,
            name : uiScaleFactor
+        },
+        {
+           type : float2,
+           name : checkerboardGrays
+        },
+        {
+           type : float4,
+           name : gradientSettings
         }
     ],
     variables : [
@@ -53,8 +61,8 @@ fragment {
     }
 
     float3 shaprCheckerboardPattern(float2 positionScaledClipSpace) {
-        const float colorLight = 1.0;
-        const float colorDark = 0.53;
+        float colorLight = materialParams.checkerboardGrays.x;
+        float colorDark = materialParams.checkerboardGrays.y;
 
         // Size of a square in pixels
         float2 squareSizePixels = float2(8.0, 8.0) * max(materialParams.uiScaleFactor, 1.0);
@@ -100,10 +108,10 @@ fragment {
     }
 
     float computeGradient(float t) {
-        const float dimmingFactor = 0.6;
-        const float gradientStartHigh = 0.9;
-        const float gradientLocation = 0.4;
-        const float gradientStartLow = 0.2;
+        float dimmingFactor = materialParams.gradientSettings.x;
+        float gradientStartHigh = materialParams.gradientSettings.y;
+        float gradientLocation = materialParams.gradientSettings.z;
+        float gradientStartLow = materialParams.gradientSettings.w;
 
         float grad;
         if (t >= gradientLocation) {


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-828](https://shapr3d.atlassian.net/browse/GFX-828)

## Short description (What? How?) 📖
We need some iterations on the looks of the gradient and checkerboard pattern backgrounds. Adding uniform variables allows us to iterate on them without needing Filament bumps in the Shapr repository.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Filament's skybox material

### Special use-cases to test 🧷
N/A

### How did you test it? 🤔

Manual 💁‍♂️
Looked at gltf viewer by hand.