### PR TITLE
GltfViewer [GFX-1053] Add json indentation

### DIFF
--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -708,7 +708,7 @@ void SimpleViewer::saveTweaksToFile(TweakableMaterial* tweaks, const char* fileP
     }
     mLastSavedFileName = filePathStr;
     std::fstream outFile(filePathStr, std::ios::binary | std::ios::out);
-    outFile << js << std::endl;
+    outFile << std::setw(4) << js << std::endl;
     outFile.close();
 }
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1053](https://shapr3d.atlassian.net/browse/GFX-1053)

## Short description (What? How?) 📖
Made GltfViewer indent JSON code so that it is easier to read the output at the expense of increased size (but we are talking about kilobytes). Also verified that the JSON parser handles these material files OK. 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
GltfViewer material load/save

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Save old materials, see if they are readable, try to load them in GltfViewer. 

Automated 💻
n/a