### PR TITLE
[GFX-1555] depthStencilPass, depthStencilFail parameter parsing bug fixed

### DIFF
--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -536,17 +536,17 @@ static std::optional<MaterialBuilder::StencilOperation> processStencilOperation(
 static bool processStencilDepthFail(MaterialBuilder& builder, const JsonishValue& value) {
     if (auto op = processStencilOperation(value, "stencil_depth_fail"); op) {
         builder.stencilDepthFail(*op);
-        return false;
+        return true;
     }
-    return true;
+    return false;
 }
 
 static bool processStencilDepthPass(MaterialBuilder& builder, const JsonishValue& value) {
     if (auto op = processStencilOperation(value, "stencil_depth_pass"); op) {
         builder.stencilDepthPass(*op);
-        return false;
+        return true;
     }
-    return true;
+    return false;
 }
 
 static bool processDepthCull(MaterialBuilder& builder, const JsonishValue& value) {


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1555](https://shapr3d.atlassian.net/browse/GFX-1555)

## Short description (What? How?) 📖
`depthStencilPass` and `depthStencilFail` produced material compiler errors, because the parser's result was inverted.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Material compiler, parser

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
I checked with a modified version of `matc_test`

Automated 💻
n/a