### PR TITLE
[GFX-1223] Generate stack unwind tables 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,13 +308,10 @@ endif()
 # ==================================================================================================
 # Release compiler flags
 # ==================================================================================================
-if (NOT MSVC)
+if (NOT MSVC AND NOT IOS)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
-
     # These aren't compatible with -fembed-bitcode (and seem to have no effect on Apple platforms anyway)
-    if (NOT IOS)
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffunction-sections -fdata-sections")
-    endif()
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffunction-sections -fdata-sections")
 endif()
 
 # On Android RELEASE builds, we disable exceptions and RTTI to save some space (about 75 KiB

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,7 @@ endif()
 # Release compiler flags
 # ==================================================================================================
 if (NOT MSVC AND NOT IOS)
+    # Omitting stack frame pointers prevents the generation of readable stack traces in crash reports on iOS
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
     # These aren't compatible with -fembed-bitcode (and seem to have no effect on Apple platforms anyway)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffunction-sections -fdata-sections")
@@ -319,6 +320,7 @@ endif()
 if (ANDROID OR IOS OR WEBGL)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-rtti")
     if (ANDROID OR WEBGL)
+        # Omitting unwind info prevents the generation of readable stack traces in crash reports on iOS
         set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-unwind-tables -fno-asynchronous-unwind-tables")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,7 +320,10 @@ endif()
 # On Android RELEASE builds, we disable exceptions and RTTI to save some space (about 75 KiB
 # saved by -fno-exception and 10 KiB saved by -fno-rtti).
 if (ANDROID OR IOS OR WEBGL)
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-exceptions -fno-rtti")
+    if (ANDROID OR WEBGL)
+        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-unwind-tables -fno-asynchronous-unwind-tables")
+    endif()
 endif()
 
 # With WebGL, we disable RTTI even for debug builds because we pass emscripten::val back and forth


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1223](https://shapr3d.atlassian.net/browse/GFX-1223)

## Short description (What? How?) 📖
Apparently we can get usable stack traces by just enabling generation of stack unwind tables on iOS. We don't need to enable C++ exceptions. We still lost parts of the stack trace, but at least [the stack frame above](https://console.firebase.google.com/u/0/project/shapr3d-mac/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/3866f5d174dfc83bf7a643f54d32537a?time=last-twenty-four-hours&types=crash&sessionEventKey=e0ca35756cdf4479ab4173d3459ea225_1648214803643439505) `panic` is preserved giving us a chance to understand (and group) Filament related crashes.

Crash report, before: 
<img width="800" alt="image" src="https://user-images.githubusercontent.com/12460850/156014856-2f27f33a-5ca0-43c4-88de-52a62becb7e0.png">

Crash report (of the same crash), after:
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/12460850/156014908-1f2fb09c-86b9-492c-8c53-61aefb899bfe.png">

FYI, #40 couldn't preserve the entire stack trace either, but [only the frame above](https://console.firebase.google.com/u/0/project/shapr3d-mac/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/f52e025c52624013b110ac4531895379?time=last-hour&types=crash&sessionEventKey=60a2f32bb6e54dd68ba1a61131c87aae_1646362369843101701) `panic`. So this PR achieves the same result without enabling C++ exceptions in Filament libs.

### UPDATE
Without `fomit-frame-pointer`, the entire stack trace is preserved.
<img width="1203" alt="image" src="https://user-images.githubusercontent.com/12460850/156051894-6210cde2-c27a-4ad8-8302-2eaffa5f70cc.png">

The size of libfilament-fused.a grew from 137.1 MB to 139.5 MB due to the added unwind info.

## Testing

### Design review 🎨

### Affected areas 🧭

### Special use-cases to test 🧷
Generate a crash on Filament's driver thread or the main thread in Shapr3D

### How did you test it? 🤔
Manual 💁‍♂️
Tested a crash on:
| Platform | Crash on `FEngine::loop` thread | Crash on `main` thread |
| --- | --- | --- |
| x86_64 iOS | skipped 🙈  | skipped 🙈  |
| arm64 iOS | [link](https://console.firebase.google.com/u/0/project/popping-heat-5625/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/e897ae711f25d9f870047a7ec1922a02?time=last-hour&sessionEventKey=6b01a20f8b8d4bea8ecde9aa60785929_1648500043390305003) | [link](https://console.firebase.google.com/u/0/project/popping-heat-5625/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/e897ae711f25d9f870047a7ec1922a02?time=last-hour&sessionEventKey=1eecebf96b924ee282317020f9c8f94e_1648505174393242329) |
| arm64 macOS | [link](https://console.firebase.google.com/u/0/project/shapr3d-mac/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/7a743f90d15571c71cf6666efe408baa?time=last-seven-days&sessionEventKey=773c54586f484c41997829e14fbc6434_1648556757705452419) | [link](https://console.firebase.google.com/u/0/project/shapr3d-mac/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/8af5ac6f4e0a85fdbaf850caaef23a89?time=last-hour&sessionEventKey=32c4adbed7dd4e7cb3abb8f8ae9a1477_1648558630450243912) |
| x86_64 macOS | [link](https://console.firebase.google.com/u/0/project/shapr3d-mac/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/33f2a1daa22c9361f8f92e86d8574141?time=last-hour&types=crash&sessionEventKey=d8a15401fcab4d2a83d6f7693efa55a1_1648296304488182019) | [link](https://console.firebase.google.com/u/0/project/shapr3d-mac/crashlytics/app/ios:com.shapr3d.shapr.beta/issues/33f2a1daa22c9361f8f92e86d8574141?time=last-hour&types=crash&sessionEventKey=87f4cb2f0fcd4fb8a5e34418485c83cc_1648532979013900359) |

Automated 💻
