### PR TITLE
[GFX-1206] Fixed normal intensity

### DIFF
--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -103,14 +103,14 @@ vec3 TriplanarNormalMap(sampler2D normalMap, float scaler, highp vec3 pos, lowp 
 
     // Tangent space normal maps
     // 2-channel XY TS normal texture: this saves 33% on storage
-    lowp vec3 tnormalX = UnpackNormal(texture(normalMap, uvX).xy) * vec3(SignNoZero(normal.x), 1, 1);
-    lowp vec3 tnormalY = UnpackNormal(texture(normalMap, uvY).xy) * vec3(SignNoZero(normal.y), 1, 1);
-    lowp vec3 tnormalZ = UnpackNormal(texture(normalMap, uvZ).xy) * vec3(SignNoZero(normal.z), 1, 1);
+    lowp vec3 tnormalX = UnpackNormal(texture(normalMap, uvX).xy) * vec3(SignNoZero(normal.x) * normalIntensity, normalIntensity, 1);
+    lowp vec3 tnormalY = UnpackNormal(texture(normalMap, uvY).xy) * vec3(SignNoZero(normal.y) * normalIntensity, normalIntensity, 1);
+    lowp vec3 tnormalZ = UnpackNormal(texture(normalMap, uvZ).xy) * vec3(SignNoZero(normal.z) * normalIntensity, normalIntensity, 1);
 
     // Swizzle world normals into tangent space and apply Whiteout blend
-    tnormalX = vec3(tnormalX.xy + normal.yz * vec2(SignNoZero(normal.x), 1), abs(tnormalX.z) * abs(normal.x)) * vec3(normalIntensity, normalIntensity, 1);
-    tnormalY = vec3(tnormalY.xy + normal.xz * vec2(-SignNoZero(normal.y), 1), abs(tnormalY.z) * abs(normal.y)) * vec3(normalIntensity, normalIntensity, 1);
-    tnormalZ = vec3(tnormalZ.xy + normal.yx * vec2(SignNoZero(normal.z), -1), abs(tnormalZ.z) * abs(normal.z)) * vec3(normalIntensity, normalIntensity, 1);
+    tnormalX = vec3(tnormalX.xy + normal.yz * vec2(SignNoZero(normal.x), 1), abs(tnormalX.z) * abs(normal.x));
+    tnormalY = vec3(tnormalY.xy + normal.xz * vec2(-SignNoZero(normal.y), 1), abs(tnormalY.z) * abs(normal.y));
+    tnormalZ = vec3(tnormalZ.xy + normal.yx * vec2(SignNoZero(normal.z), -1), abs(tnormalZ.z) * abs(normal.z));
 
     // Compute blend weights
     vec3 blend = ComputeWeights(normal);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1206](https://shapr3d.atlassian.net/browse/GFX-1206)

## Short description (What? How?) 📖
The normal mapping fix has accidentally applied normal intensity in world space instead of doing it in tangent space. This PR is fixing this issue that created exaggerated reflections.

Before this fix and after the normal mapping fix we had this:
![image](https://user-images.githubusercontent.com/90197216/154919138-a3fc556f-8711-42a9-b567-b76f8ac244c3.png)

Witht his current PR, you'll get back the proper looks as
![image](https://user-images.githubusercontent.com/90197216/154919197-d810111e-bb6a-44c8-a3a0-5791af1d191f.png)

The screenshots were taken with polished iron. The tricky thing with this bug was that normally, you wouldn't notice these as long as normal intensities stayed close to 1.0. Luckily, art made some really brave adjustments to these variables that pronounced this effect much more .

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Visualization materials

### Special use-cases to test 🧷
You'll mostly see this on highly reflective materials that have surface complexity. An example is polished iron.

### How did you test it? 🤔
Manual 💁‍♂️
Go over reflective materials and also made sure that we are not breaking the look of the others.

Automated 💻
