### PR TITLE
[GFX-988] Implement Frisvad tangent computation

### DIFF
--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -35,9 +35,21 @@ void main() {
         // because we ensure the worldFromModelNormalMatrix pre-scales the normal such that
         // all its components are < 1.0. This prevents the bitangent to exceed the range of fp16
         // in the fragment shader, where we renormalize after interpolation
-        vertex_worldTangent.xyz = objectUniforms.worldFromModelNormalMatrix * vertex_worldTangent.xyz;
         vertex_worldTangent.w = mesh_tangents.w;
         material.worldNormal = objectUniforms.worldFromModelNormalMatrix * material.worldNormal;
+
+        // Compute the tangent according to Frisvad's paper
+        // see: https://backend.orbit.dtu.dk/ws/portalfiles/portal/126824972/onb_frisvad_jgt2012_v2.pdf
+        // We need to swap axes compared to the paper, to have the singularity at -Y (bottom in Filament coordinates)
+        // Handle the singularity
+        if (material.worldNormal.y < -0.9999999) {
+            vertex_worldTangent.xyz = vec3(0.0, 0.0, -1.0);
+        } else {
+            float a = 1.0 / (1.0 + material.worldNormal.y);
+            float b = -material.worldNormal.x * material.worldNormal.z * a;
+            vertex_worldTangent.xyz = vec3(1.0 - material.worldNormal.x * material.worldNormal.x * a, b, -material.worldNormal.x);
+        }
+
     #else // MATERIAL_NEEDS_TBN
         // Without anisotropy or normal mapping we only need the normal vector
         toTangentFrame(mesh_tangents, material.worldNormal);

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -35,9 +35,13 @@ void main() {
         // because we ensure the worldFromModelNormalMatrix pre-scales the normal such that
         // all its components are < 1.0. This prevents the bitangent to exceed the range of fp16
         // in the fragment shader, where we renormalize after interpolation
+        #if defined(IN_SHAPR_SHADER)
+        vertex_worldTangent.xyz = objectUniforms.worldFromModelNormalMatrix * vertex_worldTangent.xyz;
+        #endif
         vertex_worldTangent.w = mesh_tangents.w;
         material.worldNormal = objectUniforms.worldFromModelNormalMatrix * material.worldNormal;
 
+        #if !defined(IN_SHAPR_SHADER)
         // Compute the tangent according to Frisvad's paper
         // see: https://backend.orbit.dtu.dk/ws/portalfiles/portal/126824972/onb_frisvad_jgt2012_v2.pdf
         // We need to swap axes compared to the paper, to have the singularity at -Y (bottom in Filament coordinates)
@@ -49,6 +53,7 @@ void main() {
             float b = -material.worldNormal.x * material.worldNormal.z * a;
             vertex_worldTangent.xyz = vec3(1.0 - material.worldNormal.x * material.worldNormal.x * a, b, -material.worldNormal.x);
         }
+        #endif
 
     #else // MATERIAL_NEEDS_TBN
         // Without anisotropy or normal mapping we only need the normal vector


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-988](https://shapr3d.atlassian.net/browse/GFX-988)

## Short description (What? How?) 📖
This is the Filament counterpart of https://github.com/shapr3d/shapr3d/pull/9197. Even though it is not strictly required, because Filament's mesh import takes care of computing a good tangent frame, this makes the tangent frame identical to that in Shapr3D, easing the artists' work.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
gltf viewer mesh tangent frames

### Special use-cases to test 🧷
Materials in gltf viewer

### How did you test it? 🤔
Manual 💁‍♂️
Looked at the test scene with some materials, and a debug coloring showing the tangents