### PR TITLE
[GFX-994] Revert Filament's coordinate system to Y-up

### DIFF
--- a/libs/camutils/src/FreeFlightManipulator.h
+++ b/libs/camutils/src/FreeFlightManipulator.h
@@ -67,7 +67,7 @@ public:
     }
 
     void updateTarget(FLOAT pitch, FLOAT yaw) {
-        Base::mTarget = Base::mEye + (mat3::eulerZYX(yaw, 0, pitch) * vec3(0.0, 1.0, 0.0));
+        Base::mTarget = Base::mEye + (mat3::eulerZYX(0, yaw, pitch) * vec3(0.0, 0.0, -1.0));
     }
 
     void grabBegin(int x, int y, bool strafe) override {
@@ -144,10 +144,10 @@ public:
         vec3 forceWorld = (orientation * vec4{ forceLocal, 0.0f }).xyz;
 
         if (mKeyDown[(int) Base::Key::UP]) {
-            forceWorld += vec3{  0.0,  0.0,  1.0 };
+            forceWorld += vec3{  0.0,  1.0,  0.0 };
         }
         if (mKeyDown[(int) Base::Key::DOWN]) {
-            forceWorld += vec3{  0.0,  0.0, -1.0 };
+            forceWorld += vec3{  0.0, -1.0,  0.0 };
         }
 
         forceWorld *= mMoveSpeed;

--- a/libs/camutils/src/Manipulator.cpp
+++ b/libs/camutils/src/Manipulator.cpp
@@ -170,7 +170,7 @@ void Manipulator<FLOAT>::setProperties(const Config& props) {
     }
 
     if (mProps.upVector == vec3(0)) {
-        mProps.upVector = vec3(0, 0, 1);
+        mProps.upVector = vec3(0, 1, 0);
     }
 
     if (mProps.fovDegrees == FLOAT(0)) {

--- a/libs/filagui/src/ImGuiExtensions.cpp
+++ b/libs/filagui/src/ImGuiExtensions.cpp
@@ -84,14 +84,13 @@ bool DirectionWidget(const char* label, float v[3]) {
         v[2] = dir.z;
     }
 
-    float3 arrowDir{ dir.x, dir.z, dir.y };
-    ArrowWidget widget(normalize(arrowDir));
+    ArrowWidget widget(normalize(dir));
     if (widget.draw() && !changed) {
         changed = true;
         dir = widget.getDirection();
         v[0] = dir.x;
-        v[1] = dir.z;
-        v[2] = dir.y;
+        v[1] = dir.y;
+        v[2] = dir.z;
     }
     ImGui::EndGroup();
     ImGui::PopID();

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -646,8 +646,6 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
     // set-up the camera manipulators
     mMainCameraMan = CameraManipulator::Builder()
             .targetPosition(0, 0, -4)
-            .flightStartPosition(3, 1, 2)
-            .flightStartOrientation(-0.1, 1)
             .flightMoveDamping(15.0)
             .build(config.cameraMode);
     mDebugCameraMan = CameraManipulator::Builder()

--- a/libs/filamentapp/src/FilamentApp.cpp
+++ b/libs/filamentapp/src/FilamentApp.cpp
@@ -645,15 +645,13 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
 
     // set-up the camera manipulators
     mMainCameraMan = CameraManipulator::Builder()
-            .targetPosition(0, -4, 0)
-            .upVector(0, 0, 1)
+            .targetPosition(0, 0, -4)
             .flightStartPosition(3, 1, 2)
             .flightStartOrientation(-0.1, 1)
             .flightMoveDamping(15.0)
             .build(config.cameraMode);
     mDebugCameraMan = CameraManipulator::Builder()
-            .targetPosition(0, -4, 0)
-            .upVector(0, 0, 1)
+            .targetPosition(0, 0, -4)
             .build(camutils::Mode::ORBIT);
 
     mMainView->setCamera(mMainCamera);
@@ -676,7 +674,7 @@ FilamentApp::Window::Window(FilamentApp* filamentApp,
     // configure the cameras
     configureCamerasForWindow();
 
-    mMainCamera->lookAt({4, -4, 0}, {0, -4, 0}, {0, 0, 1});
+    mMainCamera->lookAt({4, 0, -4}, {0, 0, -4}, {0, 1, 0});
 }
 
 FilamentApp::Window::~Window() {
@@ -845,7 +843,7 @@ void FilamentApp::Window::configureCamerasForWindow() {
     mMainCamera->setLensProjection(mFilamentApp->mCameraFocalLength, double(mainWidth) / height, near, far);
     mDebugCamera->setProjection(45.0, double(width) / height, 0.0078125, 4096, Camera::Fov::VERTICAL);
     mOrthoCamera->setProjection(Camera::Projection::ORTHO, -3, 3, -3 * ratio, 3 * ratio, near, far);
-    mOrthoCamera->lookAt({ 4, -4, 0 }, { 0, -4, 0 });
+    mOrthoCamera->lookAt({ 0, 0, 0 }, {0, 0, -4});
 
     // We're in split view when there are more views than just the Main and UI views.
     if (splitview) {

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -598,10 +598,7 @@ void SimpleViewer::updateIndirectLight() {
     using namespace filament::math;
     if (mIndirectLight) {
         mIndirectLight->setIntensity(mSettings.lighting.iblIntensity);
-        mIndirectLight->setRotation(
-            mat3f::rotation(mSettings.lighting.iblRotation, float3{ 0, 0, 1 }) *
-            mat3f::rotation((float)M_PI_2, float3{ 1, 0, 0 })
-        );
+        mIndirectLight->setRotation(mat3f::rotation(mSettings.lighting.iblRotation, float3{ 0, 1, 0 }));
     }
     if (mScene->getSkybox()) {
         mScene->getSkybox()->setIntensity(mSettings.lighting.skyIntensity);

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -591,6 +591,7 @@ void SimpleViewer::updateRootTransform() {
     if (mSettings.viewer.autoScaleEnabled) {
         transform = fitIntoUnitCube(mAsset->getBoundingBox(), 4);
     }
+    transform *= filament::math::mat4f::rotation(filament::math::F_PI_2, filament::math::vec3<float>(-1, 0, 0));
     tcm.setTransform(root, transform);
 }
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
<!---
Use the Jira ticket id as text in PROJ-XXX format and append it to the end of the link.
If there are multiple tickets, list all.
-->
[GFX-994](https://shapr3d.atlassian.net/browse/GFX-994)

## Short description (What? How?) 📖
Filament's certain aspects (especially the so-called froxelizer) expect the Y axis to be the upwards direction. We changed it to be the Z axis, to match Shapr3D's coordinate system. We revert it, hoping some of our issues get fixed, and get closer to upstream Filament.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Filament, gltf viewer

### Special use-cases to test 🧷
N/A

### How did you test it? 🤔
Manual 💁‍♂️
Models are now rotated in gltf viewer, apart from that, they look fine.