### PR TITLE
[GFX-1206] Saturate ambientOcclusion and fix transparent

### DIFF
--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -231,7 +231,7 @@ void ApplyOcclusion(inout MaterialInputs material, inout FragmentData fragmentDa
     } else {
         material.ambientOcclusion = materialParams.occlusion;
     }
-    material.ambientOcclusion = max(1.0 - materialParams.occlusionIntensity * (1.0 - material.ambientOcclusion), 0.0);
+    material.ambientOcclusion = clamp(1.0 - materialParams.occlusionIntensity * (1.0 - material.ambientOcclusion), 0.0, 1.0);
 #endif
 }
 

--- a/filament/src/materials/Transparent.mat
+++ b/filament/src/materials/Transparent.mat
@@ -2,6 +2,7 @@ material {
     name : Transparent,
     blending : transparent,
     transparency : twoPassesTwoSides,
+    doubleSided: true,
     postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1206](https://shapr3d.atlassian.net/browse/GFX-1206)
[GFX-1214](https://shapr3d.atlassian.net/browse/GFX-1214)

## Short description (What? How?) 📖
Filament counterpart of 
1. https://github.com/shapr3d/shapr3d/pull/9243 (ambientOcclusion)
2. https://github.com/shapr3d/shapr3d/pull/9241 (transparent should be double sided)

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
See https://github.com/shapr3d/shapr3d/pull/9243 

### Special use-cases to test 🧷
See https://github.com/shapr3d/shapr3d/pull/9243

### How did you test it? 🤔
Manual 💁‍♂️
You need to touch all of our .mat files to be able to test ambientOcclusion fix in the GltfViewer.

Automated 💻
n/a