### PR TITLE
[GFX-1289] Add skybox priority to public interface

### DIFF
--- a/filament/include/filament/Skybox.h
+++ b/filament/include/filament/Skybox.h
@@ -230,6 +230,11 @@ public:
      * @return the associated texture, or null if it does not exist
      */
     Texture const* getTexture() const noexcept;
+
+    /**
+     * Changes the coarse-level draw ordering.
+     */
+    void setPriority(uint8_t priority) noexcept;
 };
 
 } // namespace filament

--- a/filament/src/Skybox.cpp
+++ b/filament/src/Skybox.cpp
@@ -197,6 +197,10 @@ void FSkybox::setCheckerboardGrays(math::float2 grays) noexcept {
     mSkyboxMaterialInstance->setParameter("checkerboardGrays", grays);
 }
 
+void FSkybox::setPriority(uint8_t priority) noexcept {
+    mRenderableManager.setPriority(mRenderableManager.getInstance(mSkybox), priority);
+}
+
 void FSkybox::commit(backend::DriverApi& driver) noexcept {
     mSkyboxMaterialInstance->commit(driver);
 }
@@ -243,6 +247,10 @@ void Skybox::setCheckerboardGrays(math::float2 grays) noexcept {
 
 Texture const* Skybox::getTexture() const noexcept {
     return upcast(this)->getTexture();
+}
+
+void Skybox::setPriority(uint8_t priority) noexcept {
+    upcast(this)->setPriority(priority);
 }
 
 } // namespace filament

--- a/filament/src/details/Skybox.h
+++ b/filament/src/details/Skybox.h
@@ -62,6 +62,8 @@ public:
 
     void setCheckerboardGrays(math::float2 grays) noexcept;
 
+    void setPriority(uint8_t priority) noexcept;
+
     // commits UBOs
     void commit(backend::DriverApi& driver) noexcept;
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1289](https://shapr3d.atlassian.net/browse/GFX-1289)

## Short description (What? How?) 📖
In order to hide geometry below the `Z = 0` plane, we draw a plane there without color writes, but with enabled depth writes. This causes problems for the gradient background, as it will also be hidden by this plane, because it is rendered last in the opaque pass. This PR aims to put its rendering priority on its public interface, to be able to set its rendering priority externally. In case of "problematic" backgrounds, we can render the background first.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
N/A

### Special use-cases to test 🧷
N/A

### How did you test it? 🤔
Manual 💁‍♂️
Built Filament into Shapr, set priority.