### PR TITLE
GltfViewer [GFX-991] Texture validation functions

### DIFF
--- a/libs/viewer/include/viewer/SimpleViewer.h
+++ b/libs/viewer/include/viewer/SimpleViewer.h
@@ -22,6 +22,7 @@
 #include <filament/Engine.h>
 #include <filament/IndirectLight.h>
 #include <filament/Scene.h>
+#include <filament/Texture.h>
 #include <filament/View.h>
 
 #include <gltfio/Animator.h>
@@ -230,6 +231,7 @@ private:
     void changeElementVisibility(utils::Entity entity, int elementIndex, bool newVisibility);
     void changeAllVisibility(utils::Entity entity, bool changeToVisible);
 
+    const char* formatToName(filament::Texture::InternalFormat format) const;
     std::string validateTweaks(const TweakableMaterial&);
 
     void quickLoad();

--- a/libs/viewer/include/viewer/SimpleViewer.h
+++ b/libs/viewer/include/viewer/SimpleViewer.h
@@ -230,6 +230,8 @@ private:
     void changeElementVisibility(utils::Entity entity, int elementIndex, bool newVisibility);
     void changeAllVisibility(utils::Entity entity, bool changeToVisible);
 
+    std::string validateTweaks(const TweakableMaterial&);
+
     void quickLoad();
     void undoLastModification();
     //void redoLastModification();
@@ -284,6 +286,7 @@ private:
     std::unordered_map<std::string, TweakableMaterial> mTweakedMaterials{};
     std::vector<filament::MaterialInstance*> mMaterialInstances{};
     std::unordered_map<std::string, filament::Texture*> mTextures{};
+    std::unordered_map<std::string, int> mTextureFileChannels{};
     bool mVisibility[10]{ true, true, true, true, true, true, true, true, true, true };
 
     TextureSampler trilinSampler = TextureSampler(TextureSampler::MinFilter::LINEAR_MIPMAP_LINEAR, TextureSampler::MagFilter::LINEAR, TextureSampler::WrapMode::REPEAT);

--- a/libs/viewer/include/viewer/TweakableMaterial.h
+++ b/libs/viewer/include/viewer/TweakableMaterial.h
@@ -86,16 +86,16 @@ public:
 
     TweakablePropertyTextured<filament::math::float4,true> mBaseColor{ {0.0f, 0.0f, 0.0f, 1.0f} };
 
-    TweakablePropertyTextured<float, false> mNormal{};
+    TweakablePropertyTextured<float> mNormal{};
     TweakableProperty<float, false> mOcclusionIntensity{ 1.0f };
-    TweakablePropertyTextured<float, false> mOcclusion{1.0f};
+    TweakablePropertyTextured<float> mOcclusion{1.0f};
     TweakableProperty<float> mRoughnessScale{};
     TweakablePropertyTextured<float> mRoughness;
     TweakablePropertyTextured<float> mMetallic{};
 
     TweakableProperty<float> mClearCoat{};
     TweakableProperty<float> mClearCoatNormalIntensity{1.0f};
-    TweakablePropertyTextured<float, false> mClearCoatNormal{};
+    TweakablePropertyTextured<float> mClearCoatNormal{};
     TweakablePropertyTextured<float> mClearCoatRoughness{};
 
     std::vector< RequestedTexture > mRequestedTextures{};

--- a/libs/viewer/include/viewer/TweakableMaterial.h
+++ b/libs/viewer/include/viewer/TweakableMaterial.h
@@ -149,8 +149,8 @@ private:
         result[prefix + "Texture"] = (item.isFile) ? item.filename.asString() : "";
     }
 
-    template< typename T, bool MayContainFile = false, bool IsColor = true, bool IsDerivable = false, typename = IsValidTweakableType<T> >
-    void readTexturedFromJson(const json& source, const std::string& prefix, TweakableProperty<T, MayContainFile, IsColor>& item, bool isSrgb = false, bool isAlpha = false, T defaultValue = {}) {
+    template< typename T, bool MayContainFile = false, bool IsColor = false, bool IsDerivable = false, typename = IsValidTweakableType<T> >
+    void readTexturedFromJson(const json& source, const std::string& prefix, TweakableProperty<T, MayContainFile, IsColor>& item, bool isSrgb = false, bool isAlpha = false, int channelCount = 1, T defaultValue = {}) {
         item.value = source.value(prefix, defaultValue);
         if (source.find(prefix) == source.end()) {
             std::cout << "Unable to read textured property '" << prefix << "', reverting to default value without texture." << std::endl;
@@ -163,7 +163,7 @@ private:
             item.filename = filename;
             item.doRequestReload = true;
             if (item.isFile) {
-                enqueueTextureRequest(item.filename.asString(), item.doRequestReload, isSrgb, isAlpha);
+                enqueueTextureRequest(item.filename.asString(), item.doRequestReload, isSrgb, isAlpha, channelCount);
             }
         }
     }

--- a/libs/viewer/include/viewer/TweakableMaterial.h
+++ b/libs/viewer/include/viewer/TweakableMaterial.h
@@ -72,6 +72,7 @@ public:
 
     struct RequestedTexture {
         std::string filename{};
+        int channelCount{};
         bool isSrgb{};
         bool isAlpha{};
         bool doRequestReload{};
@@ -79,14 +80,14 @@ public:
 
     json toJson();
     void fromJson(const json& source);
-    void drawUI();
+    void drawUI(const std::string& header);
 
     const TweakableMaterial::RequestedTexture nextRequestedTexture();
 
-    TweakablePropertyTextured<filament::math::float4> mBaseColor{ {0.0f, 0.0f, 0.0f, 1.0f} };
+    TweakablePropertyTextured<filament::math::float4,true> mBaseColor{ {0.0f, 0.0f, 0.0f, 1.0f} };
 
     TweakablePropertyTextured<float, false> mNormal{};
-    TweakablePropertyTextured<float, false> mOcclusionIntensity{ 1.0f };
+    TweakableProperty<float, false> mOcclusionIntensity{ 1.0f };
     TweakablePropertyTextured<float, false> mOcclusion{1.0f};
     TweakableProperty<float> mRoughnessScale{};
     TweakablePropertyTextured<float> mRoughness;
@@ -130,14 +131,16 @@ public:
 
     void resetWithType(MaterialType newType);
 
+    bool mDoesRequireValidation = false;
+
 private:
     template< typename T, bool MayContainFile = false, bool IsColor = true, bool IsDerivable = false, typename = IsValidTweakableType<T> >
-    void enqueueTextureRequest(TweakableProperty<T, MayContainFile, IsColor>& item, bool isSrgb = false, bool isAlpa = false) {
-        enqueueTextureRequest(item.filename, item.doRequestReload, isSrgb, isAlpa);
+    void enqueueTextureRequest(TweakableProperty<T, MayContainFile, IsColor>& item, bool isSrgb = false, bool isAlpha = false, int channelCount = 1) {
+        enqueueTextureRequest(item.filename, item.doRequestReload, isSrgb, isAlpha, channelCount);
         item.doRequestReload = false;
     }
-
-    void enqueueTextureRequest(const std::string& filename, bool doRequestReload, bool isSrgb = false, bool isAlpa = false);
+    void enqueueTextureRequest(const std::string& filename, bool doRequestReload, bool isSrgb = false, bool isAlpha = false, int channelCount = 1);
+    void requestValidation();
 
     template< typename T, bool MayContainFile = false, bool IsColor = true, bool IsDerivable = false, typename = IsValidTweakableType<T> >
     void writeTexturedToJson(json& result, const std::string& prefix, const TweakableProperty<T, MayContainFile, IsColor>& item) {

--- a/libs/viewer/include/viewer/TweakableProperty.h
+++ b/libs/viewer/include/viewer/TweakableProperty.h
@@ -174,6 +174,21 @@ struct TweakableProperty {
             return mFilename;
         }
 
+        std::string getFileExtension() const {
+            std::string result = "";
+
+            size_t lastDotPlusOne = mFilename.find_last_of(".") + 1;
+            if (lastDotPlusOne < mFilename.length()) {
+                result = mFilename.substr(lastDotPlusOne);
+            }
+
+            for (auto& c : result) {
+                c = std::tolower(c);
+            }
+
+            return result;
+        }
+
         bool empty() { return mFilename.empty(); }
         void clear() { mFilename.clear(); }
     };
@@ -182,7 +197,7 @@ struct TweakableProperty {
     FilenameHolder filename{};
 };
 
-template <typename T, bool IsColor = true, typename = IsValidTweakableType<T> >
+template <typename T, bool IsColor = false, typename = IsValidTweakableType<T> >
 using TweakablePropertyTextured = TweakableProperty<T, true, IsColor>;
 
 template <typename T, bool IsColor = true, typename = IsValidTweakableType<T> >

--- a/libs/viewer/include/viewer/TweakableProperty.h
+++ b/libs/viewer/include/viewer/TweakableProperty.h
@@ -175,12 +175,8 @@ struct TweakableProperty {
         }
 
         std::string getFileExtension() const {
-            std::string result = "";
-
-            size_t lastDotPlusOne = mFilename.find_last_of(".") + 1;
-            if (lastDotPlusOne < mFilename.length()) {
-                result = mFilename.substr(lastDotPlusOne);
-            }
+            utils::Path path(mFilename);
+            std::string result = path.getExtension();
 
             for (auto& c : result) {
                 c = std::tolower(c);

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -926,6 +926,10 @@ std::string SimpleViewer::validateTweaks(const TweakableMaterial& tweaks) {
                         expectedFormat = filament::Texture::InternalFormat::R8;
                         expectedChannelCount = 1;
                     }
+                } else {
+                    if (expectedFormat == filament::Texture::InternalFormat::SRGB8_A8) expectedChannelCount = 4;
+                    else if (expectedFormat == filament::Texture::InternalFormat::SRGB8 || expectedFormat == filament::Texture::InternalFormat::RGB8) expectedChannelCount = 3;
+                    else if (expectedFormat == filament::Texture::InternalFormat::R8 ) expectedChannelCount = 1;
                 }
 
                 if (textureEntry->second->getFormat() != expectedFormat) {

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -797,155 +797,166 @@ void SimpleViewer::changeAllVisibility(utils::Entity entity, bool changeToVisibl
     }
 };
 
-static const char* formatToName[] = {
-    "R8",
-    "R8_SNORM",
-    "R8UI",
-    "R8I",
-    "STENCIL8",
-    "R16F",
-    "R16UI",
-    "R16I",
-    "RG8",
-    "RG8_SNORM",
-    "RG8UI",
-    "RG8I",
-    "RGB565",
-    "RGB9_E5",
-    "RGB5_A1",
-    "RGBA4",
-    "DEPTH16",
-    "RGB8",
-    "SRGB8",
-    "RGB8_SNORM",
-    "RGB8UI",
-    "RGB8I",
-    "DEPTH24",
-    "R32F",
-    "R32UI",
-    "R32I",
-    "RG16F",
-    "RG16UI",
-    "RG16I",
-    "R11F_G11F_B10F",
-    "RGBA8",
-    "SRGB8_A8",
-    "RGBA8_SNORM",
-    "UNUSED",
-    "RGB10_A2",
-    "RGBA8UI",
-    "RGBA8I",
-    "DEPTH32F",
-    "DEPTH24_STENCIL8",
-    "DEPTH32F_STENCIL8",
-    "RGB16F",
-    "RGB16UI",
-    "RGB16I",
-    "RG32F",
-    "RG32UI",
-    "RG32I",
-    "RGBA16F",
-    "RGBA16UI",
-    "RGBA16I",
-    "RGB32F",
-    "RGB32UI",
-    "RGB32I",
-    "RGBA32F",
-    "RGBA32UI",
-    "RGBA32I",
-    "EAC_R11",
-    "EAC_R11_SIGNED",
-    "EAC_RG11",
-    "EAC_RG11_SIGNED",
-    "ETC2_RGB8",
-    "ETC2_SRGB8",
-    "ETC2_RGB8_A1",
-    "ETC2_SRGB8_A1",
-    "ETC2_EAC_RGBA8",
-    "ETC2_EAC_SRGBA8",
-    "DXT1_RGB",
-    "DXT1_RGBA",
-    "DXT3_RGBA",
-    "DXT5_RGBA",
-    "DXT1_SRGB",
-    "DXT1_SRGBA",
-    "DXT3_SRGBA",
-    "DXT5_SRGBA",
-    "RGBA_ASTC_4x4",
-    "RGBA_ASTC_5x4",
-    "RGBA_ASTC_5x5",
-    "RGBA_ASTC_6x5",
-    "RGBA_ASTC_6x6",
-    "RGBA_ASTC_8x5",
-    "RGBA_ASTC_8x6",
-    "RGBA_ASTC_8x8",
-    "RGBA_ASTC_10x5",
-    "RGBA_ASTC_10x6",
-    "RGBA_ASTC_10x8",
-    "RGBA_ASTC_10x10",
-    "RGBA_ASTC_12x10",
-    "RGBA_ASTC_12x12",
-    "SRGB8_ALPHA8_ASTC_4x4",
-    "SRGB8_ALPHA8_ASTC_5x4",
-    "SRGB8_ALPHA8_ASTC_5x5",
-    "SRGB8_ALPHA8_ASTC_6x5",
-    "SRGB8_ALPHA8_ASTC_6x6",
-    "SRGB8_ALPHA8_ASTC_8x5",
-    "SRGB8_ALPHA8_ASTC_8x6",
-    "SRGB8_ALPHA8_ASTC_8x8",
-    "SRGB8_ALPHA8_ASTC_10x5",
-    "SRGB8_ALPHA8_ASTC_10x6",
-    "SRGB8_ALPHA8_ASTC_10x8",
-    "SRGB8_ALPHA8_ASTC_10x10",
-    "SRGB8_ALPHA8_ASTC_12x10",
-    "SRGB8_ALPHA8_ASTC_12x12",
-};
-
+const char* SimpleViewer::formatToName(filament::Texture::InternalFormat format) const {
+    switch (format) {
+    case filament::Texture::InternalFormat::R8: return "R8";
+    case filament::Texture::InternalFormat::R8_SNORM: return "R8_SNORM";
+    case filament::Texture::InternalFormat::R8UI: return "R8UI";
+    case filament::Texture::InternalFormat::R8I: return "R8I";
+    case filament::Texture::InternalFormat::STENCIL8: return "STENCIL8";
+    case filament::Texture::InternalFormat::R16F: return "R16F";
+    case filament::Texture::InternalFormat::R16UI: return "R16UI";
+    case filament::Texture::InternalFormat::R16I: return "R16I";
+    case filament::Texture::InternalFormat::RG8: return "RG8";
+    case filament::Texture::InternalFormat::RG8_SNORM: return "RG8_SNORM";
+    case filament::Texture::InternalFormat::RG8UI: return "RG8UI";
+    case filament::Texture::InternalFormat::RG8I: return "RG8I";
+    case filament::Texture::InternalFormat::RGB565: return "RGB565";
+    case filament::Texture::InternalFormat::RGB9_E5: return "RGB9_E5";
+    case filament::Texture::InternalFormat::RGB5_A1: return "RGB5_A1";
+    case filament::Texture::InternalFormat::RGBA4: return "RGBA4";
+    case filament::Texture::InternalFormat::DEPTH16: return "DEPTH16";
+    case filament::Texture::InternalFormat::RGB8: return "RGB8";
+    case filament::Texture::InternalFormat::SRGB8: return "SRGB8";
+    case filament::Texture::InternalFormat::RGB8_SNORM: return "RGB8_SNORM";
+    case filament::Texture::InternalFormat::RGB8UI: return "RGB8UI";
+    case filament::Texture::InternalFormat::RGB8I: return "RGB8I";
+    case filament::Texture::InternalFormat::DEPTH24: return "DEPTH24";
+    case filament::Texture::InternalFormat::R32F: return "R32F";
+    case filament::Texture::InternalFormat::R32UI: return "R32UI";
+    case filament::Texture::InternalFormat::R32I: return "R32I";
+    case filament::Texture::InternalFormat::RG16F: return "RG16F";
+    case filament::Texture::InternalFormat::RG16UI: return "RG16UI";
+    case filament::Texture::InternalFormat::RG16I: return "RG16I";
+    case filament::Texture::InternalFormat::R11F_G11F_B10F: return "R11F_G11F_B10F";
+    case filament::Texture::InternalFormat::RGBA8: return "RGBA8";
+    case filament::Texture::InternalFormat::SRGB8_A8: return "SRGB8_A8";
+    case filament::Texture::InternalFormat::RGBA8_SNORM: return "RGBA8_SNORM";
+    case filament::Texture::InternalFormat::UNUSED: return "UNUSED";
+    case filament::Texture::InternalFormat::RGB10_A2: return "RGB10_A2";
+    case filament::Texture::InternalFormat::RGBA8UI: return "RGBA8UI";
+    case filament::Texture::InternalFormat::RGBA8I: return "RGBA8I";
+    case filament::Texture::InternalFormat::DEPTH32F: return "DEPTH32F";
+    case filament::Texture::InternalFormat::DEPTH24_STENCIL8: return "DEPTH24_STENCIL8";
+    case filament::Texture::InternalFormat::DEPTH32F_STENCIL8: return "DEPTH32F_STENCIL8";
+    case filament::Texture::InternalFormat::RGB16F: return "RGB16F";
+    case filament::Texture::InternalFormat::RGB16UI: return "RGB16UI";
+    case filament::Texture::InternalFormat::RGB16I: return "RGB16I";
+    case filament::Texture::InternalFormat::RG32F: return "RG32F";
+    case filament::Texture::InternalFormat::RG32UI: return "RG32UI";
+    case filament::Texture::InternalFormat::RG32I: return "RG32I";
+    case filament::Texture::InternalFormat::RGBA16F: return "RGBA16F";
+    case filament::Texture::InternalFormat::RGBA16UI: return "RGBA16UI";
+    case filament::Texture::InternalFormat::RGBA16I: return "RGBA16I";
+    case filament::Texture::InternalFormat::RGB32F: return "RGB32F";
+    case filament::Texture::InternalFormat::RGB32UI: return "RGB32UI";
+    case filament::Texture::InternalFormat::RGB32I: return "RGB32I";
+    case filament::Texture::InternalFormat::RGBA32F: return "RGBA32F";
+    case filament::Texture::InternalFormat::RGBA32UI: return "RGBA32UI";
+    case filament::Texture::InternalFormat::RGBA32I: return "RGBA32I";
+    case filament::Texture::InternalFormat::EAC_R11: return "EAC_R11";
+    case filament::Texture::InternalFormat::EAC_R11_SIGNED: return "EAC_R11_SIGNED";
+    case filament::Texture::InternalFormat::EAC_RG11: return "EAC_RG11";
+    case filament::Texture::InternalFormat::EAC_RG11_SIGNED: return "EAC_RG11_SIGNED";
+    case filament::Texture::InternalFormat::ETC2_RGB8: return "ETC2_RGB8";
+    case filament::Texture::InternalFormat::ETC2_SRGB8: return "ETC2_SRGB8";
+    case filament::Texture::InternalFormat::ETC2_RGB8_A1: return "ETC2_RGB8_A1";
+    case filament::Texture::InternalFormat::ETC2_SRGB8_A1: return "ETC2_SRGB8_A1";
+    case filament::Texture::InternalFormat::ETC2_EAC_RGBA8: return "ETC2_EAC_RGBA8";
+    case filament::Texture::InternalFormat::ETC2_EAC_SRGBA8: return "ETC2_EAC_SRGBA8";
+    case filament::Texture::InternalFormat::DXT1_RGB: return "DXT1_RGB";
+    case filament::Texture::InternalFormat::DXT1_RGBA: return "DXT1_RGBA";
+    case filament::Texture::InternalFormat::DXT3_RGBA: return "DXT3_RGBA";
+    case filament::Texture::InternalFormat::DXT5_RGBA: return "DXT5_RGBA";
+    case filament::Texture::InternalFormat::DXT1_SRGB: return "DXT1_SRGB";
+    case filament::Texture::InternalFormat::DXT1_SRGBA: return "DXT1_SRGBA";
+    case filament::Texture::InternalFormat::DXT3_SRGBA: return "DXT3_SRGBA";
+    case filament::Texture::InternalFormat::DXT5_SRGBA: return "DXT5_SRGBA";
+    case filament::Texture::InternalFormat::RGBA_ASTC_4x4: return "RGBA_ASTC_4x4";
+    case filament::Texture::InternalFormat::RGBA_ASTC_5x4: return "RGBA_ASTC_5x4";
+    case filament::Texture::InternalFormat::RGBA_ASTC_5x5: return "RGBA_ASTC_5x5";
+    case filament::Texture::InternalFormat::RGBA_ASTC_6x5: return "RGBA_ASTC_6x5";
+    case filament::Texture::InternalFormat::RGBA_ASTC_6x6: return "RGBA_ASTC_6x6";
+    case filament::Texture::InternalFormat::RGBA_ASTC_8x5: return "RGBA_ASTC_8x5";
+    case filament::Texture::InternalFormat::RGBA_ASTC_8x6: return "RGBA_ASTC_8x6";
+    case filament::Texture::InternalFormat::RGBA_ASTC_8x8: return "RGBA_ASTC_8x8";
+    case filament::Texture::InternalFormat::RGBA_ASTC_10x5: return "RGBA_ASTC_10x5";
+    case filament::Texture::InternalFormat::RGBA_ASTC_10x6: return "RGBA_ASTC_10x6";
+    case filament::Texture::InternalFormat::RGBA_ASTC_10x8: return "RGBA_ASTC_10x8";
+    case filament::Texture::InternalFormat::RGBA_ASTC_10x10: return "RGBA_ASTC_10x10";
+    case filament::Texture::InternalFormat::RGBA_ASTC_12x10: return "RGBA_ASTC_12x10";
+    case filament::Texture::InternalFormat::RGBA_ASTC_12x12: return "RGBA_ASTC_12x12";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_4x4: return "SRGB8_ALPHA8_ASTC_4x4";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_5x4: return "SRGB8_ALPHA8_ASTC_5x4";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_5x5: return "SRGB8_ALPHA8_ASTC_5x5";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_6x5: return "SRGB8_ALPHA8_ASTC_6x5";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_6x6: return "SRGB8_ALPHA8_ASTC_6x6";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_8x5: return "SRGB8_ALPHA8_ASTC_8x5";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_8x6: return "SRGB8_ALPHA8_ASTC_8x6";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_8x8: return "SRGB8_ALPHA8_ASTC_8x8";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_10x5: return "SRGB8_ALPHA8_ASTC_10x5";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_10x6: return "SRGB8_ALPHA8_ASTC_10x6";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_10x8: return "SRGB8_ALPHA8_ASTC_10x8";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_10x10: return "SRGB8_ALPHA8_ASTC_10x10";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_12x10: return "SRGB8_ALPHA8_ASTC_12x10";
+    case filament::Texture::InternalFormat::SRGB8_ALPHA8_ASTC_12x12: return "SRGB8_ALPHA8_ASTC_12x12";
+    }
+}
 
 std::string SimpleViewer::validateTweaks(const TweakableMaterial& tweaks) {
-    auto verifyTextured = [&]<typename T, bool MayContainFile, bool IsColor, bool IsDerivable>(std::string& result, const std::string& prompt, const TweakableProperty<T, MayContainFile, IsColor, IsDerivable>& prop, filament::Texture::InternalFormat expectedFormat = filament::Texture::InternalFormat::UNUSED) {
-        if (prop.isFile) {
-            if (prop.filename.getFileExtension() != "png") {
-                result += "ERROR: " + prompt + " is not a png.\n";
-            }
+    auto verifyTextured = [&]<typename T, bool MayContainFile, bool IsColor, bool IsDerivable>(
+        std::string & result,
+        const std::string & prompt,
+        const TweakableProperty<T, MayContainFile, IsColor, IsDerivable>&prop,
+        filament::Texture::InternalFormat expectedFormat = filament::Texture::InternalFormat::UNUSED) {
 
-            auto textureEntry = mTextures.find(prop.filename.asString());
-            if (textureEntry != mTextures.end()) {
-                int expectedChannelCount;
-                // Infer the expected texture format if no explicit cue was given by the caller
-                if (expectedFormat == filament::Texture::InternalFormat::UNUSED) {
-                    if (IsColor) {
-                        if (tweaks.mShaderType == TweakableMaterial::MaterialType::TransparentSolid) {
-                            expectedFormat = filament::Texture::InternalFormat::SRGB8_A8;
-                            expectedChannelCount = 4;
-                        } else {
-                            expectedFormat = filament::Texture::InternalFormat::SRGB8;
-                            expectedChannelCount = 3;
-                        }
-                    } else {
-                        expectedFormat = filament::Texture::InternalFormat::R8;
-                        expectedChannelCount = 1;
-                    }
-                } else {
-                    if (expectedFormat == filament::Texture::InternalFormat::SRGB8_A8) expectedChannelCount = 4;
-                    else if (expectedFormat == filament::Texture::InternalFormat::SRGB8 || expectedFormat == filament::Texture::InternalFormat::RGB8) expectedChannelCount = 3;
-                    else if (expectedFormat == filament::Texture::InternalFormat::R8 ) expectedChannelCount = 1;
-                }
+        if (!prop.isFile) return;
 
-                if (textureEntry->second->getFormat() != expectedFormat) {
-                    result += "ERROR: " + prompt + " has incorrect format! Expected " + formatToName[(int16_t)expectedFormat] + ", got " + formatToName[(int16_t)textureEntry->second->getFormat()] + ".\n";
-                }
+        if (prop.filename.getFileExtension() != "png") {
+            result += "ERROR: " + prompt + " is not a png.\n";
+        }
 
-                auto textureChannelCountEntry = mTextureFileChannels.find(prop.filename.asString());
-                if (textureChannelCountEntry != mTextureFileChannels.end()) {
-                    if (textureChannelCountEntry->second != expectedChannelCount) {
-                        result += "ERROR: " + prompt + " has incorrect number of channels! Expected " + std::to_string(expectedChannelCount) + ", got " + std::to_string(mTextureFileChannels[prop.filename.asString()]) + ".\n";
-                    }
+        auto textureEntry = mTextures.find(prop.filename.asString());
+        if (textureEntry == mTextures.end()) {
+            result += "ERROR: " + prompt + " cannot be found.\n";
+            return;
+        }
+        int expectedChannelCount = 0;
+        // Infer the expected texture format if no explicit cue was given by the caller
+        if (expectedFormat == filament::Texture::InternalFormat::UNUSED) {
+            if (IsColor) {
+                if (tweaks.mShaderType == TweakableMaterial::MaterialType::TransparentSolid) {
+                    expectedFormat = filament::Texture::InternalFormat::SRGB8_A8;
+                    expectedChannelCount = 4;
                 }
                 else {
-                    result += "ERROR: " + prompt + " has no channel numbers! Expected a " + std::to_string(expectedChannelCount) + " channel texture.\n";
+                    expectedFormat = filament::Texture::InternalFormat::SRGB8;
+                    expectedChannelCount = 3;
                 }
             }
+            else {
+                expectedFormat = filament::Texture::InternalFormat::R8;
+                expectedChannelCount = 1;
+            }
+        }
+        else {
+            if (expectedFormat == filament::Texture::InternalFormat::SRGB8_A8) expectedChannelCount = 4;
+            else if (expectedFormat == filament::Texture::InternalFormat::SRGB8 || expectedFormat == filament::Texture::InternalFormat::RGB8) expectedChannelCount = 3;
+            else if (expectedFormat == filament::Texture::InternalFormat::R8) expectedChannelCount = 1;
+        }
+
+        if (textureEntry->second->getFormat() != expectedFormat) {
+            result += "ERROR: " + prompt + " has incorrect format! Expected " + formatToName(expectedFormat) + ", got " + formatToName(textureEntry->second->getFormat()) + ".\n";
+        }
+
+        auto textureChannelCountEntry = mTextureFileChannels.find(prop.filename.asString());
+        if (textureChannelCountEntry != mTextureFileChannels.end()) {
+            if (textureChannelCountEntry->second != expectedChannelCount) {
+                result += "ERROR: " + prompt + " has incorrect number of channels! Expected " + std::to_string(expectedChannelCount) + ", got " + std::to_string(textureChannelCountEntry->second) + ".\n";
+            }
+        }
+        else {
+            result += "ERROR: " + prompt + " has no channel numbers! Expected a " + std::to_string(expectedChannelCount) + " channel texture.\n";
         }
     };
 
@@ -1028,8 +1039,8 @@ void SimpleViewer::updateUserInterface() {
                                 filament::MaterialInstance* newInstance = mEngine->getShaprMaterial(tweaks.mShaderType)->createInstance();
                                 mMaterialInstances.push_back(newInstance);
                                 rm.setMaterialInstanceAt(instance, prim, newInstance);
-                                tweaks.mDoesRequireValidation = true;
                             }
+                            tweaks.mDoesRequireValidation = true;
                         }
 
                     } else {

--- a/libs/viewer/src/TweakableMaterial.cpp
+++ b/libs/viewer/src/TweakableMaterial.cpp
@@ -80,10 +80,10 @@ void TweakableMaterial::fromJson(const json& source) {
 
     readValueFromJson(source, "useWard", mUseWard, false);
 
-    readTexturedFromJson(source, "baseColor", mBaseColor, true, isAlpha);
+    readTexturedFromJson(source, "baseColor", mBaseColor, true, isAlpha, isAlpha ? 4 : 3);
 
     readValueFromJson(source, "normalIntensity", mNormalIntensity, 1.0f);
-    readTexturedFromJson(source, "normalTexture", mNormal);
+    readTexturedFromJson(source, "normalTexture", mNormal, false, false, 3);
 
     readValueFromJson(source, "roughnessScale", mRoughnessScale, 1.0f);
     readTexturedFromJson(source, "roughness", mRoughness);
@@ -95,7 +95,7 @@ void TweakableMaterial::fromJson(const json& source) {
 
     readValueFromJson(source, "clearCoat", mClearCoat, 0.0f);
     readValueFromJson(source, "clearCoatNormalIntensity", mClearCoatNormalIntensity, 1.0f);
-    readTexturedFromJson(source, "clearCoatNormal", mClearCoatNormal);
+    readTexturedFromJson(source, "clearCoatNormal", mClearCoatNormal, false, false, 3);
     readTexturedFromJson(source, "clearCoatRoughness", mClearCoatRoughness);
 
     readValueFromJson(source, "baseTextureScale", mBaseTextureScale, 1.0f);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-991](https://shapr3d.atlassian.net/browse/GFX-991)

## Short description (What? How?) 📖
Artists have been providing us bugos assets for a while now. Adding some measures to counteract them. The only missing one is the 16bpc input textures, for which I haven't found a trivial way to detect without changing STB interfaces. 

Changelist:
[Added] Error messages on incorrect texture channel counts
[Added] More explicit conversion to expected channel counts from the one
        found in the texture (maybe this will uncover some extra issues)
[Added] Texture format to string conversion array
[Changed] The default of IsColor is now FALSE on everything (artists
          need to validate this on all released materials!)
[Fixed] Occlusion intensity was handled as if it was textures, which is
        incorrect, it is a scalar attribute
## Testing

### Design review 🎨
n/a

### Affected areas 🧭
GltfViewer material editor

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Iterated over several materials and checked what if they were correct or not. If it was a false negative or false positive, I've investigated. 

Automated 💻
