### PR TITLE
[GFX-610] Fix integration of box and sphere IBLs

### DIFF
--- a/filament/include/filament/IndirectLight.h
+++ b/filament/include/filament/IndirectLight.h
@@ -20,6 +20,7 @@
 #define TNT_FILAMENT_INDIRECTLIGHT_H
 
 #include <filament/FilamentAPI.h>
+#include <filament/Options.h>
 
 #include <utils/compiler.h>
 
@@ -334,6 +335,55 @@ public:
      */
     static math::float4 getColorEstimate(const math::float3 sh[9], math::float3 direction) noexcept;
 
+    /**
+     * Sets IBL lookup options.
+     *
+     * @param options Options for IBL lookup settings.
+     */
+    void setIblOptions(IblOptions const& options) noexcept;
+
+    /**
+     * Gets IBL lookup options.
+     *
+     * @return IBL lookup options.
+     */
+    IblOptions const& getIblOptions() const noexcept;
+
+    /**
+     * Sets IBL type.
+     *
+     * @param iblTechnique Determine the IBL type (infinite, or finite box/sphere)
+     */
+    void setIblTechnique(const IblOptions::IblTechnique iblTechnique) noexcept;
+
+    /**
+     * Gets IBL type.
+     */
+    IblOptions::IblTechnique getIblTechnique() const noexcept;
+
+    /**
+     * Sets the center of the finite IBL proxy geometry.
+     *
+     * @param iblCenter The center of the finite IBL proxy geometry
+     */
+    void setIblCenter(const math::float3& iblCenter) noexcept;
+
+    /**
+     * Gets IBL center.
+     */
+    const math::float3& getIblCenter() const noexcept;
+
+    /**
+     * Sets the half extents of the finite IBL proxy geometry.
+     *
+     * @param iblCenter The half extents of the finite IBL proxy geometry
+     */
+    void setIblHalfExtents(const math::float3& iblHalfExtents) noexcept;
+
+    /**
+     * Gets IBL half extents.
+     */
+    const math::float3& getIblHalfExtents() const noexcept;
 
     /** @deprecated use static versions instead */
     UTILS_DEPRECATED

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -357,6 +357,17 @@ struct VsmShadowOptions {
     float lightBleedReduction = 0.15f;
 };
 
+struct IblOptions {    
+    enum class IblTechnique : uint32_t {
+        IBL_INFINITE, IBL_FINITE_SPHERE, IBL_FINITE_BOX
+    };
+
+    IblTechnique iblTechnique = IblTechnique::IBL_INFINITE;
+
+    math::float3 iblCenter;       // center of the sphere or IBL AABB
+    math::float3 iblHalfExtents;  // .x is radius for sphere; otherwise the half extents of the box along the X, Y, Z axes
+};
+
 } // namespace filament
 
 #endif //TNT_FILAMENT_OPTIONS_H

--- a/filament/src/IndirectLight.cpp
+++ b/filament/src/IndirectLight.cpp
@@ -268,6 +268,38 @@ float4 FIndirectLight::getColorEstimate(float3 direction) const noexcept {
    return getColorEstimate(mIrradianceCoefs.data(), direction);
 }
 
+void FIndirectLight::setIblOptions(IblOptions const& options) noexcept {
+    mIblOptions = options;
+}
+
+IblOptions const& FIndirectLight::getIblOptions() const noexcept {
+    return mIblOptions;
+}
+
+void FIndirectLight::setIblTechnique(const IblOptions::IblTechnique iblTechnique) noexcept {
+    mIblOptions.iblTechnique = iblTechnique;
+}
+
+IblOptions::IblTechnique FIndirectLight::getIblTechnique() const noexcept {
+    return mIblOptions.iblTechnique;
+}
+
+void FIndirectLight::setIblCenter(const math::float3& iblCenter) noexcept {
+    mIblOptions.iblCenter = iblCenter;
+}
+
+const math::float3& FIndirectLight::getIblCenter() const noexcept {
+    return mIblOptions.iblCenter;
+}
+
+void FIndirectLight::setIblHalfExtents(const math::float3& iblHalfExtents) noexcept {
+    mIblOptions.iblHalfExtents = iblHalfExtents;
+}
+
+const math::float3& FIndirectLight::getIblHalfExtents() const noexcept {
+    return mIblOptions.iblHalfExtents;
+}
+
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------
@@ -302,6 +334,38 @@ math::float3 IndirectLight::getDirectionEstimate() const noexcept {
 
 math::float4 IndirectLight::getColorEstimate(math::float3 direction) const noexcept {
     return upcast(this)->getColorEstimate(direction);
+}
+
+void IndirectLight::setIblOptions(IblOptions const& options) noexcept {
+    upcast(this)->setIblOptions(options);
+}
+
+IblOptions const& IndirectLight::getIblOptions() const noexcept {
+    return upcast(this)->getIblOptions();
+}
+
+void IndirectLight::setIblTechnique(const IblOptions::IblTechnique iblTechnique) noexcept {
+    upcast(this)->setIblTechnique(iblTechnique);
+}
+
+IblOptions::IblTechnique IndirectLight::getIblTechnique() const noexcept {
+    return upcast(this)->getIblTechnique();
+}
+
+void IndirectLight::setIblCenter(const math::float3& iblCenter) noexcept {
+    upcast(this)->setIblCenter(iblCenter);
+}
+
+const math::float3& IndirectLight::getIblCenter() const noexcept {
+    return upcast(this)->getIblCenter();
+}
+
+void IndirectLight::setIblHalfExtents(const math::float3& iblHalfExtents) noexcept {
+    upcast(this)->setIblHalfExtents(iblHalfExtents);
+}
+
+const math::float3& IndirectLight::getIblHalfExtents() const noexcept {
+    return upcast(this)->getIblHalfExtents();
 }
 
 math::float3 IndirectLight::getDirectionEstimate(const math::float3* sh) noexcept {

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -221,7 +221,8 @@ void PerViewUniforms::prepareIblLight(const IblOptions& options) noexcept {
     s.iblHalfExtents = options.iblHalfExtents;
 }
 
-void PerViewUniforms::prepareAmbientLight(FIndirectLight const& ibl, float intensity, float exposure) noexcept {
+void PerViewUniforms::prepareAmbientLight(FIndirectLight const& ibl,
+        float intensity, float exposure) noexcept {
     auto& engine = mEngine;
     auto& s = mPerViewUb.edit();
 

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -214,8 +214,14 @@ void PerViewUniforms::prepareDirectionalLight(
     }
 }
 
-void PerViewUniforms::prepareAmbientLight(FIndirectLight const& ibl,
-        float intensity, float exposure) noexcept {
+void PerViewUniforms::prepareIblLight(const IblOptions& options) noexcept {
+    auto& s = mPerViewUb.edit();
+    s.iblTechnique = static_cast<uint32_t>(options.iblTechnique);
+    s.iblCenter = options.iblCenter;
+    s.iblHalfExtents = options.iblHalfExtents;
+}
+
+void PerViewUniforms::prepareAmbientLight(FIndirectLight const& ibl, float intensity, float exposure) noexcept {
     auto& engine = mEngine;
     auto& s = mPerViewUb.edit();
 

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -34,6 +34,7 @@ struct FogOptions;
 struct DynamicResolutionOptions;
 struct AmbientOcclusionOptions;
 struct VsmShadowOptions;
+struct IblOptions;
 
 struct CameraInfo;
 struct ShadowMappingUniforms;
@@ -67,6 +68,8 @@ public:
 
     void prepareDirectionalLight(float exposure,
             math::float3 const& sceneSpaceDirection, LightManagerInstance instance) noexcept;
+
+    void prepareIblLight(const IblOptions& options) noexcept;
 
     void prepareAmbientLight(FIndirectLight const& ibl, float intensity, float exposure) noexcept;
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -319,6 +319,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
     }
 
     mPerViewUniforms.prepareAmbientLight(*ibl, intensity, exposure);
+    mPerViewUniforms.prepareIblLight(ibl->getIblOptions());
 
     /*
      * Directional light (always at index 0)

--- a/filament/src/details/IndirectLight.h
+++ b/filament/src/details/IndirectLight.h
@@ -22,6 +22,7 @@
 #include <backend/Handle.h>
 
 #include <filament/IndirectLight.h>
+#include <filament/Options.h>
 #include <filament/Texture.h>
 
 #include <utils/compiler.h>
@@ -33,6 +34,8 @@
 namespace filament {
 
 class FEngine;
+
+using IblOptions = filament::IblOptions;
 
 class FIndirectLight : public IndirectLight {
 public:
@@ -57,6 +60,18 @@ public:
     static math::float3 getDirectionEstimate(const math::float3 sh[9]) noexcept;
     static math::float4 getColorEstimate(const math::float3 sh[9], math::float3 direction) noexcept;
 
+    void setIblOptions(IblOptions const& options) noexcept;
+    const IblOptions& getIblOptions() const noexcept;
+
+    void setIblTechnique(const IblOptions::IblTechnique iblTechnique) noexcept;
+    IblOptions::IblTechnique getIblTechnique() const noexcept;
+
+    void setIblCenter(const math::float3& iblCenter) noexcept;
+    const math::float3& getIblCenter() const noexcept;
+
+    void setIblHalfExtents(const math::float3& iblHalfExtents) noexcept;
+    const math::float3& getIblHalfExtents() const noexcept;
+
 private:
     FTexture const* mReflectionsTexture = nullptr;
     FTexture const* mIrradianceTexture = nullptr;
@@ -64,6 +79,7 @@ private:
     float mIntensity = DEFAULT_INTENSITY;
     math::mat3f mRotation;
     uint8_t mLevelCount = 0;
+    IblOptions mIblOptions;
 };
 
 FILAMENT_UPCAST(IndirectLight)

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -130,15 +130,15 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float vsmLightBleedReduction;
     float vsmReserved0;
 
+    math::float3 iblCenter;      // center of the sphere or IBL AABB
     float lodBias;
-    float reserved1;
-    float reserved2;
-    float reserved3;
+    math::float3 iblHalfExtents; // .x is radius squared for sphere; otherwise the half extents of the box along the X, Y, Z axes
+    uint32_t iblTechnique;       // 0: infinite cubemap IBL, 1: (origin centered) finite sphere IBL, 2: (origin centered) finite cube IBL
 
     math::mat4f iblRotation; // contains the IBL's rotation
 
     // bring PerViewUib to 2 KiB
-    math::float4 padding3[53];
+    math::float4 arrayPadding[52];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -111,16 +111,17 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("vsmLightBleedReduction",  1, UniformInterfaceBlock::Type::FLOAT)
             .add("vsmReserved0",            1, UniformInterfaceBlock::Type::FLOAT)
 
+            .add("iblCenter",               1, UniformInterfaceBlock::Type::FLOAT3)
             .add("lodBias",                 1, UniformInterfaceBlock::Type::FLOAT)
-            .add("reserved1",               1, UniformInterfaceBlock::Type::FLOAT)
-            .add("reserved2",               1, UniformInterfaceBlock::Type::FLOAT)
-            .add("reserved3",               1, UniformInterfaceBlock::Type::FLOAT)
+
+            .add("iblHalfExtents",          1, UniformInterfaceBlock::Type::FLOAT3)
+            .add("iblTechnique",            1, UniformInterfaceBlock::Type::UINT)
 
             // this is a mat3, but in struct PerViewUib is a mat4 for std140 compliance
             .add("iblRotation",             1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
 
             // bring PerViewUib to 2 KiB
-            .add("padding3", 53, UniformInterfaceBlock::Type::FLOAT4)
+            .add("arrayPadding", 52, UniformInterfaceBlock::Type::FLOAT4)
             .build();
     return uib;
 }

--- a/libs/viewer/include/viewer/Settings.h
+++ b/libs/viewer/include/viewer/Settings.h
@@ -191,6 +191,7 @@ struct LightSettings {
     float skyIntensity = 30000.0f;
     float iblRotation = 0.0f;
     Skybox::SkyboxType skyboxType = Skybox::SkyboxType::ENVIRONMENT;
+    IblOptions iblOptions{};
 };
 
 struct ViewerOptions {

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -103,6 +103,12 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, float* v
     return i + 1;
 }
 
+static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, IblOptions::IblTechnique* val) {
+    CHECK_TOKTYPE(tokens[i], JSMN_PRIMITIVE);
+    *val = static_cast<IblOptions::IblTechnique>(strtod(jsonChunk + tokens[i].start, nullptr));
+    return i + 1;
+}
+
 static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, float* vals, int size) {
     CHECK_TOKTYPE(tokens[i], JSMN_ARRAY);
     if (tokens[i].size != size) {
@@ -849,6 +855,20 @@ static int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, LightSet
             i = parse(tokens, i + 1, jsonChunk, &out->skyIntensity);
         } else if (compare(tok, jsonChunk, "iblRotation") == 0) {
             i = parse(tokens, i + 1, jsonChunk, &out->iblRotation);
+        } else if (compare(tok, jsonChunk, "iblTechnique") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->iblOptions.iblTechnique);
+        } else if (compare(tok, jsonChunk, "iblCenterX") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->iblOptions.iblCenter.x);
+        } else if (compare(tok, jsonChunk, "iblCenterY") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->iblOptions.iblCenter.y);
+        } else if (compare(tok, jsonChunk, "iblCenterZ") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->iblOptions.iblCenter.z);
+        } else if (compare(tok, jsonChunk, "iblHalfExtentsX") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->iblOptions.iblHalfExtents.x);
+        } else if (compare(tok, jsonChunk, "iblHalfExtentsY") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->iblOptions.iblHalfExtents.y);
+        } else if (compare(tok, jsonChunk, "iblHalfExtentsZ") == 0) {
+            i = parse(tokens, i + 1, jsonChunk, &out->iblOptions.iblHalfExtents.z);
         } else {
             slog.w << "Invalid light setting key: '" << STR(tok, jsonChunk) << "'" << io::endl;
             i = parse(tokens, i + 1);
@@ -1016,6 +1036,8 @@ void applySettings(const LightSettings& settings, IndirectLight* ibl, utils::Ent
     if (ibl) {
         ibl->setIntensity(settings.iblIntensity);
         ibl->setRotation(math::mat3f::rotation(settings.iblRotation, math::float3 { 0, 1, 0 }));
+        ibl->setIblOptions(settings.iblOptions);
+
     }
     if (scene->getSkybox())
     {
@@ -1381,6 +1403,13 @@ static std::ostream& operator<<(std::ostream& out, const LightSettings& in) {
         << "\"iblIntensity\": " << (in.iblIntensity) << ",\n"
         << "\"skyIntensity\": " << (in.skyIntensity) << ",\n"
         << "\"iblRotation\": " << (in.iblRotation) << "\n"
+        << "\"iblTechnique\": " << static_cast<uint32_t>(in.iblOptions.iblTechnique) << "\n"
+        << "\"iblCenterX\": " << in.iblOptions.iblCenter.x << "\n"
+        << "\"iblCenterY\": " << in.iblOptions.iblCenter.y << "\n"
+        << "\"iblCenterZ\": " << in.iblOptions.iblCenter.z << "\n"
+        << "\"iblHalfExtentsX\": " << in.iblOptions.iblHalfExtents.x << "\n"
+        << "\"iblHalfExtentsY\": " << in.iblOptions.iblHalfExtents.y << "\n"
+        << "\"iblHalfExtentsZ\": " << in.iblOptions.iblHalfExtents.z << "\n"
         << "}";
 }
 
@@ -1467,6 +1496,7 @@ static std::ostream& operator<<(std::ostream& out, const ViewSettings& in) {
         << "\"vsmShadowOptions\": " << (in.vsmShadowOptions) << ",\n"
         << "\"postProcessingEnabled\": " << to_string(in.postProcessingEnabled) << "\n"
         << "}";
+    
 }
 
 static std::ostream& operator<<(std::ostream& out, const Settings& in) {

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -1441,6 +1441,7 @@ void SimpleViewer::updateUserInterface() {
     }
 
     auto& light = mSettings.lighting;
+    auto& iblOptions = mSettings.lighting.iblOptions;
     if (ImGui::CollapsingHeader("Light")) {
         ImGui::Indent();
         if (ImGui::CollapsingHeader("Skybox")) {
@@ -1450,6 +1451,35 @@ void SimpleViewer::updateUserInterface() {
         if (ImGui::CollapsingHeader("Indirect light")) {
             ImGui::SliderFloat("IBL intensity", &light.iblIntensity, 0.0f, 100000.0f);
             ImGui::SliderAngle("IBL rotation", &light.iblRotation);
+
+            if (ImGui::RadioButton("Infinite", iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_INFINITE)) {
+                iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_INFINITE;
+            }
+            ImGui::SameLine();
+            if (ImGui::RadioButton("Sphere", iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_SPHERE)) {
+                iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_SPHERE;
+            }
+            ImGui::SameLine();
+            if (ImGui::RadioButton("Box", iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_BOX)) {
+                iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_BOX;
+            }
+
+            if (iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_SPHERE) {
+                static float radius = std::sqrt(iblOptions.iblHalfExtents.x);
+
+                ImGui::SliderFloat3("Sphere center", iblOptions.iblCenter.v, -10.0f, 10.0f);
+                ImGui::SliderFloat("Sphere radius", &radius, 0.0f, 256.0f);
+
+                iblOptions.iblHalfExtents.x = radius * radius;
+            }
+            else if (iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_BOX) {
+                static filament::math::float3 iblHalfExtents = iblOptions.iblHalfExtents;
+
+                ImGui::SliderFloat3("Box center", iblOptions.iblCenter.v, -10.0f, 10.0f);
+                ImGui::SliderFloat3("Box half extents", iblHalfExtents.v, -10.0f, 10.0f);
+
+                iblOptions.iblHalfExtents = iblHalfExtents;
+            }
         }
         if (ImGui::CollapsingHeader("Sunlight")) {
             ImGui::Checkbox("Enable sunlight", &light.enableSunlight);
@@ -1615,6 +1645,7 @@ void SimpleViewer::updateUserInterface() {
     // At this point, all View settings have been modified,
     //  so we can now push them into the Filament View.
     applySettings(mSettings.view, mView);
+    mIndirectLight->setIblOptions(mSettings.lighting.iblOptions);
 
     if (light.enableSunlight) {
         mScene->addEntity(mSunlight);

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -139,6 +139,44 @@ vec3 specularDFG(const PixelParams pixel) {
 #endif
 }
 
+
+/**
+ * This function returns an IBL lookup direction, taking into account the current IBL type (e.g. infinite spherical, 
+ * finite/local sphere/box), an initial intended lookup direction (baseDir) and the particular normal we compute
+ * reflections against (e.g. either the interpolated surface or clearcoat normal).
+ */
+vec3 GetAdjustedReflectedDirection(const PixelParams pixel, const vec3 baseDir, const vec3 normal) {
+    vec3 defaultReflected = reflect(-baseDir, normal);    
+
+    if (frameUniforms.iblTechnique == IBL_TECHNIQUE_INFINITE) return defaultReflected;
+
+    // intersect the ray rayPos + t * rayDir with the finite geometry; done in the coordinate system of the finite geometry
+    vec3 rayPos = getWorldPosition() + getWorldOffset() - frameUniforms.iblCenter;
+    vec3 rayDir = defaultReflected;
+
+    vec3  r  = vec3(0.0); // resulting direction
+    float t0 = -1.0f;     // intersection parameter between ray and finite IBL geometry
+    
+    if (frameUniforms.iblTechnique == IBL_TECHNIQUE_FINITE_SPHERE) {
+        float R2 = frameUniforms.iblHalfExtents.r; // we store the squared radius to shave off a multiplication here
+        float A = 1.0; // in general, this should be dot(rayDir, rayDir) but we have just normalized it a couple of lines ago
+        float B = 2.0 * dot(rayPos, rayDir);
+        float C = dot(rayPos, rayPos) - R2;
+        vec2 roots = SolveQuadratic(A, B, C);
+        t0 = GetSmallestPositive(roots.x, roots.y);
+    }
+    else if (frameUniforms.iblTechnique == IBL_TECHNIQUE_FINITE_BOX) {
+        vec2 roots = IntersectAABB(rayPos, rayDir, -frameUniforms.iblHalfExtents, frameUniforms.iblHalfExtents);
+        t0 = GetSmallestPositive(roots.x, roots.y);
+    }
+
+    // translate results back to world space
+    vec3 intersection_point = ( t0 >= 0.0 ) ? rayPos + t0 * rayDir : defaultReflected;
+    r = normalize(intersection_point);
+
+    return r;
+}
+
 /**
  * Returns the reflected vector at the current shading point. The reflected vector
  * return by this function might be different from shading_reflected:
@@ -156,9 +194,9 @@ vec3 getReflectedVector(const PixelParams pixel, const vec3 v, const vec3 n) {
     float bendFactor          = abs(pixel.anisotropy) * saturate(5.0 * pixel.perceptualRoughness);
     vec3  bentNormal          = normalize(mix(n, anisotropicNormal, bendFactor));
 
-    vec3 r = reflect(-v, bentNormal);
+    vec3 r = GetAdjustedReflectedDirection(pixel, v, bentNormal);
 #else
-    vec3 r = reflect(-v, n);
+    vec3 r = GetAdjustedReflectedDirection(pixel, v, n);
 #endif
     return r;
 }
@@ -167,7 +205,7 @@ vec3 getReflectedVector(const PixelParams pixel, const vec3 n) {
 #if defined(MATERIAL_HAS_ANISOTROPY)
     vec3 r = getReflectedVector(pixel, shading_view, n);
 #else
-    vec3 r = shading_reflected;
+    vec3 r = GetAdjustedReflectedDirection(pixel, shading_view, n);
 #endif
     return getSpecularDominantDirection(n, r, pixel.roughness);
 }
@@ -409,7 +447,8 @@ void evaluateSheenIBL(const MaterialInputs material, const PixelParams pixel, fl
     vec3 reflectance = pixel.sheenDFG * pixel.sheenColor;
     reflectance *= specularAO(shading_NoV, diffuseAO, pixel.sheenRoughness, cache);
 
-    Fr += material.specularIntensity * reflectance * prefilteredRadiance(shading_reflected, pixel.sheenPerceptualRoughness);
+    vec3 r = GetAdjustedReflectedDirection(pixel, shading_view, shading_normal);
+    Fr += material.specularIntensity * reflectance * prefilteredRadiance(r, pixel.sheenPerceptualRoughness);
 #endif
 #endif
 }
@@ -426,10 +465,10 @@ void evaluateClearCoatIBL(const MaterialInputs material, const PixelParams pixel
 #if defined(MATERIAL_HAS_NORMAL) || defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
     // We want to use the geometric normal for the clear coat layer
     float clearCoatNoV = clampNoV(dot(shading_clearCoatNormal, shading_view));
-    vec3 clearCoatR = reflect(-shading_view, shading_clearCoatNormal);
+    vec3 clearCoatR = GetAdjustedReflectedDirection(pixel, shading_view, shading_clearCoatNormal);
 #else
     float clearCoatNoV = shading_NoV;
-    vec3 clearCoatR = shading_reflected;
+    vec3 clearCoatR = GetAdjustedReflectedDirection(pixel, shading_view, shading_normal);
 #endif
     // The clear coat layer assumes an IOR of 1.5 (4% reflectance)
     float Fc = F_Schlick(0.04, 1.0, clearCoatNoV) * pixel.clearCoat;
@@ -439,6 +478,7 @@ void evaluateClearCoatIBL(const MaterialInputs material, const PixelParams pixel
 
     // TODO: Should we apply specularAO to the attenuation as well?
     float specularAO = specularAO(clearCoatNoV, diffuseAO, pixel.clearCoatRoughness, cache);
+    
     Fr += prefilteredRadiance(clearCoatR, pixel.clearCoatPerceptualRoughness) * (specularAO * Fc);
 #endif
 }
@@ -607,7 +647,9 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     vec3 Fr;
 #if IBL_INTEGRATION == IBL_INTEGRATION_PREFILTERED_CUBEMAP
     vec3 E = specularDFG(pixel);
-    vec3 r = getReflectedVector(pixel, shading_normal);
+    // we have to modify the IBL specular evaluation direction for anisotropic materials
+    vec3 r = getReflectedVector(pixel, shading_view, shading_normal);
+
     Fr = E * prefilteredRadiance(r, pixel.perceptualRoughness);
 #elif IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING
     vec3 E = vec3(0.0); // TODO: fix for importance sampling

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -2,6 +2,11 @@
 // Image based lighting configuration
 //------------------------------------------------------------------------------
 
+// IBL techniques
+#define IBL_TECHNIQUE_INFINITE      0u
+#define IBL_TECHNIQUE_FINITE_SPHERE 1u
+#define IBL_TECHNIQUE_FINITE_BOX    2u
+
 // Number of spherical harmonics bands (1, 2 or 3)
 #define SPHERICAL_HARMONICS_BANDS           3
 
@@ -16,6 +21,39 @@
 //------------------------------------------------------------------------------
 // IBL utilities
 //------------------------------------------------------------------------------
+
+void Swap(inout float a, inout float b)
+{
+    float tmp = a;
+    a = b;
+    b = tmp;
+}
+
+// Returns the two roots of Ax^2 + Bx + C = 0, assuming that A != 0
+// The returned roots (if finite) satisfy roots.x <= roots.y
+vec2 SolveQuadratic(float A, float B, float C)
+{
+    // From Numerical Recipes in C
+    float q = -0.5 * (B + sign(B) * sqrt(B * B - 4.0 * A * C));
+    vec2 roots = vec2(q / A, C / q);
+    if (roots.x > roots.y) Swap(roots.x, roots.y);
+    return roots;
+}
+
+vec2 IntersectAABB(vec3 rayOrigin, vec3 rayDir, vec3 boxMin, vec3 boxMax) {
+    vec3 tMin = (boxMin - rayOrigin) / rayDir;
+    vec3 tMax = (boxMax - rayOrigin) / rayDir;
+    vec3 t1 = min(tMin, tMax);
+    vec3 t2 = max(tMin, tMax);
+    float tNear = max3(t1);
+    float tFar = min3(t2);
+    return vec2(tNear, tFar);
+}
+
+// Assume: a <= b
+float GetSmallestPositive(float a, float b) {
+    return a >= 0.0 ? a : b;
+}
 
 vec3 decodeDataForIBL(const vec4 data) {
     return data.rgb;
@@ -208,6 +246,39 @@ vec3 getReflectedVector(const PixelParams pixel, const vec3 n) {
     vec3 r = GetAdjustedReflectedDirection(pixel, shading_view, n);
 #endif
     return getSpecularDominantDirection(n, r, pixel.roughness);
+}
+
+// This function returns an IBL lookup direction, taking into account the current IBL type (e.g. infinite spherical, finite/local sphere/box).
+vec3 GetAdjustedReflectedDirection(const MaterialInputs material, const PixelParams pixel, const vec3 normal) {
+    vec3 defaultReflected = getReflectedVector(pixel, normal);
+
+    if (frameUniforms.iblTechnique == IBL_TECHNIQUE_INFINITE) return defaultReflected;
+
+    // intersect the ray rayPos + t * rayDir with the finite geometry; done in the coordinate system of the finite geometry
+    vec3 rayPos = getWorldPosition() + getWorldOffset() - frameUniforms.iblCenter;
+    vec3 rayDir = defaultReflected;
+
+    vec3  r  = vec3(0.0); // resulting direction
+    float t0 = -1.0f;     // intersection parameter between ray and finite IBL geometry
+    
+    if (frameUniforms.iblTechnique == IBL_TECHNIQUE_FINITE_SPHERE) {
+        float R2 = frameUniforms.iblHalfExtents.r; // we store the squared radius to shave off a multiplication here
+        float A = 1.0; // in general, this should be dot(rayDir, rayDir) but we have just normalized it a couple of lines ago
+        float B = 2.0 * dot(rayPos, rayDir);
+        float C = dot(rayPos, rayPos) - R2;
+        vec2 roots = SolveQuadratic(A, B, C);
+        t0 = GetSmallestPositive(roots.x, roots.y);
+    }
+    else if (frameUniforms.iblTechnique == IBL_TECHNIQUE_FINITE_BOX) {
+        vec2 roots = IntersectAABB(rayPos, rayDir, -frameUniforms.iblHalfExtents, frameUniforms.iblHalfExtents);
+        t0 = GetSmallestPositive(roots.x, roots.y);
+    }
+
+    // translate results back to world space
+    vec3 intersection_point = ( t0 >= 0.0 ) ? rayPos + t0 * rayDir : defaultReflected;
+    r = normalize(intersection_point);
+
+    return r;
 }
 
 //------------------------------------------------------------------------------
@@ -465,11 +536,12 @@ void evaluateClearCoatIBL(const MaterialInputs material, const PixelParams pixel
 #if defined(MATERIAL_HAS_NORMAL) || defined(MATERIAL_HAS_CLEAR_COAT_NORMAL)
     // We want to use the geometric normal for the clear coat layer
     float clearCoatNoV = clampNoV(dot(shading_clearCoatNormal, shading_view));
-    vec3 clearCoatR = GetAdjustedReflectedDirection(pixel, shading_view, shading_clearCoatNormal);
+    vec3 clearCoatR = GetAdjustedReflectedDirection(material, pixel, shading_clearCoatNormal);
 #else
     float clearCoatNoV = shading_NoV;
     vec3 clearCoatR = GetAdjustedReflectedDirection(pixel, shading_view, shading_normal);
 #endif
+
     // The clear coat layer assumes an IOR of 1.5 (4% reflectance)
     float Fc = F_Schlick(0.04, 1.0, clearCoatNoV) * pixel.clearCoat;
     float attenuation = 1.0 - Fc;
@@ -647,8 +719,7 @@ void evaluateIBL(const MaterialInputs material, const PixelParams pixel, inout v
     vec3 Fr;
 #if IBL_INTEGRATION == IBL_INTEGRATION_PREFILTERED_CUBEMAP
     vec3 E = specularDFG(pixel);
-    // we have to modify the IBL specular evaluation direction for anisotropic materials
-    vec3 r = getReflectedVector(pixel, shading_view, shading_normal);
+    vec3 r = GetAdjustedReflectedDirection(material, pixel, shading_normal);
 
     Fr = E * prefilteredRadiance(r, pixel.perceptualRoughness);
 #elif IBL_INTEGRATION == IBL_INTEGRATION_IMPORTANCE_SAMPLING

--- a/shaders/src/main.vs
+++ b/shaders/src/main.vs
@@ -50,8 +50,8 @@ void main() {
             vertex_worldTangent.xyz = vec3(0.0, 0.0, -1.0);
         } else {
             float a = 1.0 / (1.0 + material.worldNormal.y);
-            float b = -material.worldNormal.x * material.worldNormal.z * a;
-            vertex_worldTangent.xyz = vec3(1.0 - material.worldNormal.x * material.worldNormal.x * a, b, -material.worldNormal.x);
+            float b = material.worldNormal.x * material.worldNormal.z * a;
+            vertex_worldTangent.xyz = vec3(1.0 - material.worldNormal.x * material.worldNormal.x * a, b, material.worldNormal.x);
         }
         #endif
 

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -210,7 +210,11 @@ void getAnisotropyPixelParams(const MaterialInputs material, inout PixelParams p
 #if defined(MATERIAL_HAS_ANISOTROPY)
     vec3 direction = material.anisotropyDirection;
     pixel.anisotropy = material.anisotropy;
+#if defined(IN_SHAPR_SHADER)
     pixel.anisotropicT = normalize(shading_tangentToWorld * direction);
+#else
+    pixel.anisotropicT = normalize(shading_tangentToWorld * direction.yxz);
+#endif
     pixel.anisotropicB = normalize(cross(getWorldGeometricNormalVector(), pixel.anisotropicT));
 #endif
 }

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -210,11 +210,7 @@ void getAnisotropyPixelParams(const MaterialInputs material, inout PixelParams p
 #if defined(MATERIAL_HAS_ANISOTROPY)
     vec3 direction = material.anisotropyDirection;
     pixel.anisotropy = material.anisotropy;
-#if defined(IN_SHAPR_SHADER)
     pixel.anisotropicT = normalize(shading_tangentToWorld * direction);
-#else
-    pixel.anisotropicT = normalize(shading_tangentToWorld * direction.yxz);
-#endif
     pixel.anisotropicB = normalize(cross(getWorldGeometricNormalVector(), pixel.anisotropicT));
 #endif
 }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-610](https://shapr3d.atlassian.net/browse/GFX-610)

## Short description (What? How?) 📖
This PR is the fixed version of https://github.com/shapr3d/filament/pull/44 . That had to be reverted, because anisotropic shading was applied incorrectly. We referred to these as Interstellar shading:
![image](https://user-images.githubusercontent.com/90197216/161725386-c660ac2f-adb8-4900-a540-1b102de58665.png)

This was fixed in two steps. First, none of the shading paths should use anisotropicity except for the direct IBL specular. This required a refactor, done in https://github.com/shapr3d/filament/commit/828f39066883c3db3e830d5c41348d5b5261b513 .

Second, a bug had to be fixed in the Frisvad tangent computation on the GltfViewer side in https://github.com/shapr3d/filament/commit/48c3207d0b645b464463df2b0e25041fbf5ba11b . This only affected the GltfViewer. 

## Testing

### Design review 🎨
n/a (and see previous PR)

### Affected areas 🧭
Visualization IBL reflections and GltfViewer

### Special use-cases to test 🧷
As previously

### How did you test it? 🤔
Manual 💁‍♂️
Manual, all the way. Metallic == 1 objects are the best to test these changes on in GltfViewer:
![image](https://user-images.githubusercontent.com/90197216/161726427-dbc89a52-bbb9-498f-ab9d-6e0527b2db0f.png)

Automated 💻
n/a