### PR TITLE
[GFX-1463] Fix Transparent Screenshot

### DIFF
--- a/filament/src/materials/separableGaussianBlur.mat
+++ b/filament/src/materials/separableGaussianBlur.mat
@@ -50,14 +50,20 @@ vertex {
 }
 
 fragment {
-    void tap(inout highp vec3 sum, const float weight, const highp vec2 position) {
-        vec3 s = textureLod(materialParams_source, position, materialParams.level).rgb;
+    
+    float max4(const vec4 f) {
+        vec2 t = max(f.xy, f.zw);
+        return max(t.x, t.y);
+    }
+    
+    void tap(inout highp vec4 sum, const float weight, const highp vec2 position) {
+        vec4 s = textureLod(materialParams_source, position, materialParams.level);
         sum += s * weight;
     }
 
-    void tapReinhard(inout highp vec3 sum, inout float totalWeight, const float weight, const highp vec2 position) {
-        vec3 s = textureLod(materialParams_source, position, materialParams.level).rgb;
-        float w = weight / (1.0 + max3(s));
+    void tapReinhard(inout highp vec4 sum, inout float totalWeight, const float weight, const highp vec2 position) {
+        vec4 s = textureLod(materialParams_source, position, materialParams.level);
+        float w = weight / (1.0 + max4(s));
         totalWeight += w;
         sum += s * w;
     }
@@ -66,7 +72,7 @@ fragment {
         highp vec2 uv = variable_vertex.xy;
 
         // we handle the center pixel separately
-        highp vec3 sum = vec3(0);
+        highp vec4 sum = vec4(0);
 
         if (materialParams.reinhard != 0) {
             float totalWeight = 0.0;
@@ -90,6 +96,6 @@ fragment {
             }
         }
 
-        postProcess.color.rgb = sum;
+        postProcess.color = sum;
     }
 }

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -691,6 +691,8 @@ void applyRefraction(
     Fr *= material.specularIntensity * frameUniforms.iblLuminance;
     Fd *= frameUniforms.iblLuminance;
     color += Fr + mix(Fd, Ft, pixel.transmission);
+
+    at += (1.0 - at) * (1.0 - luminance(pixel.diffuseColor.rgb));
     alpha *= mix(1.0, at, pixel.transmission);
 }
 #endif

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -672,8 +672,8 @@ void applyRefraction(
     float lod = max(0.0, 2.0 * log2(tweakedPerceptualRoughness) + frameUniforms.refractionLodOffset);
 
     vec4 Fat = textureLod(light_ssr, p.xy, lod);
-    vec3 Ft = Fat.rgb;
     float at = Fat.a;
+    vec3 Ft = mix(Fat.rgb, vec3(1.0), at);
 #endif
 
     // base color changes the amount of light passing through the boundary

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -673,7 +673,11 @@ void applyRefraction(
 
     vec4 Fat = textureLod(light_ssr, p.xy, lod);
     float at = Fat.a;
+#if defined(BLEND_MODE_OPAQUE)
+    vec3 Ft = Fat.rgb;
+#else
     vec3 Ft = mix(Fat.rgb, vec3(1.0), at);
+#endif
 #endif
 
     // base color changes the amount of light passing through the boundary

--- a/shaders/src/light_indirect.fs
+++ b/shaders/src/light_indirect.fs
@@ -18,6 +18,10 @@
 
 #define IBL_INTEGRATION_IMPORTANCE_SAMPLING_COUNT   64
 
+#if ((defined(MATERIAL_HAS_TRANSMISSION) && defined(HAS_REFRACTION)) || !defined(BLEND_MODE_OPAQUE))
+#define IS_TRANSPARENT_OR_REFRACTIVE
+#endif
+
 //------------------------------------------------------------------------------
 // IBL utilities
 //------------------------------------------------------------------------------
@@ -673,11 +677,12 @@ void applyRefraction(
 
     vec4 Fat = textureLod(light_ssr, p.xy, lod);
     float at = Fat.a;
-#if defined(BLEND_MODE_OPAQUE)
-    vec3 Ft = Fat.rgb;
+#if defined(IS_TRANSPARENT_OR_REFRACTIVE)
+    vec3 Ft = mix(vec3(1.0), Fat.rgb, at);
 #else
-    vec3 Ft = mix(Fat.rgb, vec3(1.0), at);
+    vec3 Ft = Fat.rgb;
 #endif
+
 #endif
 
     // base color changes the amount of light passing through the boundary


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1463](https://shapr3d.atlassian.net/browse/GFX-1463)

## Short description (What? How?) 📖
Bug ticket was created, that screenshot in transparent environment is broken in case of PP material. The first issue was that `separableGaussianBlur` was outputting a `vec3`, so it had no alpha channel, resulting invalid values. It was easily fixed by modifying it to output a `vec4` instead.

However, since we're clearing the background to `vec4(0,0,0,0)`, this resulted in the following behavior:

<img width="689" alt="Screen Shot 2022-04-29 at 13 51 35" src="https://user-images.githubusercontent.com/6261494/165939540-0ab0d860-7709-40d7-9d28-cd4b97397b6e.png">

While this is how the same scene looks like in case of a white solid background:

<img width="689" alt="Screen Shot 2022-04-29 at 13 51 35" src="https://user-images.githubusercontent.com/6261494/165939700-9bff5060-a794-4ea3-84fd-73f6965bcb83.PNG">

The value is computed as follows: we render the opaque objects first. Then in `applyRefraction`, we read the color of the pixel into `Ft`, and the alpha to `at`, then the modulate their value using physics. The final `Ft` and `at` contributes to the final `color` and `alpha` like this:
```
color += Fr + mix(Fd, Ft, pixel.transmission);
alpha *= mix(1.0, at, pixel.transmission);
```
In the transparent background case, when the pixel falls onto the background cleared to `(0,0,0,0)`, the modification of `Ft` and `at` has a very subtle effect, so their values end up close to `0`. If `pixel.transmission` is `1.0` - like in case of PP material - we're zeroing out the first operand in both `mix` functions, hence ending up with `color` and `alpha` values being zero.

We can adjust alpha values in a reasonable manner, using the following heuristics:
* full white base color means that the object is fully transmissive;
* pitch black means it's fully opaque,
* and we need to interpolate between these two cases. 

So we came up with the following equation:
```
at += (1.0 - at) * (1.0 - luminance(pixel.diffuseColor.rgb));
```

Here are some examples of the result: 
![tweaked_alpha](https://user-images.githubusercontent.com/6261494/165944179-b8855c54-51bb-4d25-a574-5ed6207bd520.jpg)
![New Project-4](https://user-images.githubusercontent.com/6261494/165944338-9f060fa2-5f55-4e4f-98de-62d44d989cc6.jpg)
The base color from left to right: `0,0,0`, `0.5,0,0`, `1,0,0`, `1,0.5,0.5` `1,1,1`.

While this is already an improvement, the saturation of the parts that are in front of the background are gone, as we didn't do anything with `Ft`. [In this document](https://shapr3d.atlassian.net/wiki/spaces/~384802122/pages/3046179389/Saturation+of+transparent+objects+in+front+of+transparent+background), I proposed a hack that was dismissed, as it brightened the parts as well where there was no background.

**Solution for the lack of saturation**
The problem appears because we're trying to blend the object with a black background. We would need to set the background artificially to white to make this work. To do that, we're exposing the fact, that the alpha value is `0` at the background, and `1` on the object. So instead of setting `Ft` to the value read from the background:
```
#if defined(BLEND_MODE_OPAQUE)
    vec3 Ft = Fat.rgb;
```
we're doing this:
```
#else
    vec3 Ft = mix(Fat.rgb, vec3(1.0), at);
#endif
```
This yields the background color, `Fat.rgb` if `at == 1`, and `vec3(1.0)` if `at == 0`, which is the case with the `0,0,0,0` background. We interpolate between these two values with the `mix` function.

This results in some artifact in case of light colors, but as it was evaluated by many team members, this is the best we can do with this problem as of now.

## Testing
### Affected areas 🧭
Transparent screenshot of transparent materials.