### PR TITLE
Filament - Fix gltf viewer build on macOS

### DIFF
--- a/libs/viewer/src/MacosCustomFileDialogs.mm
+++ b/libs/viewer/src/MacosCustomFileDialogs.mm
@@ -68,11 +68,15 @@ bool SD_MacOpenFileDialog(char* browsedFile, const char* formats, bool folderOnl
     openPanel.canChooseFiles = !folderOnly ? YES : NO;
 
     if (!folderOnly) {
+#if (__MAC_OS_X_VERSION_MIN_REQUIRED >= 110000)
         if (@available(macOS 11.0, *)) {
             openPanel.allowedContentTypes = ConvertFormatsToUTI(formats);
         } else {
             openPanel.allowedFileTypes = GetExtensionsFromFormatString(formats);
         }
+#else
+        openPanel.allowedFileTypes = GetExtensionsFromFormatString(formats);
+#endif
     }
     NSModalResponse response = [openPanel runModal];
     


### PR DESCRIPTION
## Jira ticket URL (Why?)
N/A

## Short description (What? How?) 📖
Filament's build system is somewhat flaky. It sometimes builds gltf viewer fine, but sometimes it fails to build on macOS. This PR should fix these build failures on macOS.

On macOS >= 11, we convert file extensions to UTIs for showing the file open dialog. This wasn't available on previous versions of macOS, so only a string conversion is needed. The choice between the two is done at runtime, but the UTI-based function cannot be built with previous SDKs, so an unresolved external issue pops up.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Building gltf viewer on macOS

### Special use-cases to test 🧷
N/A

### How did you test it? 🤔
Manual 💁‍♂️
It builds on every try