### PR TITLE
[GFX-1162] Retain most recently used textures in resource cache

### DIFF
--- a/filament/src/ResourceAllocator.cpp
+++ b/filament/src/ResourceAllocator.cpp
@@ -205,7 +205,7 @@ void ResourceAllocator::gc() noexcept {
     //  - remove entries that are older than a certain age
     //      - remove only one entry per gc(),
     //      - unless we're at capacity
-    // - remove LRU entries until we're below capacity
+    // - remove LRU entries until we're below capacity (except most recent)
 
     auto& textureCache = mTextureCache;
     for (auto it = textureCache.begin(); it != textureCache.end();) {
@@ -234,8 +234,9 @@ void ResourceAllocator::gc() noexcept {
         });
 
         // now remove entries until we're at capacity
+        // unless the entry was used in this frame
         auto curr = cache.begin();
-        while (mCacheSize >= CACHE_CAPACITY) {
+        while (mCacheSize >= CACHE_CAPACITY && curr->second.age < age) {
             // by construction this entry must exist
             purge(textureCache.find(curr->first));
             ++curr;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1162](https://shapr3d.atlassian.net/browse/GFX-1162)

## Short description (What? How?) 📖
Filament only creates render target textures for the lifetime of one frame. The cost of actual allocations are kept low by employing a cache in frontend (`filament::ResourceAllocator`). This texture pool has a fixed 150MB capacity cap, which is most often enough, although multisampling and near-4K resolutions can outgrow it. If a renderer operates above said limit, it inevitably leads to reallocation of textures in every frame.

This PR aims to prevent thrashing in those occasions, by keeping textures in cache which were used in the last frame, even if that means staying above cache size limits.

## Testing

### Affected areas 🧭
Memory usage, texture allocations

### How did you test it? 🤔
Manual 💁‍♂️
Checked allocation timelines in Instruments on Metal Game Performance template.
