### PR TITLE
[GFX-1147] Integrate triplanar changes from Shapr3D into this repo

### DIFF
--- a/filament/src/materials/Cloth.mat
+++ b/filament/src/materials/Cloth.mat
@@ -2,6 +2,7 @@ material {
     name : Cloth,
     shadingModel : cloth,
     specularAntiAliasing : true,
+    postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////
         // Attributes that may have a texture assigned to them. A single control to set their value when
@@ -37,7 +38,7 @@ material {
         {
             type : int,
             name : useRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : roughnessTexture
@@ -59,7 +60,7 @@ material {
         {
             type : int,
             name : useClearCoatRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : clearCoatRoughnessTexture
@@ -146,12 +147,12 @@ material {
             name : useWard
         },
         {
-            type : float,
-            name : ambient
+            type : float4,
+            name : ambientColor
         }
     ],
     variables: [
-        objectSpacePosition, 
+        objectSpacePosition,
         objectSpaceNormal
     ],
     quality : high

--- a/filament/src/materials/Opaque.mat
+++ b/filament/src/materials/Opaque.mat
@@ -1,6 +1,7 @@
 material {
     name : Opaque,
     specularAntiAliasing : true,
+    postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////
         // Attributes that may have a texture assigned to them. A single control to set their value when
@@ -36,7 +37,7 @@ material {
         {
             type : int,
             name : useRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : roughnessTexture
@@ -58,7 +59,7 @@ material {
         {
             type : int,
             name : useClearCoatRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : clearCoatRoughnessTexture
@@ -167,12 +168,12 @@ material {
             name : useWard
         },
         {
-            type : float,
-            name : ambient
+            type : float4,
+            name : ambientColor
         }
     ],
     variables: [
-        objectSpacePosition, 
+        objectSpacePosition,
         objectSpaceNormal
     ],
     quality : high

--- a/filament/src/materials/Refractive.mat
+++ b/filament/src/materials/Refractive.mat
@@ -1,9 +1,10 @@
 material {
-    name : Refractive, 
-    shadingModel : lit, 
+    name : Refractive,
+    shadingModel : lit,
     specularAntiAliasing : true,
     refractionType : solid,
-    refractionMode : screenspace,    
+    refractionMode : screenspace,
+    postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////
         // Attributes that may have a texture assigned to them. A single control to set their value when
@@ -39,7 +40,7 @@ material {
         {
             type : int,
             name : useRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : roughnessTexture
@@ -48,11 +49,6 @@ material {
             type : float,
             name : roughness
         },
-
-        {
-            type : float,
-            name : reflectance
-        },        
 
         {
             type : int,
@@ -66,7 +62,7 @@ material {
         {
             type : int,
             name : useClearCoatRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : clearCoatRoughnessTexture
@@ -119,7 +115,7 @@ material {
             type : float,
             name : thickness
         },
- 
+
         {
             type : int,
             name : useOcclusionTexture
@@ -180,7 +176,7 @@ material {
         {
             type : float,
             name : iorScale
-        },        
+        },
         {
             type : float,
             name : anisotropy
@@ -200,7 +196,7 @@ material {
         {
             type : float,
             name : maxThickness
-        },        
+        },
         {
             type : int,
             name : doDeriveAbsorption
@@ -214,12 +210,12 @@ material {
             name : useWard
         },
         {
-            type : float,
-            name : ambient
+            type : float4,
+            name : ambientColor
         }
     ],
     variables: [
-        objectSpacePosition, 
+        objectSpacePosition,
         objectSpaceNormal
     ],
     quality : high

--- a/filament/src/materials/Subsurface.mat
+++ b/filament/src/materials/Subsurface.mat
@@ -2,6 +2,7 @@ material {
     name : Subsurface,
     shadingModel : subsurface,
     specularAntiAliasing : true,
+    postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////
         // Attributes that may have a texture assigned to them. A single control to set their value when
@@ -37,7 +38,7 @@ material {
         {
             type : int,
             name : useRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : roughnessTexture
@@ -59,7 +60,7 @@ material {
         {
             type : int,
             name : useClearCoatRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : clearCoatRoughnessTexture
@@ -162,7 +163,7 @@ material {
         {
             type : float,
             name : thickness
-        },        
+        },
         {
             type : float,
             name : maxThickness
@@ -172,12 +173,12 @@ material {
             name : useWard
         },
         {
-            type : float,
-            name : ambient
+            type : float4,
+            name : ambientColor
         }
     ],
     variables: [
-        objectSpacePosition, 
+        objectSpacePosition,
         objectSpaceNormal
     ],
     quality : high

--- a/filament/src/materials/Transparent.mat
+++ b/filament/src/materials/Transparent.mat
@@ -2,6 +2,7 @@ material {
     name : Transparent,
     blending : transparent,
     transparency : twoPassesTwoSides,
+    postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////
         // Attributes that may have a texture assigned to them. A single control to set their value when
@@ -37,7 +38,7 @@ material {
         {
             type : int,
             name : useRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : roughnessTexture
@@ -59,7 +60,7 @@ material {
         {
             type : int,
             name : useClearCoatRoughnessTexture
-        },        
+        },
         {
             type : sampler2d,
             name : clearCoatRoughnessTexture
@@ -124,12 +125,12 @@ material {
             name : useWard
         },
         {
-            type : float,
-            name : ambient
+            type : float4,
+            name : ambientColor
         }
     ],
     variables: [
-        objectSpacePosition, 
+        objectSpacePosition,
         objectSpaceNormal
     ],
     vertexDomain : object,


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1147](https://shapr3d.atlassian.net/browse/GFX-1147)

## Short description (What? How?) 📖
This is an urgent PR as the last GltfViewer broke the appearance of all materials that used normal or clearcoat normal maps;
![image](https://user-images.githubusercontent.com/90197216/154438370-dadf1a31-3ac7-4a8f-849e-daed6a052c30.png)

Turns out, we managed to test the last changes on planar surfaces where this is wasn't visible and on materials that did not have normal maps but were assigned to spheres.

It seems like the fixes to normal maps were partial in a recent change. I have taken the latest, Shapr3D master state of the material shaders and added and validated in GltfViewer that it is fixing the issues and brings the shaders to the same state.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
GltfViewer normal mapped materials

### Special use-cases to test 🧷
normal mapped materials from https://e.pcloud.link/publink/show?code=kZ8cnJZoDyl4918RRf9E4lN6FKMCBckTmU7

### How did you test it? 🤔
Manual 💁‍♂️
Load up materials in GtlfViewer, especially ones with normal maps and make sure to assign it to geometries that have nice curvatures. 

Automated 💻
n/a