### PR TITLE
[GFX-1109] External stencil buffering

### DIFF
--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -79,7 +79,10 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
 
     // Depth attachment
     descriptor.depthAttachmentPixelFormat = state.depthAttachmentPixelFormat;
-
+    const auto hasStencil = (MTLPixelFormatDepth32Float_Stencil8 == state.depthAttachmentPixelFormat) || (MTLPixelFormatDepth24Unorm_Stencil8 == state.depthAttachmentPixelFormat);
+    if (hasStencil) {
+        descriptor.stencilAttachmentPixelFormat = state.depthAttachmentPixelFormat;
+    }
     // MSAA
     descriptor.rasterSampleCount = state.sampleCount;
 

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -144,6 +144,54 @@ public:
      * @see setRenderTarget
      */
     RenderTarget* getRenderTarget() const noexcept;
+    
+    /**
+     * Specifies an offscreen render target's LDR color output texture to render into.
+     *
+     * @param texture LDR color texture
+     */
+    void setLDRColorTexture(Texture* texture) noexcept;
+
+    /**
+     * Gets the offscreen render target's LDR color output texture.
+     *
+     * Returns nullptr if the render target is the swap chain (which is default).
+     *
+     * @see setLDRColorTexture
+     */
+    Texture* getLDRColorTexture() const noexcept;
+
+    /**
+     * Specifies an offscreen render target's HDR color output texture to render into.
+     *
+     * @param texture HDR color texture
+     */
+    void setHDRColorTexture(Texture* texture) noexcept;
+    
+    /**
+     * Gets the offscreen render target's HDR color output texture.
+     *
+     * Returns nullptr if the render target is the swap chain (which is default).
+     *
+     * @see setHDRColorTexture
+     */
+    Texture* getHDRColorTexture() const noexcept;
+
+    /**
+     * Specifies an offscreen render target's depth-stencil texture to render into.
+     *
+     * @param texture depth-stencil texture
+     */
+    void setDepthStencilTexture(Texture* texture) noexcept;
+    
+    /**
+     * Gets the offscreen render target's depth-stencil texture.
+     *
+     * Returns nullptr if the render target is the swap chain (which is default).
+     *
+     * @see setDepthStencilTexture
+     */
+    Texture* getDepthStencilTexture() const noexcept;
 
     /**
      * Sets the rectangular region to render to.

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -676,7 +676,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
      }
     fg.compile();
 
-    fg.export_graphviz(slog.d, view.getName());
+    // fg.export_graphviz(slog.d, view.getName());
 
     fg.execute(driver);
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -86,7 +86,7 @@ void FView::terminate(FEngine& engine) {
         pQuery->callback(pQuery->result, pQuery);
         FPickingQuery::put(pQuery);
     }
-
+    engine.destroy(mRenderTarget);
     mPerViewUniforms.terminate(engine);
 
     DriverApi& driver = engine.getDriverApi();
@@ -334,6 +334,25 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
         filament::Viewport const& viewport, float4 const& userTime) noexcept {
     JobSystem& js = engine.getJobSystem();
+
+    engine.destroy(mRenderTarget);
+    mRenderTarget = nullptr;
+
+    if (mLDRTexture || mHDRTexture || mDepthStencilTexture) {
+
+        RenderTarget::Builder builder;
+        if (mLDRTexture) {
+            builder.texture(RenderTarget::AttachmentPoint::COLOR0, mLDRTexture);
+        }
+        if (mHDRTexture) {
+            builder.texture(RenderTarget::AttachmentPoint::COLOR1, mHDRTexture);
+        }
+        if (mDepthStencilTexture) {
+            builder.texture(RenderTarget::AttachmentPoint::DEPTH , mDepthStencilTexture);
+        }
+        mRenderTarget = upcast(builder.build(engine));
+    }
+
 
     /*
      * Prepare the scene -- this is where we gather all the objects added to the scene,
@@ -891,6 +910,30 @@ void View::setRenderTarget(RenderTarget* renderTarget) noexcept {
 
 RenderTarget* View::getRenderTarget() const noexcept {
     return upcast(this)->getRenderTarget();
+}
+
+void View::setLDRColorTexture(Texture* texture) noexcept {
+    return upcast(this)->setLDRColorTexture(upcast(texture));
+}
+
+Texture* View::getLDRColorTexture() const noexcept {
+    return upcast(this)->getLDRColorTexture();
+}
+
+void View::setHDRColorTexture(Texture* texture) noexcept {
+    return upcast(this)->setHDRColorTexture(upcast(texture));
+}
+
+Texture* View::getHDRColorTexture() const noexcept {
+    return upcast(this)->getHDRColorTexture();
+}
+
+void View::setDepthStencilTexture(Texture* texture) noexcept {
+    return upcast(this)->setDepthStencilTexture(upcast(texture));
+}
+
+Texture* View::getDepthStencilTexture() const noexcept {
+    return upcast(this)->getDepthStencilTexture();
 }
 
 void View::setSampleCount(uint8_t count) noexcept {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -143,6 +143,7 @@ private:
         Viewport vp;
         Viewport svp;
         math::float2 scale;
+        Texture::InternalFormat depthFormat;
         backend::TextureFormat hdrFormat;
         uint8_t msaa;
         backend::TargetBufferFlags clearFlags;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -208,6 +208,30 @@ public:
     void setRenderTarget(FRenderTarget* renderTarget) noexcept {
         mRenderTarget = renderTarget;
     }
+    
+    void setLDRColorTexture(FTexture* texture) noexcept {
+        mLDRTexture = texture;
+    }
+
+    FTexture* getLDRColorTexture() const noexcept {
+        return mLDRTexture;
+    }
+
+    void setHDRColorTexture(FTexture* texture) noexcept {
+        mHDRTexture = texture;
+    }
+
+    FTexture* getHDRColorTexture() const noexcept {
+        return mHDRTexture;
+    }
+
+    void setDepthStencilTexture(FTexture* texture) noexcept {
+        mDepthStencilTexture = texture;
+    }
+
+    FTexture* getDepthStencilTexture() const noexcept {
+        return mDepthStencilTexture;
+    }
 
     FRenderTarget* getRenderTarget() const noexcept {
         return mRenderTarget;
@@ -521,6 +545,9 @@ private:
     bool mFrontFaceWindingInverted = false;
 
     FRenderTarget* mRenderTarget = nullptr;
+    FTexture* mLDRTexture = nullptr;
+    FTexture* mHDRTexture = nullptr;
+    FTexture* mDepthStencilTexture = nullptr;
 
     uint8_t mVisibleLayers = 0x1;
     uint8_t mSampleCount = 1;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1109](https://shapr3d.atlassian.net/browse/GFX-1109)

## Short description (What? How?) 📖
Metal backend was extended to handle properly stencil attachments in case of packed depth-stencil texture formats (OpenGL and Vulkan backend already supported separate and packed depth and stencil attachments).

The custom rendertarget attachments was split up to individual textures (based on the upstream google commits filament moves in this direction too), because the current framegraph implementation can't handle different textures coming from different passes. The View's API changed according to this. With these changes it's possible now to acquire the depth-stencil, LDR color, HDR color textures: 

<img width="1262" alt="Screenshot 2022-05-02 at 10 22 15" src="https://user-images.githubusercontent.com/100697016/166205679-ac3c5389-6af5-47cb-af09-d1a1aef6a34d.png">

## Testing

### Design review 🎨
n/a 

### Affected areas 🧭
Filament's frame graph building, metal backend

### Special use-cases to test 🧷
Multisampling, post processing

### How did you test it? 🤔
Manual 💁‍♂️
I experimented with the `rendertarget` sample-project.

Automated 💻
n/a