### PR TITLE
[GFX-547] Set buffer sizes in root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB "10" CACHE STRING
     "Size of the OpenGL handle arena, default 4."
 )
 
-set(FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB "8" CACHE STRING
+set(FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB "96" CACHE STRING
     "Size of the Metal handle arena, default 8."
 )
 

--- a/filament/backend/src/HandleAllocator.cpp
+++ b/filament/backend/src/HandleAllocator.cpp
@@ -29,9 +29,9 @@ UTILS_NOINLINE
 HandleAllocator<P0, P1, P2>::Allocator::Allocator(AreaPolicy::HeapArea const& area)
         : mArea(area) {
     // TODO: we probably need a better way to set the size of these pools
-    const size_t unit = area.size() / 32;
-    const size_t offsetPool1 =      unit;
-    const size_t offsetPool2 = 16 * unit;
+    const size_t unit = area.size() / 256;
+    const size_t offsetPool1 = unit;
+    const size_t offsetPool2 = 2 * unit;
     char* const p = (char*)area.begin();
     mPool0 = PoolAllocator< P0, 16>(p, p + offsetPool1);
     mPool1 = PoolAllocator< P1, 16>(p + offsetPool1, p + offsetPool2);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-547](https://shapr3d.atlassian.net/browse/GFX-547)

## Short description (What? How?) 📖
We've investigated the implications of changing the buffer size parameters in the root CMakeLists.txt. You can read the findings [here](https://shapr3d.atlassian.net/wiki/spaces/DD/pages/2868347235/Filament+findings#Setting-buffer-sizes). 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Size of `HandleArena` in Filament.

### Special use-cases to test 🧷
* Load huge models.
* Check if you get any of these errors:
    * `CommandStream used too much space: `_`» total used memory amount here «`_` out of 51380224 (will block)`
    * `HandleAllocator arena is full, using slower system heap. Please increase the appropriate constant (e.g. FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB).`

### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
Manual 💁‍♂️
See Confluence doc for measurements.
Automated 💻
n/a