### PR TITLE
[GFX-1109] External depth buffering

### DIFF
--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -121,12 +121,19 @@ public:
      */
     struct ClearOptions {
         /** Color to use to clear the SwapChain */
-        math::float4 clearColor = {};
+        math::float4 clearColorValue = {};
+        
         /**
          * Whether the SwapChain should be cleared using the clearColor. Use this if translucent
          * View will be drawn, for instance.
          */
-        bool clear = false;
+        bool clearColor = false;
+        
+        /**
+         * Whether the SwapChain should be clear the depth.
+         */
+        bool clearDepth = true;
+        
         /**
          * Whether the SwapChain content should be discarded. clear implies discard. Set this
          * to false (along with clear to false as well) if the SwapChain already has content that

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -146,27 +146,11 @@ public:
     RenderTarget* getRenderTarget() const noexcept;
     
     /**
-     * Specifies an offscreen render target's LDR color output texture to render into.
-     *
-     * @param texture LDR color texture
-     */
-    void setLDRColorTexture(Texture* texture) noexcept;
-
-    /**
-     * Gets the offscreen render target's LDR color output texture.
-     *
-     * Returns nullptr if the render target is the swap chain (which is default).
-     *
-     * @see setLDRColorTexture
-     */
-    Texture* getLDRColorTexture() const noexcept;
-
-    /**
      * Specifies an offscreen render target's HDR color output texture to render into.
      *
      * @param texture HDR color texture
      */
-    void setHDRColorTexture(Texture* texture) noexcept;
+    void setHdrColorTexture(Texture* texture) noexcept;
     
     /**
      * Gets the offscreen render target's HDR color output texture.
@@ -175,7 +159,7 @@ public:
      *
      * @see setHDRColorTexture
      */
-    Texture* getHDRColorTexture() const noexcept;
+    Texture* getHdrColorTexture() const noexcept;
 
     /**
      * Specifies an offscreen render target's depth-stencil texture to render into.

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -144,6 +144,54 @@ public:
      * @see setRenderTarget
      */
     RenderTarget* getRenderTarget() const noexcept;
+    
+    /**
+     * Specifies an offscreen render target's LDR color output texture to render into.
+     *
+     * @param texture LDR color texture
+     */
+    void setLDRColorTexture(Texture* texture) noexcept;
+
+    /**
+     * Gets the offscreen render target's LDR color output texture.
+     *
+     * Returns nullptr if the render target is the swap chain (which is default).
+     *
+     * @see setLDRColorTexture
+     */
+    Texture* getLDRColorTexture() const noexcept;
+
+    /**
+     * Specifies an offscreen render target's HDR color output texture to render into.
+     *
+     * @param texture HDR color texture
+     */
+    void setHDRColorTexture(Texture* texture) noexcept;
+    
+    /**
+     * Gets the offscreen render target's HDR color output texture.
+     *
+     * Returns nullptr if the render target is the swap chain (which is default).
+     *
+     * @see setHDRColorTexture
+     */
+    Texture* getHDRColorTexture() const noexcept;
+
+    /**
+     * Specifies an offscreen render target's depth-stencil texture to render into.
+     *
+     * @param texture depth-stencil texture
+     */
+    void setDepthStencilTexture(Texture* texture) noexcept;
+    
+    /**
+     * Gets the offscreen render target's depth-stencil texture.
+     *
+     * Returns nullptr if the render target is the swap chain (which is default).
+     *
+     * @see setDepthStencilTexture
+     */
+    Texture* getDepthStencilTexture() const noexcept;
 
     /**
      * Sets the rectangular region to render to.

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -676,7 +676,7 @@ void FRenderer::renderJob(ArenaScope& arena, FView& view) {
      }
     fg.compile();
 
-    fg.export_graphviz(slog.d, view.getName());
+    // fg.export_graphviz(slog.d, view.getName());
 
     fg.execute(driver);
 

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -86,6 +86,7 @@ void FView::terminate(FEngine& engine) {
         pQuery->callback(pQuery->result, pQuery);
         FPickingQuery::put(pQuery);
     }
+
     mPerViewUniforms.terminate(engine);
 
     DriverApi& driver = engine.getDriverApi();

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -86,7 +86,6 @@ void FView::terminate(FEngine& engine) {
         pQuery->callback(pQuery->result, pQuery);
         FPickingQuery::put(pQuery);
     }
-    engine.destroy(mRenderTarget);
     mPerViewUniforms.terminate(engine);
 
     DriverApi& driver = engine.getDriverApi();
@@ -334,25 +333,6 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
         filament::Viewport const& viewport, float4 const& userTime) noexcept {
     JobSystem& js = engine.getJobSystem();
-
-    engine.destroy(mRenderTarget);
-    mRenderTarget = nullptr;
-
-    if (mLDRTexture || mHDRTexture || mDepthStencilTexture) {
-
-        RenderTarget::Builder builder;
-        if (mLDRTexture) {
-            builder.texture(RenderTarget::AttachmentPoint::COLOR0, mLDRTexture);
-        }
-        if (mHDRTexture) {
-            builder.texture(RenderTarget::AttachmentPoint::COLOR1, mHDRTexture);
-        }
-        if (mDepthStencilTexture) {
-            builder.texture(RenderTarget::AttachmentPoint::DEPTH , mDepthStencilTexture);
-        }
-        mRenderTarget = upcast(builder.build(engine));
-    }
-
 
     /*
      * Prepare the scene -- this is where we gather all the objects added to the scene,
@@ -912,20 +892,12 @@ RenderTarget* View::getRenderTarget() const noexcept {
     return upcast(this)->getRenderTarget();
 }
 
-void View::setLDRColorTexture(Texture* texture) noexcept {
-    return upcast(this)->setLDRColorTexture(upcast(texture));
+void View::setHdrColorTexture(Texture* texture) noexcept {
+    return upcast(this)->setHdrColorTexture(upcast(texture));
 }
 
-Texture* View::getLDRColorTexture() const noexcept {
-    return upcast(this)->getLDRColorTexture();
-}
-
-void View::setHDRColorTexture(Texture* texture) noexcept {
-    return upcast(this)->setHDRColorTexture(upcast(texture));
-}
-
-Texture* View::getHDRColorTexture() const noexcept {
-    return upcast(this)->getHDRColorTexture();
+Texture* View::getHdrColorTexture() const noexcept {
+    return upcast(this)->getHdrColorTexture();
 }
 
 void View::setDepthStencilTexture(Texture* texture) noexcept {

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -86,7 +86,7 @@ void FView::terminate(FEngine& engine) {
         pQuery->callback(pQuery->result, pQuery);
         FPickingQuery::put(pQuery);
     }
-
+    engine.destroy(mRenderTarget);
     mPerViewUniforms.terminate(engine);
 
     DriverApi& driver = engine.getDriverApi();
@@ -334,6 +334,25 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
         filament::Viewport const& viewport, float4 const& userTime) noexcept {
     JobSystem& js = engine.getJobSystem();
+
+    engine.destroy(mRenderTarget);
+    mRenderTarget = nullptr;
+
+    if (mLDRTexture || mHDRTexture || mDepthStencilTexture) {
+
+        RenderTarget::Builder builder;
+        if (mLDRTexture) {
+            builder.texture(RenderTarget::AttachmentPoint::COLOR0, mLDRTexture);
+        }
+        if (mHDRTexture) {
+            builder.texture(RenderTarget::AttachmentPoint::COLOR1, mHDRTexture);
+        }
+        if (mDepthStencilTexture) {
+            builder.texture(RenderTarget::AttachmentPoint::DEPTH , mDepthStencilTexture);
+        }
+        mRenderTarget = upcast(builder.build(engine));
+    }
+
 
     /*
      * Prepare the scene -- this is where we gather all the objects added to the scene,
@@ -891,6 +910,30 @@ void View::setRenderTarget(RenderTarget* renderTarget) noexcept {
 
 RenderTarget* View::getRenderTarget() const noexcept {
     return upcast(this)->getRenderTarget();
+}
+
+void View::setLDRColorTexture(Texture* texture) noexcept {
+    return upcast(this)->setLDRColorTexture(upcast(texture));
+}
+
+Texture* View::getLDRColorTexture() const noexcept {
+    return upcast(this)->getLDRColorTexture();
+}
+
+void View::setHDRColorTexture(Texture* texture) noexcept {
+    return upcast(this)->setHDRColorTexture(upcast(texture));
+}
+
+Texture* View::getHDRColorTexture() const noexcept {
+    return upcast(this)->getHDRColorTexture();
+}
+
+void View::setDepthStencilTexture(Texture* texture) noexcept {
+    return upcast(this)->setDepthStencilTexture(upcast(texture));
+}
+
+Texture* View::getDepthStencilTexture() const noexcept {
+    return upcast(this)->getDepthStencilTexture();
 }
 
 void View::setSampleCount(uint8_t count) noexcept {

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -143,6 +143,7 @@ private:
         Viewport vp;
         Viewport svp;
         math::float2 scale;
+        Texture::InternalFormat depthFormat;
         backend::TextureFormat hdrFormat;
         uint8_t msaa;
         backend::TargetBufferFlags clearFlags;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -208,13 +208,13 @@ public:
     void setRenderTarget(FRenderTarget* renderTarget) noexcept {
         mRenderTarget = renderTarget;
     }
-    
+
     void setHdrColorTexture(FTexture* texture) noexcept {
-        mHDRTexture = texture;
+        mHdrTexture = texture;
     }
 
     FTexture* getHdrColorTexture() const noexcept {
-        return mHDRTexture;
+        return mHdrTexture;
     }
 
     void setDepthStencilTexture(FTexture* texture) noexcept {
@@ -537,7 +537,7 @@ private:
     bool mFrontFaceWindingInverted = false;
 
     FRenderTarget* mRenderTarget = nullptr;
-    FTexture* mHDRTexture = nullptr;
+    FTexture* mHdrTexture = nullptr;
     FTexture* mDepthStencilTexture = nullptr;
 
     uint8_t mVisibleLayers = 0x1;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -208,6 +208,30 @@ public:
     void setRenderTarget(FRenderTarget* renderTarget) noexcept {
         mRenderTarget = renderTarget;
     }
+    
+    void setLDRColorTexture(FTexture* texture) noexcept {
+        mLDRTexture = texture;
+    }
+
+    FTexture* getLDRColorTexture() const noexcept {
+        return mLDRTexture;
+    }
+
+    void setHDRColorTexture(FTexture* texture) noexcept {
+        mHDRTexture = texture;
+    }
+
+    FTexture* getHDRColorTexture() const noexcept {
+        return mHDRTexture;
+    }
+
+    void setDepthStencilTexture(FTexture* texture) noexcept {
+        mDepthStencilTexture = texture;
+    }
+
+    FTexture* getDepthStencilTexture() const noexcept {
+        return mDepthStencilTexture;
+    }
 
     FRenderTarget* getRenderTarget() const noexcept {
         return mRenderTarget;
@@ -521,6 +545,9 @@ private:
     bool mFrontFaceWindingInverted = false;
 
     FRenderTarget* mRenderTarget = nullptr;
+    FTexture* mLDRTexture = nullptr;
+    FTexture* mHDRTexture = nullptr;
+    FTexture* mDepthStencilTexture = nullptr;
 
     uint8_t mVisibleLayers = 0x1;
     uint8_t mSampleCount = 1;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -209,19 +209,11 @@ public:
         mRenderTarget = renderTarget;
     }
     
-    void setLDRColorTexture(FTexture* texture) noexcept {
-        mLDRTexture = texture;
-    }
-
-    FTexture* getLDRColorTexture() const noexcept {
-        return mLDRTexture;
-    }
-
-    void setHDRColorTexture(FTexture* texture) noexcept {
+    void setHdrColorTexture(FTexture* texture) noexcept {
         mHDRTexture = texture;
     }
 
-    FTexture* getHDRColorTexture() const noexcept {
+    FTexture* getHdrColorTexture() const noexcept {
         return mHDRTexture;
     }
 
@@ -545,7 +537,6 @@ private:
     bool mFrontFaceWindingInverted = false;
 
     FRenderTarget* mRenderTarget = nullptr;
-    FTexture* mLDRTexture = nullptr;
     FTexture* mHDRTexture = nullptr;
     FTexture* mDepthStencilTexture = nullptr;
 

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -1071,8 +1071,8 @@ void applySettings(const ViewerOptions& settings, Camera* camera, Skybox* skybox
         // we have to clear because the side-bar doesn't have a background, we cannot use
         // a skybox on the ui scene, because the ui view is always full screen.
         renderer->setClearOptions({
-                .clearColor = { inverseTonemapSRGB(settings.backgroundColor), 1.0f },
-                .clear = true
+                .clearColorValue = { inverseTonemapSRGB(settings.backgroundColor), 1.0f },
+                .clearColor = true
         });
     }
     if (skybox) {

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -197,8 +197,8 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
 
     // Without an IBL, we must clear the swapchain to black before each frame.
     renderer->setClearOptions({
-            .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f },
-            .clear = !FilamentApp::get().getIBL()  });
+            .clearColorValue = { 0.0f, 0.0f, 0.0f, 1.0f },
+            .clearColor = !FilamentApp::get().getIBL()  });
 
 }
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -1018,8 +1018,8 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
 
     // Without an IBL, we must clear the swapchain to black before each frame.
     renderer->setClearOptions({
-            .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f },
-            .clear = !FilamentApp::get().getIBL()  });
+            .clearColorValue = { 0.0f, 0.0f, 0.0f, 1.0f },
+            .clearColor = !FilamentApp::get().getIBL()  });
 
     Camera& camera = view->getCamera();
     camera.setExposure(g_params.cameraAperture, 1.0f / g_params.cameraSpeed, g_params.cameraISO);

--- a/samples/rendertarget.cpp
+++ b/samples/rendertarget.cpp
@@ -338,7 +338,7 @@ int main(int argc, char** argv) {
     };
 
     auto preRender = [&app](Engine*, View*, Scene*, Renderer* renderer) {
-        renderer->setClearOptions({.clearColor = {0.1,0.2,0.4,1.0}, .clear = true});
+        renderer->setClearOptions({.clearColorValue = {0.1,0.2,0.4,1.0}, .clearColor = true});
     };
 
     FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1109](https://shapr3d.atlassian.net/browse/GFX-1109)

## Short description (What? How?) 📖

The View's API was extended with HDR color and depth-stencil output textures. The already existing RenderTarget API was kept, because the IBL pre-filtering used it. The depth-stencil output texture contains the resolved texture if hardware supports the operation otherwise the multisample texture.

<img width="1262" alt="Screenshot 2022-05-02 at 10 22 15" src="https://user-images.githubusercontent.com/100697016/166205679-ac3c5389-6af5-47cb-af09-d1a1aef6a34d.png">

## Testing

### Design review 🎨
n/a 

### Affected areas 🧭
Filament's frame graph building, metal backend

### Special use-cases to test 🧷
Multisampling, post processing

### How did you test it? 🤔
Manual 💁‍♂️
I experimented with the `rendertarget` sample-project.

Automated 💻
n/a