### PR TITLE
[GFX-1265] Improve Cloth and Subsurface shading

### DIFF
--- a/filament/src/materials/Cloth.mat
+++ b/filament/src/materials/Cloth.mat
@@ -147,6 +147,14 @@ material {
             name : subsurfaceColor
         },
         {
+            type : float3,
+            name : subsurfaceTint,
+        },
+        {
+            type : int,
+            name : doDeriveSubsurfaceColor
+        },
+        {
             type : int,
             name : useWard
         },

--- a/filament/src/materials/Cloth.mat
+++ b/filament/src/materials/Cloth.mat
@@ -139,6 +139,10 @@ material {
             name : sheenColor
         },
         {
+            type : float,
+            name : sheenIntensity
+        },
+        {
             type : float3,
             name : subsurfaceColor
         },

--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -361,13 +361,14 @@ void ApplyShaprScalars(inout MaterialInputs material, inout FragmentData fragmen
 }
 
 // As all-black cloth materials require positive sheen contribution in order to be visible (read: not pitch black),
-// this function is re-normalizing the final luminance (estimate) of the auto-computed sheen color if it would be
-// too dark otherwise. We do have to do this re-normalization to avoid (or minimize, really) the hue shifts. 
+// this function should be re-normalizing the final luminance (estimate) of the auto-computed sheen color if it 
+// would be too dark otherwise. However, we'd still need to cater for the special case of denormal and all-black
+// incoming colors, so I've ultimately decided to just clamp the result of the sqrt.
 vec3 BaseColorToSheenColor(vec3 baseColor) {
-    const float LUMINANCE_THRESHOLD = sqrt(2.5e-3);
-    vec3 result = sqrt(baseColor.rgb);
-    float luminance = max(max(result.r, result.g), result.b);
-    return ( luminance < LUMINANCE_THRESHOLD ) ? result * ( LUMINANCE_THRESHOLD / luminance ) : result;
+    //  This epsilon is selected such that visuals on Cloth are cca. matching a perfectly black, roughness = 1 Opaque material
+    const float LUMINANCE_THRESHOLD = sqrt(5e-3);
+    vec3 result = max( sqrt(baseColor.rgb), vec3(LUMINANCE_THRESHOLD) );
+    return result;
 }
 
 void ApplyNonTextured(inout MaterialInputs material, inout FragmentData fragmentData) {

--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -371,11 +371,12 @@ void ApplyNonTextured(inout MaterialInputs material, inout FragmentData fragment
     material.anisotropyDirection = materialParams.anisotropyDirection;
 #endif
 #if defined(MATERIAL_HAS_SHEEN_COLOR) && !defined(SHADING_MODEL_SUBSURFACE) && defined(BLENDING_DISABLED)
-    // Subsurface is not using sheen color but the others are
+    // Subsurface and transparent are not using sheen color but the others are
     material.sheenColor =
         (materialParams.doDeriveSheenColor == 1) ? sqrt(material.baseColor.rgb) : materialParams.sheenColor;
+    material.sheenColor *= materialParams.sheenIntensity;
 #endif
-#if defined(MATERIAL_HAS_SUBSURFACE_COLOR) && defined(SHADING_MODEL_SUBSURFACE)
+#if defined(MATERIAL_HAS_SUBSURFACE_COLOR) && ( defined(SHADING_MODEL_SUBSURFACE) || defined(SHADING_MODEL_CLOTH) )
     material.subsurfaceColor = materialParams.subsurfaceColor;
 #endif
 #if defined(MATERIAL_HAS_SUBSURFACE_POWER) && defined(SHADING_MODEL_SUBSURFACE)

--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -377,7 +377,13 @@ void ApplyNonTextured(inout MaterialInputs material, inout FragmentData fragment
     material.sheenColor *= materialParams.sheenIntensity;
 #endif
 #if defined(MATERIAL_HAS_SUBSURFACE_COLOR) && ( defined(SHADING_MODEL_SUBSURFACE) || defined(SHADING_MODEL_CLOTH) )
-    material.subsurfaceColor = materialParams.subsurfaceColor;
+    if (materialParams.doDeriveSubsurfaceColor == 1) {
+        material.subsurfaceColor = material.baseColor.rgb;
+    } else {
+        material.subsurfaceColor = materialParams.subsurfaceColor;
+    }
+    // note: this also incorporates the subsurface intensity, i.e. subsurfaceTint = subsurfaceTintColor * subsurfaceIntensity
+    material.subsurfaceColor *= materialParams.subsurfaceTint; 
 #endif
 #if defined(MATERIAL_HAS_SUBSURFACE_POWER) && defined(SHADING_MODEL_SUBSURFACE)
     material.subsurfacePower = materialParams.subsurfacePower;

--- a/filament/src/materials/Opaque.mat
+++ b/filament/src/materials/Opaque.mat
@@ -164,6 +164,10 @@ material {
             name : sheenColor
         },
         {
+            type : float,
+            name : sheenIntensity
+        },
+        {
             type : int,
             name : useWard
         },

--- a/filament/src/materials/Refractive.mat
+++ b/filament/src/materials/Refractive.mat
@@ -195,6 +195,10 @@ material {
         },
         {
             type : float,
+            name : sheenIntensity
+        },
+        {
+            type : float,
             name : maxThickness
         },
         {

--- a/filament/src/materials/Subsurface.mat
+++ b/filament/src/materials/Subsurface.mat
@@ -148,6 +148,14 @@ material {
             name : subsurfaceColor
         },
         {
+            type : int,
+            name : doDeriveSubsurfaceColor
+        },
+        {
+            type : float3,
+            name : subsurfaceTint,
+        },
+        {
             type : float,
             name : subsurfacePower
         },

--- a/libs/viewer/include/viewer/TweakableMaterial.h
+++ b/libs/viewer/include/viewer/TweakableMaterial.h
@@ -111,7 +111,9 @@ public:
     TweakableProperty<float> mAnisotropy{}; // for metals
     TweakableProperty<filament::math::float3, false, false> mAnisotropyDirection{}; // for metals; not color
     
-    TweakableProperty<filament::math::float3> mSubsurfaceColor{}; // for cloth and subsurface
+    TweakablePropertyDerivable<filament::math::float3> mSubsurfaceColor{}; // for cloth and subsurface
+    TweakableProperty<filament::math::float3> mSubsurfaceTint{}; // for cloth and subsurface
+    TweakableProperty<float> mSubsurfaceIntensity{1.0f}; // for cloth and subsurface
     TweakableProperty<float> mSheenIntensity{1.0f}; // value multiplier for sheen color
     TweakablePropertyDerivable<filament::math::float3> mSheenColor{}; // for cloth
     TweakablePropertyTextured<float> mSheenRoughness{}; // for cloth

--- a/libs/viewer/include/viewer/TweakableMaterial.h
+++ b/libs/viewer/include/viewer/TweakableMaterial.h
@@ -112,6 +112,7 @@ public:
     TweakableProperty<filament::math::float3, false, false> mAnisotropyDirection{}; // for metals; not color
     
     TweakableProperty<filament::math::float3> mSubsurfaceColor{}; // for cloth and subsurface
+    TweakableProperty<float> mSheenIntensity{1.0f}; // value multiplier for sheen color
     TweakablePropertyDerivable<filament::math::float3> mSheenColor{}; // for cloth
     TweakablePropertyTextured<float> mSheenRoughness{}; // for cloth
 

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -1288,11 +1288,15 @@ void SimpleViewer::updateUserInterface() {
                             matInstance->setParameter("doDeriveSheenColor", 0);
                         }
                         matInstance->setParameter("subsurfaceColor", tweaks.mSubsurfaceColor.value);
+                        matInstance->setParameter("doDeriveSubsurfaceColor", tweaks.mSubsurfaceColor.useDerivedQuantity ? 1 : 0);
+                        matInstance->setParameter("subsurfaceTint", tweaks.mSubsurfaceTint.value * tweaks.mSubsurfaceIntensity.value);
                     } else if (tweaks.mShaderType == TweakableMaterial::MaterialType::Subsurface) {
                         matInstance->setParameter("thickness", tweaks.mThickness.value);
                         setTextureIfPresent(tweaks.mThickness.isFile, tweaks.mThickness.filename, "thickness");
                         matInstance->setParameter("subsurfaceColor", tweaks.mSubsurfaceColor.value);
+                        matInstance->setParameter("doDeriveSubsurfaceColor", tweaks.mSubsurfaceColor.useDerivedQuantity ? 1 : 0);
                         matInstance->setParameter("subsurfacePower", tweaks.mSubsurfacePower.value);
+                        matInstance->setParameter("subsurfaceTint", tweaks.mSubsurfaceTint.value * tweaks.mSubsurfaceIntensity.value);
                     }
 
                     if (tweaks.mShaderType == TweakableMaterial::MaterialType::Opaque || tweaks.mShaderType == TweakableMaterial::MaterialType::Refractive) {

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -1281,8 +1281,10 @@ void SimpleViewer::updateUserInterface() {
                     if (tweaks.mShaderType == TweakableMaterial::MaterialType::Cloth) {
                         if (tweaks.mSheenColor.useDerivedQuantity) {
                             matInstance->setParameter("doDeriveSheenColor", 1);
+                            matInstance->setParameter("sheenIntensity", tweaks.mSheenIntensity.value);
                         } else {
                             matInstance->setParameter("sheenColor", tweaks.mSheenColor.value);
+                            matInstance->setParameter("sheenIntensity", 1.0f);
                             matInstance->setParameter("doDeriveSheenColor", 0);
                         }
                         matInstance->setParameter("subsurfaceColor", tweaks.mSubsurfaceColor.value);
@@ -1300,9 +1302,11 @@ void SimpleViewer::updateUserInterface() {
 
                         if (tweaks.mSheenColor.useDerivedQuantity) {
                             matInstance->setParameter("doDeriveSheenColor", 1);
+                            matInstance->setParameter("sheenIntensity", tweaks.mSheenIntensity.value);
                         }
                         else {
                             matInstance->setParameter("sheenColor", tweaks.mSheenColor.value);
+                            matInstance->setParameter("sheenIntensity", 1.0f);
                             matInstance->setParameter("doDeriveSheenColor", 0);
                         }
                         if (tweaks.mShaderType == TweakableMaterial::MaterialType::Opaque) {

--- a/libs/viewer/src/TweakableMaterial.cpp
+++ b/libs/viewer/src/TweakableMaterial.cpp
@@ -3,7 +3,7 @@
 TweakableMaterial::TweakableMaterial() {
     mSpecularIntensity.value = 1.0f;    
     mAnisotropyDirection.value = { 1.0f, 0.0f, 0.0f };
-    mSubsurfaceColor.value = { 1.0f, 1.0f, 1.0f };
+    mSubsurfaceColor.value = { 0.0f, 0.0f, 0.0f };
     mSubsurfaceTint.value = { 1.0f, 1.0f, 1.0f };
     mMaxThickness.value = 1.0f;
     mIor.value = 1.5f;
@@ -120,7 +120,7 @@ void TweakableMaterial::fromJson(const json& source) {
 
     readValueFromJson(source, "isSheenColorDerived", mSheenColor.useDerivedQuantity, false);
     readValueFromJson(source, "sheenIntensity", mSheenIntensity, 1.0f);
-    readValueFromJson<filament::math::float3, true>(source, "subsurfaceColor", mSubsurfaceColor, { 1.0f, 1.0f, 1.0f });
+    readValueFromJson<filament::math::float3, true>(source, "subsurfaceColor", mSubsurfaceColor, { 0.0f, 0.0f, 0.0f });
     readValueFromJson(source, "isSubsurfaceColorDerived", mSubsurfaceColor.useDerivedQuantity, false);
     readValueFromJson<filament::math::float3, true>(source, "subsurfaceTint", mSubsurfaceTint, { 1.0f, 1.0f, 1.0f });
     readValueFromJson(source, "subsurfaceIntensity", mSubsurfaceIntensity.value, 1.0f);
@@ -190,7 +190,7 @@ void TweakableMaterial::resetWithType(MaterialType newType) {
     resetMemberToValue(mAnisotropy, {});
     resetMemberToValue(mAnisotropyDirection, { 1.0f, 0.0f, 0.0f });
 
-    resetMemberToValue(mSubsurfaceColor, { 1.0f, 1.0f, 1.0f });
+    resetMemberToValue(mSubsurfaceColor, { 0.0f, 0.0f, 0.0f });
     resetMemberToValue(mSubsurfaceTint, { 1.0f, 1.0f, 1.0f });
     resetMemberToValue(mSubsurfaceIntensity, 1.0f);
     resetMemberToValue(mSheenColor, {});

--- a/libs/viewer/src/TweakableMaterial.cpp
+++ b/libs/viewer/src/TweakableMaterial.cpp
@@ -3,6 +3,7 @@
 TweakableMaterial::TweakableMaterial() {
     mSpecularIntensity.value = 1.0f;    
     mAnisotropyDirection.value = { 1.0f, 0.0f, 0.0f };
+    mSubsurfaceColor.value = { 1.0f, 1.0f, 1.0f };
     mMaxThickness.value = 1.0f;
     mIor.value = 1.5f;
     mIorScale.value = 1.0f;
@@ -50,6 +51,7 @@ json TweakableMaterial::toJson() {
     result["anisotropyDirection"] = mAnisotropyDirection.value;
 
     result["sheenColor"] = mSheenColor.value;
+    result["sheenIntensity"] = mSheenIntensity.value;
     result["subsurfaceColor"] = mSubsurfaceColor.value;
     result["isSheenColorDerived"] = mSheenColor.useDerivedQuantity;
     result["subsurfacePower"] = mSubsurfacePower.value;
@@ -113,7 +115,8 @@ void TweakableMaterial::fromJson(const json& source) {
     readValueFromJson<filament::math::float3, true, true>(source, "sheenColor", mSheenColor, { 0.0f, 0.0f, 0.0f });
 
     readValueFromJson(source, "isSheenColorDerived", mSheenColor.useDerivedQuantity, false);
-    readValueFromJson<filament::math::float3, true>(source, "subsurfaceColor", mSubsurfaceColor, { 0.0f, 0.0f, 0.0f });
+    readValueFromJson(source, "sheenIntensity", mSheenIntensity, 1.0f);
+    readValueFromJson<filament::math::float3, true>(source, "subsurfaceColor", mSubsurfaceColor, { 1.0f, 1.0f, 1.0f });
     readValueFromJson(source, "subsurfacePower", mSubsurfacePower, 1.0f);
 
     readValueFromJson<filament::math::float3, true, true>(source, "absorption", mAbsorption, { 0.0f, 0.0f, 0.0f });
@@ -180,8 +183,9 @@ void TweakableMaterial::resetWithType(MaterialType newType) {
     resetMemberToValue(mAnisotropy, {});
     resetMemberToValue(mAnisotropyDirection, { 1.0f, 0.0f, 0.0f });
 
-    resetMemberToValue(mSubsurfaceColor, {});
+    resetMemberToValue(mSubsurfaceColor, { 1.0f, 1.0f, 1.0f });
     resetMemberToValue(mSheenColor, {});
+    resetMemberToValue(mSheenIntensity, {});
     resetMemberToValue(mSheenRoughness, {});
 
     resetMemberToValue(mSubsurfacePower, 1.0f);
@@ -274,6 +278,9 @@ void TweakableMaterial::drawUI(const std::string& header) {
     case MaterialType::Opaque: {
         if (ImGui::CollapsingHeader("Sheen settings")) {
             mSheenColor.addWidget("sheen color");
+            if (mSheenColor.useDerivedQuantity) {
+                mSheenIntensity.addWidget("auto-sheen intensity");
+            }
             mSheenRoughness.addWidget("sheen roughness");
             if (mSheenRoughness.isFile) enqueueTextureRequest(mSheenRoughness);
         }
@@ -318,6 +325,9 @@ void TweakableMaterial::drawUI(const std::string& header) {
         if (ImGui::CollapsingHeader("Cloth settings")) {
             mSubsurfaceColor.addWidget("subsurface color");
             mSheenColor.addWidget("sheen color");
+            if (mSheenColor.useDerivedQuantity) {
+                mSheenIntensity.addWidget("auto-sheen intensity");
+            }
         }
         break;
     }

--- a/libs/viewer/src/TweakableMaterial.cpp
+++ b/libs/viewer/src/TweakableMaterial.cpp
@@ -4,6 +4,7 @@ TweakableMaterial::TweakableMaterial() {
     mSpecularIntensity.value = 1.0f;    
     mAnisotropyDirection.value = { 1.0f, 0.0f, 0.0f };
     mSubsurfaceColor.value = { 1.0f, 1.0f, 1.0f };
+    mSubsurfaceTint.value = { 1.0f, 1.0f, 1.0f };
     mMaxThickness.value = 1.0f;
     mIor.value = 1.5f;
     mIorScale.value = 1.0f;
@@ -53,6 +54,9 @@ json TweakableMaterial::toJson() {
     result["sheenColor"] = mSheenColor.value;
     result["sheenIntensity"] = mSheenIntensity.value;
     result["subsurfaceColor"] = mSubsurfaceColor.value;
+    result["isSubsurfaceColorDerived"] = mSubsurfaceColor.useDerivedQuantity;
+    result["subsurfaceTint"] = mSubsurfaceTint.value;
+    result["subsurfaceIntensity"] = mSubsurfaceIntensity.value;
     result["isSheenColorDerived"] = mSheenColor.useDerivedQuantity;
     result["subsurfacePower"] = mSubsurfacePower.value;
     writeTexturedToJson(result, "sheenRoughness", mSheenRoughness);
@@ -117,6 +121,9 @@ void TweakableMaterial::fromJson(const json& source) {
     readValueFromJson(source, "isSheenColorDerived", mSheenColor.useDerivedQuantity, false);
     readValueFromJson(source, "sheenIntensity", mSheenIntensity, 1.0f);
     readValueFromJson<filament::math::float3, true>(source, "subsurfaceColor", mSubsurfaceColor, { 1.0f, 1.0f, 1.0f });
+    readValueFromJson(source, "isSubsurfaceColorDerived", mSubsurfaceColor.useDerivedQuantity, false);
+    readValueFromJson<filament::math::float3, true>(source, "subsurfaceTint", mSubsurfaceTint, { 1.0f, 1.0f, 1.0f });
+    readValueFromJson(source, "subsurfaceIntensity", mSubsurfaceIntensity.value, 1.0f);
     readValueFromJson(source, "subsurfacePower", mSubsurfacePower, 1.0f);
 
     readValueFromJson<filament::math::float3, true, true>(source, "absorption", mAbsorption, { 0.0f, 0.0f, 0.0f });
@@ -184,6 +191,8 @@ void TweakableMaterial::resetWithType(MaterialType newType) {
     resetMemberToValue(mAnisotropyDirection, { 1.0f, 0.0f, 0.0f });
 
     resetMemberToValue(mSubsurfaceColor, { 1.0f, 1.0f, 1.0f });
+    resetMemberToValue(mSubsurfaceTint, { 1.0f, 1.0f, 1.0f });
+    resetMemberToValue(mSubsurfaceIntensity, 1.0f);
     resetMemberToValue(mSheenColor, {});
     resetMemberToValue(mSheenIntensity, {});
     resetMemberToValue(mSheenRoughness, {});
@@ -324,6 +333,9 @@ void TweakableMaterial::drawUI(const std::string& header) {
     case MaterialType::Cloth: {
         if (ImGui::CollapsingHeader("Cloth settings")) {
             mSubsurfaceColor.addWidget("subsurface color");
+            mSubsurfaceTint.addWidget("subsurface tint");
+            mSubsurfaceIntensity.addWidget("subsurface intensity");
+
             mSheenColor.addWidget("sheen color");
             if (mSheenColor.useDerivedQuantity) {
                 mSheenIntensity.addWidget("auto-sheen intensity");
@@ -334,6 +346,8 @@ void TweakableMaterial::drawUI(const std::string& header) {
     case MaterialType::Subsurface: {
         if (ImGui::CollapsingHeader("Subsurface settings")) {
             mSubsurfaceColor.addWidget("subsurface color");
+            mSubsurfaceTint.addWidget("subsurface tint");
+            mSubsurfaceIntensity.addWidget("subsurface intensity");
 
             mSubsurfacePower.addWidget("subsurface power", 0.125f, 16.0f);
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1265](https://shapr3d.atlassian.net/browse/GFX-1265)

## Short description (What? How?) 📖
(EDIT Note: this will be followed up by a Shapr PR.)

The initial premise of the Cloth changes was that all fabrics with black `baseColor` looked completely flat, as if no shading was applied. The solution to this issue has two aspects:
* First, these materials should use derivable sheen colors. 
* Second, we have to clamp the almost-black colors to a reasonably dark gray, and re-normalize the very dark (but not almost black) colors 

I've tried to avoid hue shifts by using re-normalization but that would still need a special case around (0,0,0) color arguments (and denormals, for that matter) so I'm just clamping the result of the sqrt independently (i.e., per component) to some epsilon that was chosen such that an Opaque shader with all black and roughness equal to 1 would look roughly the same as a Cloth shader with 0.25 auto-sheen intensity and roughness 1 on all black (art will be scaling auto-sheen, hence the magical 0.25). 

Opaque:
![image](https://user-images.githubusercontent.com/90197216/156178170-d06c440e-39a8-4dd4-b717-dc4a8131ee2a.png)

Cloth:
![image](https://user-images.githubusercontent.com/90197216/156178190-220a13e7-88ed-4b3d-a3ab-201170c6da80.png)

While I was at it, I've extended the subsurface part of our materials within this PR by adding a subsurface intensity and tint attribute on the GltfViewer side of things and derivable option for `subsurfaceColor` (which will default to `baseColor` if turned on). These can be used to improve the appearance of cloth, metal, and plastic materials.

![image](https://user-images.githubusercontent.com/90197216/156178434-f91236d7-2abf-430c-8e34-40ce854d47c3.png)

EDIT: the current master looks as follows
![IMG_0143](https://user-images.githubusercontent.com/90197216/157044611-d9cc56bb-7f09-4f4c-9428-67afd0f4a39e.PNG)

After this change, this is what you'll see:
![IMG_0142](https://user-images.githubusercontent.com/90197216/157044590-aa7d4d40-06c7-4179-95aa-2365d4db4699.PNG)

Save for the JPG encoding induced errors, the real visual difference is in the leather's look (third column from the left). It has become visible darker, we'll be investigating this in a separate ticket, as the leather are currently being re-authored. 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
GltfViewer and Visualization

### Special use-cases to test 🧷
Cloth, Opaque, and Subsurface shaders

### How did you test it? 🤔
Manual 💁‍♂️
Doodle with Cloth, Opaque, and Subsurface shaders and play around with color changes with derivable quantities. 

Automated 💻
