### PR TITLE
[GFX-1098] Add toggle for disabling double transform TS<->WS

### DIFF
--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -56,7 +56,11 @@ void computeShadingParams() {
 void prepareMaterial(const MaterialInputs material) {
 #if defined(HAS_ATTRIBUTE_TANGENTS)
 #if defined(MATERIAL_HAS_NORMAL)
+#if defined(SHAPR_USE_WORLD_NORMALS)
+    shading_normal = material.normal;
+#else
     shading_normal = normalize(shading_tangentToWorld * material.normal);
+#endif
 #else
     shading_normal = getWorldGeometricNormalVector();
 #endif
@@ -64,12 +68,20 @@ void prepareMaterial(const MaterialInputs material) {
     shading_reflected = reflect(-shading_view, shading_normal);
 
 #if defined(MATERIAL_HAS_BENT_NORMAL)
+#if defined(SHAPR_USE_WORLD_NORMALS)
+    shading_bentNormal = material.bentNormal;
+#else
     shading_bentNormal = normalize(shading_tangentToWorld * material.bentNormal);
+#endif
 #endif
 
 #if defined(MATERIAL_HAS_CLEAR_COAT)
 #if defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
+#if defined(SHAPR_USE_WORLD_NORMALS)
+    shading_clearCoatNormal = material.clearCoatNormal;
+#else
     shading_clearCoatNormal = normalize(shading_tangentToWorld * material.clearCoatNormal);
+#endif
 #else
     shading_clearCoatNormal = getWorldGeometricNormalVector();
 #endif

--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -11,7 +11,7 @@ void computeShadingParams() {
     highp vec3 n = vertex_worldNormal;
 #if defined(MATERIAL_NEEDS_TBN)
     highp vec3 t = vertex_worldTangent.xyz;
-    highp vec3 b = cross(n, t) * sign(vertex_worldTangent.w);
+    highp vec3 b = cross(n, t) * (vertex_worldTangent.w < 0.0 ? -1.0 : 1.0);
 #endif
 
 #if defined(MATERIAL_HAS_DOUBLE_SIDED_CAPABILITY)


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1098](https://shapr3d.atlassian.net/browse/GFX-1098)

## Short description (What? How?) 📖
Our normal maps don't look good on some faces. There are three root causes:
- By having our normal maps projected "through" the geometry (see diagram, this is closer to the real "volumetric" property of materials), we horizontally flip the normal map on some faces. This also flips the X coordinate of the tangent space normal, which we need to account for. 
<img width="454" alt="image" src="https://user-images.githubusercontent.com/91476779/153433962-dd2f2259-a1ea-49a6-8ca0-99b91ccafb79.png">

- Filament applies a root transform to the entire scene, when the IBL has a rotation transform applied. This makes an unexpected switch in the coordinate system in Visualization compared to Model Space.

- Filament expects normals in tangent space, but our triplanar mapping produces world space results. Thus we need to transform our results back to tangent space, just for Filament to undo it to world space. This not only wastes shader ALU, but introduces extra numerical imprecision. Filament also has a bug, where faces having their normal facing along the -X, -Y, or -Z axis will have a singular tangent to world transform matrix. The root cause of this lies in Filament's quaternion-based tangent frame encoding, where 180deg rotations produce a quaternion with an exactly 0 real component, whose sign is used later on to flip the bitangent or not (but sign(0) yields 0, making the bitangent a null vector, see https://shapr3d.atlassian.net/browse/GFX-1169 for further details).

This PR adds a new flag to our shaders, `SHAPR_USE_WORLD_NORMALS`, which disables Filament's transform from tangent to world space, making it expect normals in world space. This spares us two transforms in the fragment shader, and avoids the singularity bug. The reason this is a flag, is we will need tangent space normals support, when we introduce mesh-based environments.

This is only the Filament side of the story, a follow-up PR will contain the Shapr3D side.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Normal mapping on all geometry

### Special use-cases to test 🧷
Should have no effect in gltf viewer

### How did you test it? 🤔
Manual 💁‍♂️
Looked at some materials with normal maps in gltf viewer.