### PR TITLE
[Fixed] Windows sample and GltfViewer compilation

### DIFF
--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -199,13 +199,13 @@ const char* toString(backend::SamplerType type) noexcept {
 inline
 const char* toString(backend::SamplerFormat type) noexcept {
     switch (type) {
-    case backend::SamplerFormat::FLOAT: return "float";
     case backend::SamplerFormat::INT: return "int";
-    case backend::SamplerFormat::SHADOW: return "shadow";
     case backend::SamplerFormat::UINT: return "uint";
+    case backend::SamplerFormat::FLOAT: return "float";
+    case backend::SamplerFormat::SHADOW: return "shadow";
     default: break;
     }
-    return "float";
+    return "int";
 }
 
 inline
@@ -228,13 +228,13 @@ const char* toString(backend::Precision precision) noexcept {
 inline
 const char* toString(backend::StencilOperation stencilOp) noexcept {
     switch (stencilOp) {
-    case backend::StencilOperation::INVERT: return "invert";
     case backend::StencilOperation::KEEP: return "keep";
-    case backend::StencilOperation::REPLACE: return "replace";
     case backend::StencilOperation::ZERO: return "zero";
+    case backend::StencilOperation::INVERT: return "invert";
+    case backend::StencilOperation::REPLACE: return "replace";
     default: break;
     }
-    return "zero";
+    return "keep";
 }
 
 // Returns a human-readable variant description.

--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -197,6 +197,18 @@ const char* toString(backend::SamplerType type) noexcept {
 }
 
 inline
+const char* toString(backend::SamplerFormat type) noexcept {
+    switch (type) {
+    case backend::SamplerFormat::FLOAT: return "float";
+    case backend::SamplerFormat::INT: return "int";
+    case backend::SamplerFormat::SHADOW: return "shadow";
+    case backend::SamplerFormat::UINT: return "uint";
+    default: break;
+    }
+    return "float";
+}
+
+inline
 const char* toString(backend::SubpassType type) noexcept {
     switch (type) {
         case backend::SubpassType::SUBPASS_INPUT: return "subpassInput";
@@ -214,13 +226,15 @@ const char* toString(backend::Precision precision) noexcept {
 }
 
 inline
-const char* toString(backend::SamplerFormat format) noexcept {
-    switch (format) {
-        case backend::SamplerFormat::INT: return "int";
-        case backend::SamplerFormat::UINT: return "uint";
-        case backend::SamplerFormat::FLOAT: return "float";
-        case backend::SamplerFormat::SHADOW: return "shadow";
+const char* toString(backend::StencilOperation stencilOp) noexcept {
+    switch (stencilOp) {
+    case backend::StencilOperation::INVERT: return "invert";
+    case backend::StencilOperation::KEEP: return "keep";
+    case backend::StencilOperation::REPLACE: return "replace";
+    case backend::StencilOperation::ZERO: return "zero";
+    default: break;
     }
+    return "zero";
 }
 
 // Returns a human-readable variant description.

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <optional>
 
 #include <ctype.h>
 #include <private/filament/Variant.h>


### PR DESCRIPTION
## Jira ticket URL (Why?)
N/A

## Short description (What? How?) 📖
Recent depth-stencil changes broke Windows compilation of GltfViewer. One was caused by a missing <optional> include (may be hidden by differences in VS2002/2019) and the other is due to two missing toString calls. This PR adds these. 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
GltfViewer on Windows

### Special use-cases to test 🧷
Compile and run GltfViewer on Windows.

### How did you test it? 🤔
Manual 💁‍♂️
As above

Automated 💻
n/a