### PR TITLE
CMake [GFX-1223] Add CMake option to use C++ exceptions in Filament

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ option(FILAMENT_USE_SWIFTSHADER "Compile Filament against SwiftShader" OFF)
 
 option(FILAMENT_ENABLE_LTO "Enable link-time optimizations if supported by the compiler" OFF)
 
+option(FILAMENT_ENABLE_CPP_EXCEPTIONS "Enable the use of C++ exceptions" OFF)
+
 option(FILAMENT_SKIP_SAMPLES "Don't build samples" OFF)
 
 option(FILAMENT_SUPPORTS_XCB "Include XCB support in Linux builds" ON)
@@ -283,7 +285,10 @@ if (ANDROID)
 endif()
 
 if (CYGWIN)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+    if (NOT FILAMENT_ENABLE_CPP_EXCEPTIONS)
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -fno-exceptions")
+    endif()
 endif()
 
 if (MSVC)
@@ -320,7 +325,10 @@ endif()
 # On Android RELEASE builds, we disable exceptions and RTTI to save some space (about 75 KiB
 # saved by -fno-exception and 10 KiB saved by -fno-rtti).
 if (ANDROID OR IOS OR WEBGL)
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
+    if (NOT FILAMENT_ENABLE_CPP_EXCEPTIONS)
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions")
+    endif()
 endif()
 
 # With WebGL, we disable RTTI even for debug builds because we pass emscripten::val back and forth

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,7 +287,7 @@ endif()
 if (CYGWIN)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
     if (NOT FILAMENT_ENABLE_CPP_EXCEPTIONS)
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -fno-exceptions")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
     endif()
 endif()
 

--- a/build.sh
+++ b/build.sh
@@ -47,6 +47,8 @@ function print_help {
     echo "        Add iOS simulator support to the iOS build."
     echo "    -t"
     echo "        Enable SwiftShader support for Vulkan in desktop builds."
+    echo "    -e"
+    echo "        Enable C++ exceptions in Release builds."
     echo "    -l"
     echo "        Build arm64/x86_64 universal libraries."
     echo "        For iOS, this builds universal binaries for devices and the simulator (implies -s)."
@@ -162,6 +164,8 @@ OPENGL_IOS_OPTION="-DFILAMENT_SUPPORTS_OPENGL=ON"
 SWIFTSHADER_OPTION="-DFILAMENT_USE_SWIFTSHADER=OFF"
 
 MATDBG_OPTION="-DFILAMENT_ENABLE_MATDBG=OFF"
+
+ENABLE_CPP_EXCEPTIONS_OPTION="-DFILAMENT_ENABLE_CPP_EXCEPTIONS=OFF"
 
 IOS_BUILD_SIMULATOR=false
 BUILD_UNIVERSAL_LIBRARIES=false
@@ -599,6 +603,7 @@ function build_ios_target {
             -DCMAKE_TOOLCHAIN_FILE=../../third_party/clang/iOS.cmake \
             ${MATDBG_OPTION} \
             ${OPENGL_IOS_OPTION} \
+            ${ENABLE_CPP_EXCEPTIONS_OPTION} \
             ../..
     fi
 
@@ -805,7 +810,7 @@ function run_tests {
 
 pushd "$(dirname "$0")" > /dev/null
 
-while getopts ":hacCfijmp:q:uvgslwtdk:" opt; do
+while getopts ":hacCfijmp:q:uvgslwtedk:" opt; do
     case ${opt} in
         h)
             print_help
@@ -918,6 +923,9 @@ while getopts ":hacCfijmp:q:uvgslwtdk:" opt; do
         t)
             SWIFTSHADER_OPTION="-DFILAMENT_USE_SWIFTSHADER=ON"
             echo "SwiftShader support enabled."
+            ;;
+        e)
+            ENABLE_CPP_EXCEPTIONS_OPTION="-DFILAMENT_ENABLE_CPP_EXCEPTIONS=ON"
             ;;
         l)
             BUILD_UNIVERSAL_LIBRARIES=true


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1223](https://shapr3d.atlassian.net/browse/GFX-1223)

## Short description (What? How?) 📖
As stated in the Jira card we are better off enabling C++ exceptions in Filament. This PR adds a CMake option for it which is used by the build script.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Instead of aborting, Filament now handles errors by throwing exceptions.

### Special use-cases to test 🧷

### How did you test it? 🤔
Manual 💁‍♂️
I tested it in Shapr3D by returning `nil` in the functions in `MetalPlatformGfx`.

Automated 💻
