### PR TITLE
[GFX-1555] External stencil buffering

### DIFF
--- a/filament/backend/src/metal/MetalBlitter.mm
+++ b/filament/backend/src/metal/MetalBlitter.mm
@@ -315,7 +315,7 @@ void MetalBlitter::blitDepthPlane(id<MTLCommandBuffer> cmdBuffer, bool blitColor
             MTLPixelFormatInvalid,
             MTLPixelFormatInvalid
         },
-        .depthAttachmentPixelFormat =
+        .depthStencilAttachmentPixelFormat =
                 blitDepth ? args.destination.depth.pixelFormat : MTLPixelFormatInvalid,
         .sampleCount = 1,
         .blendState = {}

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1138,8 +1138,8 @@ void MetalDriver::blit(TargetBufferFlags buffers,
     }
 
     if (any(buffers & TargetBufferFlags::DEPTH)) {
-        MetalRenderTarget::Attachment srcDepthAttachment = srcTarget->getDepthAttachment();
-        MetalRenderTarget::Attachment dstDepthAttachment = dstTarget->getDepthAttachment();
+        MetalRenderTarget::Attachment srcDepthAttachment = srcTarget->getDepthStencilAttachment();
+        MetalRenderTarget::Attachment dstDepthAttachment = dstTarget->getDepthStencilAttachment();
 
         if (srcDepthAttachment && dstDepthAttachment) {
             ASSERT_PRECONDITION(isBlitableTextureType(srcDepthAttachment.getTexture().textureType) &&
@@ -1193,10 +1193,10 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
         }
         colorPixelFormat[i] = attachment.getPixelFormat();
     }
-    MTLPixelFormat depthPixelFormat = MTLPixelFormatInvalid;
-    const auto& depthAttachment = mContext->currentRenderTarget->getDepthAttachment();
-    if (depthAttachment) {
-        depthPixelFormat = depthAttachment.getPixelFormat();
+    MTLPixelFormat depthStencilPixelFormat = MTLPixelFormatInvalid;
+    const auto& depthStencilAttachment = mContext->currentRenderTarget->getDepthStencilAttachment();
+    if (depthStencilAttachment) {
+        depthStencilPixelFormat = depthStencilAttachment.getPixelFormat();
     }
     metal::PipelineState pipelineState {
         .vertexFunction = program->vertexFunction,
@@ -1212,7 +1212,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             colorPixelFormat[6],
             colorPixelFormat[7]
         },
-        .depthAttachmentPixelFormat = depthPixelFormat,
+        .depthStencilAttachmentPixelFormat = depthStencilPixelFormat,
         .sampleCount = mContext->currentRenderTarget->getSamples(),
         .blendState = BlendState {
             .blendingEnabled = rs.hasBlending(),

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -282,7 +282,7 @@ public:
 
     Attachment getDrawColorAttachment(size_t index);
     Attachment getReadColorAttachment(size_t index);
-    Attachment getDepthAttachment();
+    Attachment getDepthStencilAttachment();
 
 private:
 
@@ -296,7 +296,7 @@ private:
     uint8_t samples = 1;
 
     Attachment color[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = {};
-    Attachment depth = {};
+    Attachment depthStencil = {};
 };
 
 // MetalFence is used to implement both Fences and Syncs.

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -780,19 +780,19 @@ MetalRenderTarget::MetalRenderTarget(MetalContext* context, uint32_t width, uint
     }
 
     if (depthAttachment) {
-        depth = depthAttachment;
+        depthStencil = depthAttachment;
 
-        ASSERT_PRECONDITION(depth.getSampleCount() <= samples,
+        ASSERT_PRECONDITION(depthStencil.getSampleCount() <= samples,
                 "MetalRenderTarget was initialized with a MSAA DEPTH texture, but sample count is %d.",
                 samples);
 
         // If we were given a single-sampled texture but the samples parameter is > 1, we create
         // a multisampled sidecar texture and do a resolve automatically.
-        if (samples > 1 && depth.getSampleCount() == 1) {
-            auto& sidecar = depth.metalTexture->msaaSidecar;
+        if (samples > 1 && depthStencil.getSampleCount() == 1) {
+            auto& sidecar = depthStencil.metalTexture->msaaSidecar;
             if (!sidecar) {
-                sidecar = createMultisampledTexture(*context, depth.getPixelFormat(),
-                        depth.metalTexture->width, depth.metalTexture->height, samples);
+                sidecar = createMultisampledTexture(*context, depthStencil.getPixelFormat(),
+                        depthStencil.metalTexture->width, depthStencil.metalTexture->height, samples);
             }
         }
     }
@@ -841,22 +841,32 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
         }
     }
 
-    Attachment depthAttachment = getDepthAttachment();
-    descriptor.depthAttachment.texture = depthAttachment.getTexture();
-    descriptor.depthAttachment.level = depthAttachment.level;
-    descriptor.depthAttachment.slice = depthAttachment.layer;
+    Attachment depthStencilAttachment = getDepthStencilAttachment();
+    descriptor.depthAttachment.texture = depthStencilAttachment.getTexture();
+    descriptor.depthAttachment.level = depthStencilAttachment.level;
+    descriptor.depthAttachment.slice = depthStencilAttachment.layer;
     descriptor.depthAttachment.loadAction = getLoadAction(params, TargetBufferFlags::DEPTH);
     descriptor.depthAttachment.storeAction = getStoreAction(params, TargetBufferFlags::DEPTH);
     descriptor.depthAttachment.clearDepth = params.clearDepth;
 
-    const bool automaticResolve = samples > 1 && depthAttachment.getSampleCount() == 1;
+    const auto hasStencil = (MTLPixelFormatDepth32Float_Stencil8 == depthStencilAttachment.getPixelFormat()) || (MTLPixelFormatDepth24Unorm_Stencil8 == depthStencilAttachment.getPixelFormat());
+    if (hasStencil) {
+        descriptor.stencilAttachment.texture = depthStencilAttachment.getTexture();
+        descriptor.stencilAttachment.level = depthStencilAttachment.level;
+        descriptor.stencilAttachment.slice = depthStencilAttachment.layer;
+        descriptor.stencilAttachment.loadAction = getLoadAction(params, TargetBufferFlags::STENCIL);
+        descriptor.stencilAttachment.storeAction = getStoreAction(params, TargetBufferFlags::STENCIL);
+        descriptor.stencilAttachment.clearStencil = params.clearStencil;
+    }
+    
+    const bool automaticResolve = samples > 1 && depthStencilAttachment.getSampleCount() == 1;
     if (automaticResolve) {
         // We're rendering into our temporary MSAA texture and doing an automatic resolve.
         // We should not be attempting to load anything into the MSAA texture.
         assert_invariant(descriptor.depthAttachment.loadAction != MTLLoadActionLoad);
         assert_invariant(!defaultRenderTarget);
 
-        id<MTLTexture> sidecar = depthAttachment.getMSAASidecarTexture();
+        id<MTLTexture> sidecar = depthStencilAttachment.getMSAASidecarTexture();
         assert_invariant(sidecar);
 
         descriptor.depthAttachment.texture = sidecar;
@@ -864,10 +874,21 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
         descriptor.depthAttachment.slice = 0;
         const bool discard = any(discardFlags & TargetBufferFlags::DEPTH);
         if (!discard) {
-            descriptor.depthAttachment.resolveTexture = depthAttachment.getTexture();
-            descriptor.depthAttachment.resolveLevel = depthAttachment.level;
-            descriptor.depthAttachment.resolveSlice = depthAttachment.layer;
+            descriptor.depthAttachment.resolveTexture = depthStencilAttachment.getTexture();
+            descriptor.depthAttachment.resolveLevel = depthStencilAttachment.level;
+            descriptor.depthAttachment.resolveSlice = depthStencilAttachment.layer;
             descriptor.depthAttachment.storeAction = MTLStoreActionMultisampleResolve;
+        }
+        if (hasStencil) {
+            descriptor.stencilAttachment.texture = sidecar;
+            descriptor.stencilAttachment.level = 0;
+            descriptor.stencilAttachment.slice = 0;
+            if (!discard) {
+                descriptor.stencilAttachment.resolveTexture = depthStencilAttachment.getTexture();
+                descriptor.stencilAttachment.resolveLevel = depthStencilAttachment.level;
+                descriptor.stencilAttachment.resolveSlice = depthStencilAttachment.layer;
+                descriptor.stencilAttachment.storeAction = MTLStoreActionMultisampleResolve;
+            }
         }
     }
 }
@@ -892,8 +913,8 @@ MetalRenderTarget::Attachment MetalRenderTarget::getReadColorAttachment(size_t i
     return result;
 }
 
-MetalRenderTarget::Attachment MetalRenderTarget::getDepthAttachment() {
-    Attachment result = depth;
+MetalRenderTarget::Attachment MetalRenderTarget::getDepthStencilAttachment() {
+    Attachment result = depthStencil;
     if (defaultRenderTarget) {
         result.texture = context->currentDrawSwapChain->acquireDepthTexture();
     }

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -849,7 +849,8 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
     descriptor.depthAttachment.storeAction = getStoreAction(params, TargetBufferFlags::DEPTH);
     descriptor.depthAttachment.clearDepth = params.clearDepth;
 
-    const auto hasStencil = (MTLPixelFormatDepth32Float_Stencil8 == depthStencilAttachment.getPixelFormat()) || (MTLPixelFormatDepth24Unorm_Stencil8 == depthStencilAttachment.getPixelFormat());
+    const auto hasStencil = (MTLPixelFormatDepth32Float_Stencil8 == depthStencilAttachment.getPixelFormat()) ||
+                            (MTLPixelFormatDepth24Unorm_Stencil8 == depthStencilAttachment.getPixelFormat());
     if (hasStencil) {
         descriptor.stencilAttachment.texture = depthStencilAttachment.getTexture();
         descriptor.stencilAttachment.level = depthStencilAttachment.level;
@@ -858,7 +859,7 @@ void MetalRenderTarget::setUpRenderPassAttachments(MTLRenderPassDescriptor* desc
         descriptor.stencilAttachment.storeAction = getStoreAction(params, TargetBufferFlags::STENCIL);
         descriptor.stencilAttachment.clearStencil = params.clearStencil;
     }
-    
+
     const bool automaticResolve = samples > 1 && depthStencilAttachment.getSampleCount() == 1;
     if (automaticResolve) {
         // We're rendering into our temporary MSAA texture and doing an automatic resolve.

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -217,7 +217,7 @@ struct PipelineState {
     id<MTLFunction> fragmentFunction = nil;                                    // 8 bytes
     VertexDescription vertexDescription;                                       // 528 bytes
     MTLPixelFormat colorAttachmentPixelFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = { MTLPixelFormatInvalid };  // 64 bytes
-    MTLPixelFormat depthAttachmentPixelFormat = MTLPixelFormatInvalid;         // 8 bytes
+    MTLPixelFormat depthStencilAttachmentPixelFormat = MTLPixelFormatInvalid;         // 8 bytes
     NSUInteger sampleCount = 1;                                                // 8 bytes
     BlendState blendState;                                                     // 56 bytes
     bool colorWrite = true;                                                    // 1 byte
@@ -230,7 +230,7 @@ struct PipelineState {
                 this->vertexDescription == rhs.vertexDescription &&
                 std::equal(this->colorAttachmentPixelFormat, this->colorAttachmentPixelFormat + MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT,
                         rhs.colorAttachmentPixelFormat) &&
-                this->depthAttachmentPixelFormat == rhs.depthAttachmentPixelFormat &&
+                this->depthStencilAttachmentPixelFormat == rhs.depthStencilAttachmentPixelFormat &&
                 this->sampleCount == rhs.sampleCount &&
                 this->blendState == rhs.blendState &&
                 this->colorWrite == rhs.colorWrite

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -78,7 +78,11 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
     }
 
     // Depth attachment
-    descriptor.depthAttachmentPixelFormat = state.depthAttachmentPixelFormat;
+    descriptor.depthAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
+    const auto hasStencil = (MTLPixelFormatDepth32Float_Stencil8 == state.depthStencilAttachmentPixelFormat) || (MTLPixelFormatDepth24Unorm_Stencil8 == state.depthStencilAttachmentPixelFormat);
+    if (hasStencil) {
+        descriptor.stencilAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
+    }
 
     // MSAA
     descriptor.rasterSampleCount = state.sampleCount;

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -79,7 +79,8 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
 
     // Depth attachment
     descriptor.depthAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
-    const auto hasStencil = (MTLPixelFormatDepth32Float_Stencil8 == state.depthStencilAttachmentPixelFormat) || (MTLPixelFormatDepth24Unorm_Stencil8 == state.depthStencilAttachmentPixelFormat);
+    const bool hasStencil = (MTLPixelFormatDepth32Float_Stencil8 == state.depthStencilAttachmentPixelFormat)
+                        || (MTLPixelFormatDepth24Unorm_Stencil8 == state.depthStencilAttachmentPixelFormat);
     if (hasStencil) {
         descriptor.stencilAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
     }
@@ -104,7 +105,7 @@ id<MTLDepthStencilState> DepthStateCreator::operator()(id<MTLDevice> device,
     MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
     depthStencilDescriptor.depthCompareFunction = state.compareFunction;
     depthStencilDescriptor.depthWriteEnabled = state.depthWriteEnabled;
-    
+
     if (state.stencilWriteEnabled) {
         MTLStencilDescriptor* stencilDescriptor = [MTLStencilDescriptor new];
         stencilDescriptor.readMask = 0xFF;
@@ -113,12 +114,12 @@ id<MTLDepthStencilState> DepthStateCreator::operator()(id<MTLDevice> device,
         stencilDescriptor.stencilFailureOperation = MTLStencilOperationKeep;
         stencilDescriptor.depthFailureOperation = state.stencilDepthFail;
         stencilDescriptor.depthStencilPassOperation = state.stencilDepthPass;
-        
+
         depthStencilDescriptor.backFaceStencil = stencilDescriptor;
         depthStencilDescriptor.frontFaceStencil = stencilDescriptor;
-    
+
     }
-    
+
     return [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
 }
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -883,8 +883,8 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 // We set a "read" constraint on these attachments here because we need to preserve them
                 // when the color pass happens in several passes (e.g. with SSR)
                 auto depthAttachmentUsage = FrameGraphTexture::Usage::DEPTH_ATTACHMENT;
-                const bool hasStencil = Texture::InternalFormat::DEPTH32F_STENCIL8 == config.depthFormat ||
-                                        Texture::InternalFormat::DEPTH24_STENCIL8 == config.depthFormat;
+                const bool hasStencil = TextureFormat::DEPTH32F_STENCIL8 == config.depthFormat ||
+                                        TextureFormat::DEPTH24_STENCIL8 == config.depthFormat;
                 if (hasStencil) {
                     depthAttachmentUsage |= FrameGraphTexture::Usage::STENCIL_ATTACHMENT;
                 }

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -817,6 +817,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 Blackboard& blackboard = fg.getBlackboard();
                 TargetBufferFlags clearDepthFlags = config.clearFlags & TargetBufferFlags::DEPTH;
                 TargetBufferFlags clearColorFlags = config.clearFlags & TargetBufferFlags::COLOR;
+                TargetBufferFlags clearStencilFlags = config.clearFlags & TargetBufferFlags::STENCIL;
 
                 data.shadows = blackboard.get<FrameGraphTexture>("shadows");
                 data.ssr  = blackboard.get<FrameGraphTexture>("ssr");
@@ -854,6 +855,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
                 if (!data.depth) {
                     // clear newly allocated depth buffers, regardless of given clear flags
                     clearDepthFlags = TargetBufferFlags::DEPTH;
+                    clearStencilFlags = TargetBufferFlags::STENCIL;
                     data.depth = builder.createTexture("Depth Buffer", {
                             .width = colorBufferDesc.width,
                             .height = colorBufferDesc.height,
@@ -880,11 +882,16 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
 
                 // We set a "read" constraint on these attachments here because we need to preserve them
                 // when the color pass happens in several passes (e.g. with SSR)
+                auto depthAttachmentUsage = FrameGraphTexture::Usage::DEPTH_ATTACHMENT;
+                if (MTLPixelFormatDepth32Float_Stencil8 == config.depthFormat || MTLPixelFormatDepth24Unorm_Stencil8 == config.depthFormat) {
+                    depthAttachmentUsage |= FrameGraphTexture::Usage::STENCIL_ATTACHMENT;
+                }
+
                 data.color = builder.read(data.color, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                data.depth = builder.read(data.depth, FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
+                data.depth = builder.read(data.depth, depthAttachmentUsage | clearStencilFlags);
 
                 data.color = builder.write(data.color, FrameGraphTexture::Usage::COLOR_ATTACHMENT);
-                data.depth = builder.write(data.depth, FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
+                data.depth = builder.write(data.depth, depthAttachmentUsage | clearStencilFlags);
 
                 builder.declareRenderPass("Color Pass Target", {
                         .attachments = { .color = { data.color, data.output }, .depth = data.depth },


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1555](https://shapr3d.atlassian.net/browse/GFX-1555)

## Short description (What? How?) 📖
This is purely technical PR. Metal backend was extended to handle properly stencil attachments in case of packed depth-stencil texture formats (OpenGL and Vulkan backend already supported separate and packed depth and stencil attachments). The depth attachment was renamed according to the new use case. This PR's modifications don't address the hardware support part of the stencil resolve.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Filament metal backend

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
https://github.com/shapr3d/filament/pull/55 test based on this implementation.

Automated 💻
n/a