### PR TITLE
Filament [GFX-925] Disallow color components to get out of 0..1 range

### DIFF
--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -175,7 +175,7 @@ fragment {
 
         if (materialParams.skyboxType != SHAPR_SKYBOX_TYPE_ENVIRONMENT) {
             material.baseColor = float4(0.0);
-            material.postLightingColor = sky;
+            material.postLightingColor = saturate(sky);
         } else {
             material.baseColor = sky;
         }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-925](https://shapr3d.atlassian.net/browse/GFX-925)

## Short description (What? How?) 📖
Gradients got burnt out when very saturated colours were chosen. See screenshot.
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/91476779/146028402-688ffb44-14d8-400a-95c7-570d705823d5.png">

The root cause was color components close to 0 becoming negative, if another component was close to 1, which caused color grading to fail.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Visualization tool gradient environment

### Special use-cases to test 🧷
Visualization tool gradient environment with very saturated colours

### How did you test it? 🤔
Manual 💁‍♂️
Tried problematic colors, looked fine.