### PR TITLE
[GFX-1101] Pass external buffers with ownership transfer in Metal

### DIFF
--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -69,9 +69,6 @@ bool MetalBuffer::releaseExternalBuffer() {
         return false;
     }
 
-#if !__has_feature(objc_arc)
-    [mExternalBuffer release];
-#endif
     mExternalBuffer = nil;
     return true;
 }

--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -57,7 +57,7 @@ MetalBuffer::~MetalBuffer() {
     }
 }
 
-void MetalBuffer::wrapExternalBuffer(id <MTLBuffer> buffer) {
+void MetalBuffer::wrapExternalBuffer(id<MTLBuffer> buffer) {
     ASSERT_PRECONDITION(!mExternalBuffer, "A external buffer is already wrapped. Call releaseExternalBuffer()");
     ASSERT_PRECONDITION(buffer, "External buffer cannot be nil");
     ASSERT_PRECONDITION(!mCpuBuffer, "This buffer is backed by CPU memory");

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -709,13 +709,13 @@ void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescripto
 void MetalDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, void* externalBuffer) {
     auto* ib = handle_cast<MetalIndexBuffer>(ibh);
     ib->buffer.releaseExternalBuffer();
-    ib->buffer.wrapExternalBuffer((__bridge id<MTLBuffer>)externalBuffer);
+    ib->buffer.wrapExternalBuffer((id<MTLBuffer>) CFBridgingRelease(externalBuffer));
 }
 
 void MetalDriver::setExternalBuffer(Handle<HwBufferObject> boh, void* externalBuffer) {
     auto* bo = handle_cast<MetalBufferObject>(boh);
     bo->getBuffer()->releaseExternalBuffer();
-    bo->getBuffer()->wrapExternalBuffer((__bridge id<MTLBuffer>)externalBuffer);
+    bo->getBuffer()->wrapExternalBuffer((id<MTLBuffer>) CFBridgingRelease(externalBuffer));
 }
 
 void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -125,11 +125,18 @@ public:
 
 
     /**
-     * Wraps the given external buffer (stores a strong reference to it).
+     * Specify a native buffer to import as a Filament index buffer.
+     *
+     * The externalBuffer pointer is backend-specific:
+     *   - Metal: id<MTLBuffer>
+     *
+     * With Metal, the id<MTLBuffer> object should be cast to an void* using
+     * CFBridgingRetain to transfer ownership to Filament. Filament will release ownership of
+     * the buffer object when the Filament index buffer is destroyed.
      *
      * To use this, you must first call enableExternalBuffer() on the Builder.
      *
-     * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
+     * @param engine Reference to the filament::Engine to associate this IndexBuffer with.
      * @param externalBuffer Pointer to the external buffer that will be used in this buffer slot.
      */
     void setExternalBuffer(Engine& engine, void* externalBuffer);

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -206,7 +206,14 @@ public:
     void setBufferObjectAt(Engine& engine, uint8_t bufferIndex, BufferObject const* bufferObject);
 
     /**
-     * Wraps the given external buffer (stores a strong reference to it).
+     * Specify a native buffer to import as a Filament vertex buffer.
+     *
+     * The externalBuffer pointer is backend-specific:
+     *   - Metal: id<MTLBuffer>
+     *
+     * With Metal, the id<MTLBuffer> object should be cast to an void* using
+     * CFBridgingRetain to transfer ownership to Filament. Filament will release ownership of
+     * the buffer object when the Filament vertex buffer is destroyed.
      *
      * To use this, you must first call enableExternalBuffer() on the Builder.
      *


### PR DESCRIPTION
## Jira ticket URL
[GFX-1101](https://shapr3d.atlassian.net/browse/GFX-1101)

## Short description 📖
Small correction continuing https://github.com/shapr3d/filament/pull/1. External index/vertex buffers should do bridging with ownership transfer, in order to ensure that the `id<MTLBuffer>` resource is kept alive from the moment a vertex/index buffer object is created on the frontend, to when it is processed by the driver thread. This makes external buffer handling aligned with external resources semantics existing upstream, namely in [`Texture::Builder::import()`](https://github.com/google/filament/blob/5dba7fdae0ae1e700d5f987d106d52c0e95a1835/filament/include/filament/Texture.h#L212).