### PR TITLE
UIB [GFX-1053] Fix padding

### DIFF
--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -56,20 +56,20 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     // camera position in view space (when camera_at_origin is enabled), i.e. it's (0,0,0).
     // Always add worldOffset in the shader to get the true world-space position of the camera.
-    math::float3 cameraPosition;
+    alignas(16) math::float3 cameraPosition;
     float time; // time in seconds, with a 1 second period
 
     math::float4 lightColorIntensity; // directional light
 
     math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
 
-    math::float3 padding1;
+    alignas(16) math::float3 padding1;
     uint32_t lightChannels;
 
-    math::float3 lightDirection;
+    alignas(16) math::float3 lightDirection;
     uint32_t fParamsX; // stride-x
 
-    math::float3 shadowBias; // unused, normal bias, unused
+    alignas(16) math::float3 shadowBias; // unused, normal bias, unused
     float oneOverFroxelDimensionY;
 
     math::float4 zParams; // froxel Z parameters
@@ -95,7 +95,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     // bit 8-15: screen-space contact shadows ray casting steps
     uint32_t directionalShadows;
 
-    math::float3 worldOffset; // this is (0,0,0) when camera_at_origin is disabled
+    alignas(16) math::float3 worldOffset; // this is (0,0,0) when camera_at_origin is disabled
     float ssContactShadowDistance;
 
     // fog
@@ -103,7 +103,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float fogMaxOpacity;
     float fogHeight;
     float fogHeightFalloff;         // falloff * 1.44269
-    math::float3 fogColor;
+    alignas(16) math::float3 fogColor;
     float fogDensity;               // (density/falloff)*exp(-falloff*(camera.y - fogHeight))
     float fogInscatteringStart;
     float fogInscatteringSize;
@@ -132,7 +132,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float reserved2;
     float reserved3;
 
-    math::float3 cameraForward;
+    alignas(16) math::float3 cameraForward;
     float padding3;
 
     // bring PerViewUib to 2 KiB

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -54,9 +54,6 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     math::float4 resolution; // viewport width, height, 1/width, 1/height
 
-    math::float3 cameraForward;
-    float padding0;
-
     // camera position in view space (when camera_at_origin is enabled), i.e. it's (0,0,0).
     // Always add worldOffset in the shader to get the true world-space position of the camera.
     math::float3 cameraPosition;
@@ -135,8 +132,11 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float reserved2;
     float reserved3;
 
+    math::float3 cameraForward;
+    float padding3;
+
     // bring PerViewUib to 2 KiB
-    math::float4 padding3[57];
+    math::float4 paddingArray[57];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -45,15 +45,13 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // view
             .add("resolution",              1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             // camera
-            .add("cameraForward",           1, UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH)
-            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT)
             .add("cameraPosition",          1, UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH)
             // time
             .add("time",                    1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
             // directional light
             .add("lightColorIntensity",     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("sun",                     1, UniformInterfaceBlock::Type::FLOAT4)
-            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT3)
+            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT3)
             .add("lightChannels",           1, UniformInterfaceBlock::Type::UINT)
             .add("lightDirection",          1, UniformInterfaceBlock::Type::FLOAT3)
             .add("fParamsX",                1, UniformInterfaceBlock::Type::UINT)
@@ -116,8 +114,12 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("reserved2",               1, UniformInterfaceBlock::Type::FLOAT)
             .add("reserved3",               1, UniformInterfaceBlock::Type::FLOAT)
 
+            // camera
+            .add("cameraForward", 1, UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH)
+            .add("padding3", 1, UniformInterfaceBlock::Type::FLOAT)
+
             // bring PerViewUib to 2 KiB
-            .add("padding3", 57, UniformInterfaceBlock::Type::FLOAT4)
+            .add("paddingArray", 57, UniformInterfaceBlock::Type::FLOAT4)
             .build();
     return uib;
 }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1053](https://shapr3d.atlassian.net/browse/GFX-1053)

## Short description (What? How?) 📖
I had to move the new ortho-fixed camera forward direction related new attributes to the end of the UIB, as GltfViewer scenes were not visible otherwise using the default material (on Windows). This might be due to some stale shader things or anything as it is working correctly for Levi. 

I thought that alignment rules were to blame (std140 is rather finicky to begin with: [OpenGL 4.5, Section 7.6.2.2, page 137](https://www.khronos.org/registry/OpenGL/specs/gl/glspec45.core.pdf#page=159)) but the ultimate solution was to explicitly align all float3 attributes to 16 byte boundaries _and_ move the new camera forward `float3` and its padder to the end of the UIB. Needs more investigation. 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Make sure everything is visible in all Shapr3D and GltfViewer platforms. 

Automated 💻
