### PR TITLE
[GFX-1260] Memoryless storage mode with fallback (Metal)

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -61,6 +61,7 @@ struct MetalContext {
 
     // Supported features.
     bool supportsTextureSwizzling = false;
+    bool supportsMemorylessRenderTargets = false;
     uint8_t maxColorRenderTargets = 4;
     struct {
         uint8_t common;

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -47,6 +47,7 @@ class TimerQueryInterface;
 struct MetalUniformBuffer;
 struct MetalIndexBuffer;
 struct MetalSamplerGroup;
+struct MetalTexture;
 struct MetalVertexBuffer;
 
 constexpr static uint8_t MAX_SAMPLE_COUNT = 8;  // Metal devices support at most 8 MSAA samples
@@ -58,6 +59,8 @@ struct MetalContext {
 
     id<MTLCommandBuffer> pendingCommandBuffer = nullptr;
     id<MTLRenderCommandEncoder> currentRenderPassEncoder = nullptr;
+
+    std::atomic<bool> memorylessLimitsReached = false;
 
     // Supported features.
     bool supportsTextureSwizzling = false;
@@ -93,8 +96,9 @@ struct MetalContext {
 
     MetalSamplerGroup* samplerBindings[SAMPLER_BINDING_COUNT] = {};
 
-    // Keeps track of all alive sampler groups.
+    // Keeps track of all alive sampler groups, textures.
     tsl::robin_set<MetalSamplerGroup*> samplerGroups;
+    tsl::robin_set<MetalTexture*> textures;
 
     MetalBufferPool* bufferPool;
 

--- a/filament/backend/src/metal/MetalContext.mm
+++ b/filament/backend/src/metal/MetalContext.mm
@@ -113,6 +113,13 @@ id<MTLCommandBuffer> getPendingCommandBuffer(MetalContext* context) {
     // all frames and their completion handlers finish before context is deallocated.
     [context->pendingCommandBuffer addCompletedHandler:^(id <MTLCommandBuffer> buffer) {
         context->resourceTracker.clearResources((__bridge void*) buffer);
+        
+        auto errorCode = (MTLCommandBufferError)buffer.error.code;
+        if (@available(macOS 11.0, macCatalyst 14.0, *)) {
+            if (errorCode == MTLCommandBufferErrorMemoryless) {
+                context->memorylessLimitsReached = true;
+            }
+        }
     }];
     ASSERT_POSTCONDITION(context->pendingCommandBuffer, "Could not obtain command buffer.");
     return context->pendingCommandBuffer;

--- a/filament/backend/src/metal/MetalDriver.h
+++ b/filament/backend/src/metal/MetalDriver.h
@@ -37,6 +37,7 @@ class MetalBuffer;
 struct MetalUniformBuffer;
 struct MetalContext;
 struct MetalProgram;
+struct MetalTexture;
 struct UniformBufferState;
 
 #ifndef FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -88,6 +88,9 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
             mContext->highestSupportedGpuFamily.macCatalyst >= 2;   // newer Mac Catalyst GPUs
     }
 
+    // In order to support memoryless render targets, an Apple GPU is needed.
+    mContext->supportsMemorylessRenderTargets = mContext->highestSupportedGpuFamily.apple >= 1;
+
     mContext->maxColorRenderTargets = 4;
     if (mContext->highestSupportedGpuFamily.apple >= 2 ||
         mContext->highestSupportedGpuFamily.mac >= 1 ||

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -193,6 +193,18 @@ void MetalDriver::endFrame(uint32_t frameId) {
 
     assert_invariant(mContext->groupMarkers.empty());
 
+    // If we exceeded memoryless limits, turn it off for the rest of the lifetime of the driver.
+    if (mContext->supportsMemorylessRenderTargets && mContext->memorylessLimitsReached) {
+        for (MetalTexture* texture : mContext->textures) {
+            // Release memoryless MTLTexture-s, which are currently only the MSAA sidecars.
+            // Creation of new render targets is going to trigger the re-allocation of sidecars,
+            // with private storage mode from now on. Here, at the end of the frame,
+            // all render targets that have textures with sidecars are assumed to be destroyed.
+            texture->msaaSidecar = nil;
+        }
+        mContext->supportsMemorylessRenderTargets = false;
+    }
+
 #if defined(FILAMENT_METAL_PROFILING)
     os_signpost_interval_end(mContext->log, mContext->signpostId, "Frame encoding");
 #endif
@@ -238,9 +250,9 @@ void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8
     auto& sc = mContext->sampleCountLookup;
     samples = sc[std::min(MAX_SAMPLE_COUNT, samples)];
 
-    construct_handle<MetalTexture>(th, *mContext, target, levels, format, samples,
+    mContext->textures.insert(construct_handle<MetalTexture>(th, *mContext, target, levels, format, samples,
             width, height, depth, usage, TextureSwizzle::CHANNEL_0, TextureSwizzle::CHANNEL_1,
-            TextureSwizzle::CHANNEL_2, TextureSwizzle::CHANNEL_3);
+            TextureSwizzle::CHANNEL_2, TextureSwizzle::CHANNEL_3));
 }
 
 void MetalDriver::createTextureSwizzledR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
@@ -516,6 +528,7 @@ void MetalDriver::destroyTexture(Handle<HwTexture> th) {
         }
     }
 
+    mContext->textures.erase(handle_cast<MetalTexture>(th));
     destruct_handle<MetalTexture>(th);
 }
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -288,7 +288,7 @@ private:
 
     static MTLLoadAction getLoadAction(const RenderPassParams& params, TargetBufferFlags buffer);
     static MTLStoreAction getStoreAction(const RenderPassParams& params, TargetBufferFlags buffer);
-    static id<MTLTexture> createMultisampledTexture(id<MTLDevice> device, MTLPixelFormat format,
+    static id<MTLTexture> createMultisampledTexture(MetalContext& context, MTLPixelFormat format,
             uint32_t width, uint32_t height, uint8_t samples);
 
     MetalContext* context;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1260](https://shapr3d.atlassian.net/browse/GFX-1260)

## Short description (What? How?) 📖
This PR changes the storage mode of MSAA sidecar textures to [memoryless](https://developer.apple.com/documentation/metal/mtlstoragemode/memoryless) in the Metal backend, on supported devices. Reverts https://github.com/google/filament/pull/4333 upstream.

Sidecars only may sound limiting, however these constitute the majority of memory usage in a multisampled setup. These textures are guaranteed to have transient content, which is a prerequisite of memoryless storage mode. A limitiation of this feature - besides the requirement of an Apple GPU - is that only a certain geometry complexity can be processed and rendered this way. Exceeding this limit causes a command buffer error. 

We now handle memoryless limit reached event by turning off the memoryless feature, and falling back to private storage mode. No further attempts are made to return to memoryless, an engine restart is needed.

## Testing

### Affected areas 🧭
Metal backend, render targets.

### Special use-cases to test 🧷
Loading very high triangle count models. 

### How did you test it? 🤔
- Verified that memory usage is reduced, under Memory tab of a Metal Frame Capture.
- Tested that fallback to private works by artifically increasing complexity by encoding each render command multiple times (loop in [MetalDriver.mm#L1365-L1369](https://github.com/shapr3d/filament/blob/64bfa1033c60d8665fcacb284c95d65a5a236abc/filament/backend/src/metal/MetalDriver.mm#L1365-L1369)).
