### PR TITLE
Filament - Bump iOS deployment target to 13.0

### DIFF
--- a/third_party/clang/iOS.cmake
+++ b/third_party/clang/iOS.cmake
@@ -15,7 +15,7 @@ set(DIST_ARCH ${IOS_ARCH})
 
 add_definitions(-DIOS)
 
-set(IOS_MIN_TARGET "11.0")
+set(IOS_MIN_TARGET "13.0")
 
 if(PLATFORM_NAME STREQUAL "iphonesimulator")
     add_definitions(-DFILAMENT_IOS_SIMULATOR)

--- a/third_party/clang/iOS.cmake
+++ b/third_party/clang/iOS.cmake
@@ -19,11 +19,6 @@ set(IOS_MIN_TARGET "13.0")
 
 if(PLATFORM_NAME STREQUAL "iphonesimulator")
     add_definitions(-DFILAMENT_IOS_SIMULATOR)
-    # The simulator only supports iOS >= 13.0
-    set(IOS_MIN_TARGET "13.0")
-elseif(PLATFORM_NAME STREQUAL "macosx")
-    # Mac Catalyst only supports iOS >= 13.0
-    set(IOS_MIN_TARGET "13.0")
 endif()
 
 SET(CMAKE_SYSTEM_NAME Darwin)


### PR DESCRIPTION
## Jira ticket URL (Why?)
-

## Short description (What? How?) 📖
`json.hpp`, used by gltf viewer's library, `libviewer` uses `std::filesystem::path`, which was introduced in iOS 13.0 SDK. We need to bump to this version, to avoid build errors.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Filament custom fork builds with `<source root>/libs/filament/create_pkg.sh`

### Special use-cases to test 🧷
Just try to build, and it should succeed

### How did you test it? 🤔

Manual 💁‍♂️
Ran the script, build succeeded