### PR TITLE
[GFX-1161] Improve transparent materials rendered in translucent views

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -728,11 +728,13 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
             h = config.vp.height * config.scale.x;
         }
 
+        const TextureFormat format = (view.getBlendMode() == BlendMode::TRANSLUCENT) ? mHdrTranslucent : mHdrQualityMedium;
+        
         input = ppm.opaqueBlit(fg, input, {
                 .width = w,
                 .height = h,
                 .levels = roughnessLodCount,
-                .format = TextureFormat::R11F_G11F_B10F,
+                .format = format,
         });
 
         input = ppm.generateGaussianMipmap(fg, input, roughnessLodCount, true, kernelSize);

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -161,7 +161,10 @@ vec4 resolve() {
     }
 #else
     vec4 color = resolveAlphaFragment(ivec2(getUV()));
-    color.rgb /= color.a + FLT_EPS;
+    if (color.a == 0.0) {
+        color.a = max(FLT_EPS, max3(color.rgb));
+    }
+    color.rgb /= color.a;
     if (materialParams.bloom.x > 0.0) {
         color.rgb = bloom(color.rgb);
     }
@@ -170,7 +173,7 @@ vec4 resolve() {
         color.rgb = vignette(color.rgb, uv, materialParams.vignette, materialParams.vignetteColor);
     }
     color.rgb  = colorGrade(materialParams_lut, color.rgb);
-    color.rgb *= color.a + FLT_EPS;
+    color.rgb *= color.a;
 #endif
     return color;
 }

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -271,10 +271,11 @@ vec4 evaluateLights(const MaterialInputs material) {
     // until the very end but it costs more ALUs on mobile. The gains are
     // currently not worth the extra operations
     vec3 color = vec3(0.0);
+    float alpha = 1.0;
 
     // We always evaluate the IBL as not having one is going to be uncommon,
     // it also saves 1 shader variant
-    evaluateIBL(material, pixel, color);
+    evaluateIBL(material, pixel, color, alpha);
 
 #if defined(HAS_DIRECTIONAL_LIGHTING)
     evaluateDirectionalLight(material, pixel, color);
@@ -290,7 +291,11 @@ vec4 evaluateLights(const MaterialInputs material) {
     color *= material.baseColor.a;
 #endif
 
+#if defined(BLEND_MODE_OPAQUE)
+    return vec4(color, alpha);
+#else
     return vec4(color, computeDiffuseAlpha(material.baseColor.a));
+#endif
 }
 
 void addEmissive(const MaterialInputs material, inout vec4 color) {


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1161](https://shapr3d.atlassian.net/browse/GFX-1161)

## Short description (What? How?) 📖
This PR fixes issues with certain transparent materials, possible when rendered against a background cleared to transparent (all zeros).

First, we adjust color grading (in the `!POST_PROCESS_OPAQUE` case) so that it outputs a visible fragment when input alpha is zero but RGB values are not. Given that our color render target is treated as containing colors with premultipled alpha, these values should be considered invalid - however certain materials may produce such output, (visible on screen), for example a material with `blending: transparent` and `baseColor.a = 0`.

Second, we allow for screen-space refractive materials to output transparent results. We retain the alpha channel of the blitted color texture, sample it in shader, and adjust based on material properties (i.e. transmission and specular highlights may adjust output alpha to more opaque). Only `blending: opaque` is supported, because computed alpha value should be stored in the render target directly, alpha-compositing on top of some existing color would be incorrect and pointless. (Notice that an opaque refractive material may "cut a transparent hole" in the render target if the transparent background shows up in the refracted contents).

## Testing

### Affected areas 🧭
`View`-s with blending set to `BlendMode::TRANSLUCENT`. Transparent/glass-like materials.
