### PR TITLE
[KRN-77] Comply with cpp17 deprecations

### DIFF
--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -70,13 +70,19 @@ class UTILS_PUBLIC TransformManager : public FilamentAPI {
 public:
     using Instance = utils::EntityInstance<TransformManager>;
 
-    class children_iterator : std::iterator<std::forward_iterator_tag, Instance> {
+    class children_iterator {
         friend class FTransformManager;
         TransformManager const& mManager;
         Instance mInstance;
         children_iterator(TransformManager const& mgr, Instance instance) noexcept
                 : mManager(mgr), mInstance(instance) { }
     public:
+        using value_type = Instance;
+        using difference_type = ptrdiff_t;
+        using pointer = value_type*;
+        using reference = value_type&;
+        using iterator_category = std::forward_iterator_tag;
+
         children_iterator& operator++();
 
         children_iterator operator++(int) { // NOLINT


### PR DESCRIPTION
## Jira ticket URL (Why?)
[KRN-77](https://shapr3d.atlassian.net/browse/KRN-77)

## Short description (What? How?) 📖
This PR replaces `std::iterator<>` (deprecated in cpp17) with a different implementation, so we can eventually upgrade to Xcode 13.3

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
N/A

### Special use-cases to test 🧷
N/A

### How did you test it? 🤔
Manual 💁‍♂️
❌ 

Automated 💻
❌ 