### PR TITLE
[GFX-999] Filament stencil operations

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -835,7 +835,7 @@ struct RasterState {
     }
 
     bool operator == (RasterState rhs) const noexcept { 
-        return std::memcmp(u, rhs.u, sizeof(u));
+        return std::memcmp(u, rhs.u, sizeof(u)) == 0;
     }
 
     bool operator != (RasterState rhs) const noexcept { 

--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -29,6 +29,7 @@
 #include <math/vec4.h>
 
 #include <array>    // FIXME: STL headers are not allowed in public headers
+#include <cstring>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -300,11 +301,11 @@ enum class CullingMode : uint8_t {
 
 //! Stencil depth fail and pass operation mode.
 enum class StencilOperation : uint8_t {
-    ZERO,
     KEEP,
+    ZERO,
     INVERT,
     REPLACE,
-    DEFAULT = ZERO
+    DEFAULT = KEEP
 };
 
 //! Pixel Data Format
@@ -834,9 +835,7 @@ struct RasterState {
     }
 
     bool operator == (RasterState rhs) const noexcept { 
-        bool eq = true;
-        for (uint8_t i = 0; i < 5; ++i) eq = eq && (u[i] == rhs.u[i]);
-        return eq;
+        return std::memcmp(u, rhs.u, sizeof(u));
     }
 
     bool operator != (RasterState rhs) const noexcept { 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1261,6 +1261,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
                 mContext->depthStencilStateCache.getOrCreateState(depthState);
         assert_invariant(state != nil);
         [mContext->currentRenderPassEncoder setDepthStencilState:state];
+        [mContext->currentRenderPassEncoder setStencilReferenceValue:1];
     }
 
     if (ps.polygonOffset.constant != 0.0 || ps.polygonOffset.slope != 0.0) {
@@ -1378,7 +1379,6 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     id<MTLCommandBuffer> cmdBuffer = getPendingCommandBuffer(mContext);
     id<MTLBuffer> metalIndexBuffer = indexBuffer->buffer.getGpuBufferForDraw(cmdBuffer);
     size_t offset = indexBuffer->buffer.getGpuBufferStreamOffset();
-    [mContext->currentRenderPassEncoder setStencilReferenceValue:1];
     [mContext->currentRenderPassEncoder drawIndexedPrimitives:getMetalPrimitiveType(primitive->type)
                                                    indexCount:primitive->count
                                                     indexType:getIndexType(indexBuffer->elementSize)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1250,7 +1250,10 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     // Set the depth-stencil state, if a state change is needed.
     DepthStencilState depthState {
         .compareFunction = getMetalCompareFunction(rs.depthFunc),
+        .stencilDepthFail = getMetalStencilOperation(rs.stencilDepthFail),
+        .stencilDepthPass = getMetalStencilOperation(rs.stencilDepthPass),
         .depthWriteEnabled = rs.depthWrite,
+        .stencilWriteEnabled = rs.stencilWrite,
     };
     mContext->depthStencilState.updateState(depthState);
     if (mContext->depthStencilState.stateChanged()) {
@@ -1375,6 +1378,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     id<MTLCommandBuffer> cmdBuffer = getPendingCommandBuffer(mContext);
     id<MTLBuffer> metalIndexBuffer = indexBuffer->buffer.getGpuBufferForDraw(cmdBuffer);
     size_t offset = indexBuffer->buffer.getGpuBufferStreamOffset();
+    [mContext->currentRenderPassEncoder setStencilReferenceValue:1];
     [mContext->currentRenderPassEncoder drawIndexedPrimitives:getMetalPrimitiveType(primitive->type)
                                                    indexCount:primitive->count
                                                     indexType:getIndexType(indexBuffer->elementSize)

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -53,6 +53,17 @@ constexpr inline MTLCompareFunction getMetalCompareFunction(RasterState::DepthFu
     }
 }
 
+constexpr inline MTLStencilOperation getMetalStencilOperation(RasterState::StencilOperation operation)
+        noexcept {
+    using StencilOperation = RasterState::StencilOperation;
+    switch (operation) {
+        case StencilOperation::ZERO:    return MTLStencilOperationZero;
+        case StencilOperation::KEEP:    return MTLStencilOperationKeep;
+        case StencilOperation::REPLACE: return MTLStencilOperationReplace;
+        case StencilOperation::INVERT:  return MTLStencilOperationInvert;
+    }
+}
+
 constexpr inline MTLIndexType getIndexType(size_t elementSize) noexcept {
     if (elementSize == 2) {
         return MTLIndexTypeUInt16;

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -57,8 +57,8 @@ constexpr inline MTLStencilOperation getMetalStencilOperation(RasterState::Stenc
         noexcept {
     using StencilOperation = RasterState::StencilOperation;
     switch (operation) {
-        case StencilOperation::ZERO:    return MTLStencilOperationZero;
         case StencilOperation::KEEP:    return MTLStencilOperationKeep;
+        case StencilOperation::ZERO:    return MTLStencilOperationZero;
         case StencilOperation::REPLACE: return MTLStencilOperationReplace;
         case StencilOperation::INVERT:  return MTLStencilOperationInvert;
     }

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -261,7 +261,7 @@ using PipelineStateCache = StateCache<PipelineState, id<MTLRenderPipelineState>,
 struct DepthStencilState {
     MTLCompareFunction compareFunction = MTLCompareFunctionNever;       // 8 bytes
     MTLStencilOperation stencilDepthFail = MTLStencilOperationKeep;     // 8 bytes
-    MTLStencilOperation stencilDepthPass = MTLStencilOperationReplace;  // 8 bytes
+    MTLStencilOperation stencilDepthPass = MTLStencilOperationKeep;     // 8 bytes
     bool depthWriteEnabled = false;                                     // 1 byte
     bool stencilWriteEnabled = false;                                   // 1 byte
     char padding[6] = { 0 };                                            // 6 bytes

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -260,12 +260,18 @@ using PipelineStateCache = StateCache<PipelineState, id<MTLRenderPipelineState>,
 
 struct DepthStencilState {
     MTLCompareFunction compareFunction = MTLCompareFunctionNever;       // 8 bytes
+    MTLStencilOperation stencilDepthFail = MTLStencilOperationKeep;     // 8 bytes
+    MTLStencilOperation stencilDepthPass = MTLStencilOperationReplace;  // 8 bytes
     bool depthWriteEnabled = false;                                     // 1 byte
-    char padding[7] = { 0 };                                            // 7 bytes
+    bool stencilWriteEnabled = false;                                   // 1 byte
+    char padding[6] = { 0 };                                            // 6 bytes
 
     bool operator==(const DepthStencilState& rhs) const noexcept {
         return this->compareFunction == rhs.compareFunction &&
-               this->depthWriteEnabled == rhs.depthWriteEnabled;
+               this->depthWriteEnabled == rhs.depthWriteEnabled &&
+               this->stencilWriteEnabled == rhs.stencilWriteEnabled && 
+               this->stencilDepthFail == rhs.stencilDepthFail && 
+               this->stencilDepthPass == rhs.stencilDepthPass;
     }
 
     bool operator!=(const DepthStencilState& rhs) const noexcept {
@@ -275,7 +281,7 @@ struct DepthStencilState {
 
 // This assert checks that the struct is the size we expect without any "hidden" padding bytes
 // inserted by the compiler.
-static_assert(sizeof(DepthStencilState) == 16, "DepthStencilState unexpected size.");
+static_assert(sizeof(DepthStencilState) == 32, "DepthStencilState unexpected size.");
 
 struct DepthStateCreator {
     id<MTLDepthStencilState> operator()(id<MTLDevice> device, const DepthStencilState& state)

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -100,6 +100,21 @@ id<MTLDepthStencilState> DepthStateCreator::operator()(id<MTLDevice> device,
     MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
     depthStencilDescriptor.depthCompareFunction = state.compareFunction;
     depthStencilDescriptor.depthWriteEnabled = state.depthWriteEnabled;
+    
+    if (state.stencilWriteEnabled) {
+        MTLStencilDescriptor* stencilDescriptor = [MTLStencilDescriptor new];
+        stencilDescriptor.readMask = 0xFF;
+        stencilDescriptor.writeMask = 0xFF;
+        stencilDescriptor.stencilCompareFunction = MTLCompareFunctionAlways;
+        stencilDescriptor.stencilFailureOperation = MTLStencilOperationKeep;
+        stencilDescriptor.depthFailureOperation = state.stencilDepthFail;
+        stencilDescriptor.depthStencilPassOperation = state.stencilDepthPass;
+        
+        depthStencilDescriptor.backFaceStencil = stencilDescriptor;
+        depthStencilDescriptor.frontFaceStencil = stencilDescriptor;
+    
+    }
+    
     return [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
 }
 

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -251,6 +251,16 @@ constexpr inline GLenum getTextureCompareFunc(backend::SamplerCompareFunc func) 
     }
 }
 
+constexpr inline GLenum getStencilOperation(backend::RasterState::StencilOperation operation) noexcept {
+    using StencilOperation = backend::RasterState::StencilOperation;
+    switch (operation) {
+        case StencilOperation::ZERO:    return GL_ZERO;
+        case StencilOperation::KEEP:    return GL_KEEP;
+        case StencilOperation::INVERT:  return GL_INVERT;
+        case StencilOperation::REPLACE: return GL_REPLACE;
+    }
+}
+
 constexpr inline GLenum getDepthFunc(backend::SamplerCompareFunc func) noexcept {
     return getTextureCompareFunc(func);
 }

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -254,8 +254,8 @@ constexpr inline GLenum getTextureCompareFunc(backend::SamplerCompareFunc func) 
 constexpr inline GLenum getStencilOperation(backend::RasterState::StencilOperation operation) noexcept {
     using StencilOperation = backend::RasterState::StencilOperation;
     switch (operation) {
-        case StencilOperation::ZERO:    return GL_ZERO;
         case StencilOperation::KEEP:    return GL_KEEP;
+        case StencilOperation::ZERO:    return GL_ZERO;
         case StencilOperation::INVERT:  return GL_INVERT;
         case StencilOperation::REPLACE: return GL_REPLACE;
     }

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -240,7 +240,7 @@ private:
             GLenum stencilFunc          = GL_ALWAYS;
             GLenum stencilFail          = GL_KEEP;
             GLenum stencilDepthFail     = GL_KEEP;
-            GLenum stencilDepthPass     = GL_REPLACE;
+            GLenum stencilDepthPass     = GL_KEEP;
             GLuint stencilRef           = 0;
             GLuint stencilWriteMask     = 0xFF;
             GLuint stencilReadMask     = 0xFF;

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -105,6 +105,10 @@ public:
     inline void endQuery(GLenum target) noexcept;
     inline GLuint getQuery(GLenum target) noexcept;
 
+    inline void stencilMask(GLuint mask) noexcept;
+    inline void stencilFunc(GLenum func, GLuint ref, GLuint mask) noexcept;
+    inline void stencilOp(GLenum stencilFail, GLenum depthFail, GLenum depthPass) noexcept;
+
     inline void setScissor(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
     inline void viewport(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
     inline void depthRange(GLclampf near, GLclampf far) noexcept;
@@ -233,6 +237,13 @@ private:
             GLboolean colorMask         = GL_TRUE;
             GLboolean depthMask         = GL_TRUE;
             GLenum depthFunc            = GL_LESS;
+            GLenum stencilFunc          = GL_ALWAYS;
+            GLenum stencilFail          = GL_KEEP;
+            GLenum stencilDepthFail     = GL_KEEP;
+            GLenum stencilDepthPass     = GL_REPLACE;
+            GLuint stencilRef           = 0;
+            GLuint stencilWriteMask     = 0xFF;
+            GLuint stencilReadMask     = 0xFF;
         } raster;
 
         struct PolygonOffset {
@@ -572,6 +583,39 @@ void OpenGLContext::depthFunc(GLenum func) noexcept {
     update_state(state.raster.depthFunc, func, [&]() {
         glDepthFunc(func);
     });
+}
+
+void OpenGLContext::stencilMask(GLuint mask) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    update_state(state.raster.stencilWriteMask, mask, [&]() {
+        glStencilMask(mask);
+    });
+}
+
+void OpenGLContext::stencilFunc(GLenum func, GLuint ref, GLuint mask) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    if (UTILS_UNLIKELY(
+            state.raster.stencilFunc != func ||
+            state.raster.stencilRef != ref ||
+            state.raster.stencilReadMask != mask)) {
+        state.raster.stencilFunc = func;
+        state.raster.stencilRef = ref;
+        state.raster.stencilReadMask = mask;
+        glStencilFunc(func, ref, mask);
+    }
+}
+
+void OpenGLContext::stencilOp(GLenum stencilFail, GLenum depthFail, GLenum depthPass) noexcept {
+    // WARNING: don't call this without updating mRasterState
+    if (UTILS_UNLIKELY(
+            state.raster.stencilFail != stencilFail ||
+            state.raster.stencilDepthFail != depthFail ||
+            state.raster.stencilDepthPass != depthPass)) {
+        state.raster.stencilFail = stencilFail;
+        state.raster.stencilDepthFail = depthFail;
+        state.raster.stencilDepthPass = depthPass;
+        glStencilOp(stencilFail, depthFail, depthPass);
+    }
 }
 
 void OpenGLContext::polygonOffset(GLfloat factor, GLfloat units) noexcept {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -311,6 +311,19 @@ void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
         gl.depthMask(GLboolean(rs.depthWrite));
     }
 
+    if (!rs.stencilWrite) {
+        gl.disable(GL_STENCIL_TEST);
+    } else {
+        gl.enable(GL_STENCIL_TEST);
+        gl.stencilMask(0xFF);
+        gl.stencilFunc(GL_ALWAYS, 1, 0xFF);
+        gl.stencilOp(
+            GL_KEEP, 
+            getStencilOperation(rs.stencilDepthFail), 
+            getStencilOperation(rs.stencilDepthPass)
+        );
+    }
+
     // write masks
     gl.colorMask(GLboolean(rs.colorWrite));
 

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -53,7 +53,7 @@ public:
     using Interpolation = Interpolation;
     using VertexDomain = VertexDomain;
     using TransparencyMode = TransparencyMode;
-    
+
     using StencilOperation = backend::StencilOperation;
     using ParameterType = backend::UniformType;
     using Precision = backend::Precision;

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -169,7 +169,7 @@ public:
     //! Indicates whether instances of this material will, by default, use depth testing.
     bool isDepthCullingEnabled() const noexcept;
 
-    //! Indicates whether instances of this material will, write to the stencil buffer
+    //! Indicates whether instances of this material will write to the stencil buffer
     bool isStencilWriteEnabled() const noexcept;
 
     /** 

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -53,7 +53,8 @@ public:
     using Interpolation = Interpolation;
     using VertexDomain = VertexDomain;
     using TransparencyMode = TransparencyMode;
-
+    
+    using StencilOperation = backend::StencilOperation;
     using ParameterType = backend::UniformType;
     using Precision = backend::Precision;
     using SamplerType = backend::SamplerType;
@@ -167,6 +168,21 @@ public:
 
     //! Indicates whether instances of this material will, by default, use depth testing.
     bool isDepthCullingEnabled() const noexcept;
+
+    //! Indicates whether instances of this material will, write to the stencil buffer
+    bool isStencilWriteEnabled() const noexcept;
+
+    /** 
+     * Indicates whether instances of this material will, keep/replace/zero/invert 
+     * the contents of the stencil buffer if the depth test fails.
+     */
+    StencilOperation getStencilDepthFail() const noexcept;
+
+    /** 
+     * Indicates whether instances of this material will, keep/replace/zero/invert 
+     * the contents of the stencil buffer if the depth test passes.
+     */
+    StencilOperation getStencilDepthPass() const noexcept;
 
     //! Indicates whether this material is double-sided.
     bool isDoubleSided() const noexcept;

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -173,13 +173,13 @@ public:
     bool isStencilWriteEnabled() const noexcept;
 
     /** 
-     * Indicates whether instances of this material will, keep/replace/zero/invert 
+     * Indicates whether instances of this material will keep/replace/zero/invert 
      * the contents of the stencil buffer if the depth test fails.
      */
     StencilOperation getStencilDepthFail() const noexcept;
 
     /** 
-     * Indicates whether instances of this material will, keep/replace/zero/invert 
+     * Indicates whether instances of this material will keep/replace/zero/invert 
      * the contents of the stencil buffer if the depth test passes.
      */
     StencilOperation getStencilDepthPass() const noexcept;

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -40,6 +40,7 @@ class UTILS_PUBLIC MaterialInstance : public FilamentAPI {
 public:
     using CullingMode = filament::backend::CullingMode;
     using TransparencyMode = filament::TransparencyMode;
+    using StencilOperation = filament::backend::StencilOperation;
 
     template<typename T>
     using is_supported_parameter_t = typename std::enable_if<
@@ -224,6 +225,22 @@ public:
      * Overrides the default depth testing state that was set on the material.
      */
     void setDepthCulling(bool enable) noexcept;
+
+    /**
+     * Overrides the default stencil state that was set on the material.
+     */
+    void setStencilWrite(bool enable) noexcept;
+
+    /**
+     * Overrides the default depth fail stencil operation that was set on the material.
+     */
+    void setStencilDepthFail(StencilOperation operation) noexcept;
+
+    /**
+     * Overrides the default depth pass stencil operation that was set on the material.
+     */
+    void setStencilDepthPass(StencilOperation operation) noexcept;
+
 };
 
 } // namespace filament

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -190,6 +190,18 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
     parser->getRefractionMode(&mRefractionMode);
     parser->getRefractionType(&mRefractionType);
 
+    bool stencilWrite;
+    StencilOperation stencilDepthFail;
+    StencilOperation stencilDepthPass;
+
+    parser->getStencilWrite(&stencilWrite);
+    parser->getStencilDepthFail(&stencilDepthFail);
+    parser->getStencilDepthPass(&stencilDepthPass);
+
+    mRasterState.stencilWrite = stencilWrite;
+    mRasterState.stencilDepthFail = stencilDepthFail;
+    mRasterState.stencilDepthPass = stencilDepthPass;
+
     if (mBlendingMode == BlendingMode::MASKED) {
         parser->getMaskThreshold(&mMaskThreshold);
     }
@@ -603,6 +615,18 @@ bool Material::isDepthWriteEnabled() const noexcept {
 
 bool Material::isDepthCullingEnabled() const noexcept {
     return upcast(this)->isDepthCullingEnabled();
+}
+
+bool Material::isStencilWriteEnabled() const noexcept {
+    return upcast(this)->isStencilWriteEnabled();
+}
+
+StencilOperation Material::getStencilDepthFail() const noexcept {
+    return upcast(this)->getStencilDepthFail();
+}
+
+StencilOperation Material::getStencilDepthPass() const noexcept {
+    return upcast(this)->getStencilDepthPass();
 }
 
 bool Material::isDoubleSided() const noexcept {

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -184,6 +184,9 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
           mCulling(other->mCulling),
           mColorWrite(other->mColorWrite),
           mDepthWrite(other->mDepthWrite),
+          mStencilWrite(other->mStencilWrite),
+          mStencilDepthFail(other->mStencilDepthFail),
+          mStencilDepthPass(other->mStencilDepthPass),
           mDepthFunc(other->mDepthFunc),
           mScissorRect(other->mScissorRect),
           mName(name ? CString(name) : other->mName) {
@@ -239,6 +242,10 @@ void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* ma
     mColorWrite = rasterState.colorWrite;
     mDepthWrite = rasterState.depthWrite;
     mDepthFunc = rasterState.depthFunc;
+
+    mStencilWrite = rasterState.stencilWrite;
+    mStencilDepthFail = rasterState.stencilDepthFail;
+    mStencilDepthPass = rasterState.stencilDepthPass;
 
     mMaterialSortingKey = RenderPass::makeMaterialSortingKey(
             material->getId(), material->generateMaterialInstanceId());
@@ -419,6 +426,18 @@ void MaterialInstance::setDepthWrite(bool enable) noexcept {
 
 void MaterialInstance::setDepthCulling(bool enable) noexcept {
     upcast(this)->setDepthCulling(enable);
+}
+
+void MaterialInstance::setStencilWrite(bool enable) noexcept {
+    upcast(this)->setStencilWrite(enable);
+}
+
+void MaterialInstance::setStencilDepthFail(StencilOperation operation) noexcept {
+    upcast(this)->setStencilDepthFail(operation);
+}
+
+void MaterialInstance::setStencilDepthPass(StencilOperation operation) noexcept {
+    upcast(this)->setStencilDepthPass(operation);
 }
 
 MaterialInstance* MaterialInstance::duplicate(MaterialInstance const* other, const char* name) noexcept {

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -164,6 +164,22 @@ bool MaterialParser::getDepthWrite(bool* value) const noexcept {
     return mImpl.getFromSimpleChunk(ChunkType::MaterialDepthWrite, value);
 }
 
+bool MaterialParser::getStencilWrite(bool* value) const noexcept {
+    return mImpl.getFromSimpleChunk(ChunkType::MaterialStencilWrite, value);
+}
+
+bool MaterialParser::getStencilDepthFail(backend::StencilOperation* value) const noexcept {
+    static_assert(sizeof(backend::StencilOperation) == sizeof(uint8_t),
+            "StencilOperation expected size is wrong");
+    return mImpl.getFromSimpleChunk(ChunkType::MaterialStencilDepthFail, reinterpret_cast<uint8_t*>(value));
+}
+
+bool MaterialParser::getStencilDepthPass(backend::StencilOperation* value) const noexcept {
+    static_assert(sizeof(backend::StencilOperation) == sizeof(uint8_t),
+            "StencilOperation expected size is wrong");
+    return mImpl.getFromSimpleChunk(ChunkType::MaterialStencilDepthPass, reinterpret_cast<uint8_t*>(value));
+}
+
 bool MaterialParser::getDoubleSidedSet(bool* value) const noexcept {
     return mImpl.getFromSimpleChunk(ChunkType::MaterialDoubleSidedSet, value);
 }

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -77,6 +77,9 @@ public:
     bool getInterpolation(Interpolation* value) const noexcept;
     bool getVertexDomain(VertexDomain* value) const noexcept;
     bool getMaterialDomain(MaterialDomain* domain) const noexcept;
+    bool getStencilWrite(bool* value) const noexcept;
+    bool getStencilDepthFail(backend::StencilOperation* value) const noexcept;
+    bool getStencilDepthPass(backend::StencilOperation* value) const noexcept;
 
     bool getShading(Shading*) const noexcept;
     bool getBlendingMode(BlendingMode*) const noexcept;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -203,6 +203,9 @@ void RenderPass::setupColorCommand(Command& cmdDraw,
     cmdDraw.primitive.rasterState.colorWrite = mi->getColorWrite();
     cmdDraw.primitive.rasterState.depthWrite = mi->getDepthWrite();
     cmdDraw.primitive.rasterState.depthFunc = mi->getDepthFunc();
+    cmdDraw.primitive.rasterState.stencilWrite = mi->getStencilWrite();
+    cmdDraw.primitive.rasterState.stencilDepthFail = mi->getStencilDepthFail();
+    cmdDraw.primitive.rasterState.stencilDepthPass = mi->getStencilDepthPass();
     cmdDraw.primitive.mi = mi;
     cmdDraw.primitive.materialVariant.key = variant;
     // we keep "RasterState::colorWrite" to the value set by material (could be disabled)

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -210,11 +210,11 @@ public:
 
     struct PrimitiveInfo { // 24 bytes
         FMaterialInstance const* mi = nullptr;                          // 8 bytes (4)
-        backend::Handle<backend::HwRenderPrimitive> primitiveHandle;    // 4 bytes
-        backend::RasterState rasterState;                               // 4 bytes
-        uint16_t index = 0;                                             // 2 bytes
+        backend::RasterState rasterState;                               // 5 bytes
         Variant materialVariant;                                        // 1 byte
-        uint8_t reserved[13 - sizeof(void*)] = {};                      // 5 byte (9)
+        uint16_t index = 0;                                             // 2 bytes
+        backend::Handle<backend::HwRenderPrimitive> primitiveHandle;    // 4 bytes
+        uint8_t reserved[12 - sizeof(void*)] = {};                      // 4 byte (8)
     };
     static_assert(sizeof(PrimitiveInfo) == 24);
 

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -111,6 +111,12 @@ public:
     bool isDepthCullingEnabled() const noexcept {
         return mRasterState.depthFunc != backend::RasterState::DepthFunc::A;
     }
+
+    bool isStencilWriteEnabled() const noexcept { return mRasterState.stencilWrite; }
+
+    StencilOperation getStencilDepthFail() const noexcept { return mRasterState.stencilDepthFail; }
+    StencilOperation getStencilDepthPass() const noexcept { return mRasterState.stencilDepthPass; }
+
     bool isDoubleSided() const noexcept { return mDoubleSided; }
     bool hasDoubleSidedCapability() const noexcept { return mDoubleSidedCapability; }
     float getMaskThreshold() const noexcept { return mMaskThreshold; }

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -91,6 +91,12 @@ public:
 
     bool getDepthWrite() const noexcept { return mDepthWrite; }
 
+    bool getStencilWrite() const noexcept { return mStencilWrite; }
+
+    StencilOperation getStencilDepthFail() const noexcept { return mStencilDepthFail; }
+
+    StencilOperation getStencilDepthPass() const noexcept { return mStencilDepthPass; }
+
     TransparencyMode getTransparencyMode() const noexcept { return mTransparencyMode; }
 
     backend::RasterState::DepthFunc getDepthFunc() const noexcept { return mDepthFunc; }
@@ -119,6 +125,12 @@ public:
     void setDepthWrite(bool enable) noexcept { mDepthWrite = enable; }
 
     void setDepthCulling(bool enable) noexcept;
+
+    void setStencilWrite(bool enable) noexcept { mStencilWrite = enable; }
+
+    void setStencilDepthFail(StencilOperation operation) noexcept { mStencilDepthFail = operation; }
+
+    void setStencilDepthPass(StencilOperation operation) noexcept { mStencilDepthPass = operation; }
 
     const char* getName() const noexcept;
 
@@ -162,6 +174,9 @@ private:
     backend::CullingMode mCulling;
     bool mColorWrite;
     bool mDepthWrite;
+    bool mStencilWrite;
+    StencilOperation mStencilDepthFail;
+    StencilOperation mStencilDepthPass;
     backend::RasterState::DepthFunc mDepthFunc;
     TransparencyMode mTransparencyMode;
 

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -73,6 +73,10 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialDepthTest = charTo64bitNum("MAT_DTEST"),
     MaterialCullingMode = charTo64bitNum("MAT_CUMO"),
 
+    MaterialStencilWrite = charTo64bitNum("MAT_SWRIT"),
+    MaterialStencilDepthFail = charTo64bitNum("MAT_SFAIL"),
+    MaterialStencilDepthPass = charTo64bitNum("MAT_SPASS"),
+
     MaterialHasCustomDepthShader =charTo64bitNum("MAT_CSDP"),
 
     MaterialVertexDomain = charTo64bitNum("MAT_VEDO"),

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -733,7 +733,7 @@ private:
     bool mStencilWrite = false;
 
     StencilOperation mStencilDepthFail = StencilOperation::KEEP;
-    StencilOperation mStencilDepthPass = StencilOperation::REPLACE;
+    StencilOperation mStencilDepthPass = StencilOperation::KEEP;
 
     bool mSpecularAntiAliasing = false;
     bool mClearCoatIorChange = true;

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -394,7 +394,7 @@ public:
     //! Set the stencil depth fail operation. Stencil value kept by default.
     MaterialBuilder& stencilDepthFail(StencilOperation operation) noexcept;
 
-    //! Set the stencil depth pass operation. Stencil value replaced with reference value by default.
+    //! Set the stencil depth pass operation. Stencil value kept by default.
     MaterialBuilder& stencilDepthPass(StencilOperation operation) noexcept;
 
     /**

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -199,6 +199,7 @@ public:
     using TransparencyMode = filament::TransparencyMode;
     using SpecularAmbientOcclusion = filament::SpecularAmbientOcclusion;
 
+    using StencilOperation = filament::backend::StencilOperation;
     using UniformType = filament::backend::UniformType;
     using SamplerType = filament::backend::SamplerType;
     using SubpassType = filament::backend::SubpassType;
@@ -386,6 +387,15 @@ public:
 
     //! Enable / disable depth based culling (enabled by default, material instances can override).
     MaterialBuilder& depthCulling(bool enable) noexcept;
+
+    //! Enable / disable stencil-buffer write (disabled by default, material instances can override).
+    MaterialBuilder& stencilWrite(bool enable) noexcept;
+
+    //! Set the stencil depth fail operation. Stencil value kept by default.
+    MaterialBuilder& stencilDepthFail(StencilOperation operation) noexcept;
+
+    //! Set the stencil depth pass operation. Stencil value replaced with reference value by default.
+    MaterialBuilder& stencilDepthPass(StencilOperation operation) noexcept;
 
     /**
      * Double-sided materials don't cull faces, equivalent to culling(CullingMode::NONE).
@@ -719,6 +729,11 @@ private:
     bool mDepthTest = true;
     bool mDepthWrite = true;
     bool mDepthWriteSet = false;
+
+    bool mStencilWrite = false;
+
+    StencilOperation mStencilDepthFail = StencilOperation::KEEP;
+    StencilOperation mStencilDepthPass = StencilOperation::REPLACE;
 
     bool mSpecularAntiAliasing = false;
     bool mClearCoatIorChange = true;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -300,6 +300,21 @@ MaterialBuilder& MaterialBuilder::depthWrite(bool enable) noexcept {
     return *this;
 }
 
+MaterialBuilder& MaterialBuilder::stencilWrite(bool enable) noexcept {
+    mStencilWrite = enable;
+    return *this;
+}
+
+MaterialBuilder& MaterialBuilder::stencilDepthFail(StencilOperation operation) noexcept {
+    mStencilDepthFail = operation;
+    return *this;
+}
+
+MaterialBuilder& MaterialBuilder::stencilDepthPass(StencilOperation operation) noexcept {
+    mStencilDepthPass = operation;
+    return *this;
+}
+
 MaterialBuilder& MaterialBuilder::depthCulling(bool enable) noexcept {
     mDepthTest = enable;
     return *this;
@@ -1018,6 +1033,10 @@ void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo&
     container.addSimpleChild<bool>(ChunkType::MaterialDepthWrite, mDepthWrite);
     container.addSimpleChild<bool>(ChunkType::MaterialDepthTest, mDepthTest);
     container.addSimpleChild<uint8_t>(ChunkType::MaterialCullingMode, static_cast<uint8_t>(mCullingMode));
+
+    container.addSimpleChild<bool>(ChunkType::MaterialStencilWrite, mStencilWrite);
+    container.addSimpleChild<uint8_t>(ChunkType::MaterialStencilDepthFail, static_cast<uint8_t>(mStencilDepthFail));
+    container.addSimpleChild<uint8_t>(ChunkType::MaterialStencilDepthPass, static_cast<uint8_t>(mStencilDepthPass));
 
     uint64_t properties = 0;
     for (size_t i = 0; i < MATERIAL_PROPERTIES_COUNT; i++) {

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -103,6 +103,10 @@ static bool printMaterial(ostream& json, const ChunkContainer& container) {
     printChunk<bool, bool>(json, container, MaterialColorWrite, "color_write");
     printChunk<bool, bool>(json, container, MaterialDepthWrite, "depth_write");
     printChunk<bool, bool>(json, container, MaterialDepthTest, "depth_test");
+    printChunk<bool, bool>(json, container, MaterialStencilWrite, "stencil_write");
+    printChunk<backend::StencilOperation, uint8_t>(json, container, MaterialStencilDepthFail, "stencil_depth_fail");
+    printChunk<backend::StencilOperation, uint8_t>(json, container, MaterialStencilDepthPass, "stencil_depth_pass");
+    
     printChunk<bool, bool>(json, container, MaterialDoubleSided, "double_sided");
     printChunk<CullingMode, uint8_t>(json, container, MaterialCullingMode, "culling");
     printChunk<TransparencyMode, uint8_t>(json, container, MaterialTransparencyMode, "transparency");

--- a/libs/matdbg/src/TextWriter.cpp
+++ b/libs/matdbg/src/TextWriter.cpp
@@ -122,6 +122,10 @@ static bool printMaterial(ostream& text, const ChunkContainer& container) {
     printChunk<bool, bool>(text, container, MaterialColorWrite, "Color write: ");
     printChunk<bool, bool>(text, container, MaterialDepthWrite, "Depth write: ");
     printChunk<bool, bool>(text, container, MaterialDepthTest, "Depth test: ");
+    printChunk<bool, bool>(text, container, MaterialStencilWrite, "Stencil write: ");
+    printChunk<backend::StencilOperation, uint8_t>(text, container, MaterialStencilDepthFail, "Stencil depth fail operation: ");
+    printChunk<backend::StencilOperation, uint8_t>(text, container, MaterialStencilDepthPass, "Stencil depth pass operation: ");
+    
     printChunk<bool, bool>(text, container, MaterialDoubleSided, "Double sided: ");
     printChunk<CullingMode, uint8_t>(text, container, MaterialCullingMode, "Culling: ");
     printChunk<TransparencyMode, uint8_t>(text, container, MaterialTransparencyMode, "Transparency: ");


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-999](https://shapr3d.atlassian.net/browse/GFX-999)

## Short description (What? How?) 📖
This PR introduces the almost minimal functionality to filament materials to enable us create the selection outline.
The material API was extended with `stencilWrite`, `stencilDepthFail`, `stencilDepthPass` settings.
These options control both the back and front face stencil test operations. For simplicity the stencil test always succeeds (if enabled with `stencilWrite`) and the reference value fixed to 1.

| Settings  | Valid values |
| ------------- | ------------- |
| `stencilWrite`  | `true` `false` |
| `stencilDepthFail`  | `keep` `zero` `invert` `replace`  |
| `stencilDepthPass`  | `keep` `zero` `invert` `replace`  | 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
OpenGL backend, Metal backend, Material API, Material parser

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Run it on my local machine (MacBook Pro 16") with a modified version of the `rendertarget` filament sample.

<img width="1403" alt="Screenshot 2022-05-04 at 10 22 20" src="https://user-images.githubusercontent.com/100697016/166645875-73d33eca-d964-4343-9734-df07f098dc36.png">

Automated 💻
n/a