### PR TITLE
[GFX-1529] Debug shader output

### DIFF
--- a/libs/filamat/src/shaders/CodeGenerator.cpp
+++ b/libs/filamat/src/shaders/CodeGenerator.cpp
@@ -112,6 +112,8 @@ io::sstream& CodeGenerator::generateProlog(io::sstream& out, ShaderType type,
 
     out << SHADERS_COMMON_TYPES_FS_DATA;
 
+    out << SHADERS_COMMON_DEBUG_FS_DATA;
+
     out << "\n";
     return out;
 }

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 set(SHADERS
         src/ambient_occlusion.fs
         src/brdf.fs
+        src/common_debug.fs
         src/common_getters.fs
         src/common_graphics.fs
         src/common_lighting.fs

--- a/shaders/src/common_debug.fs
+++ b/shaders/src/common_debug.fs
@@ -1,0 +1,37 @@
+//*****************************************************************************
+// Common debug facilities for "printf style debugging" in fragment shaders. 
+// Use the {Get|Set}DebugColor interfaces to output vec3s from the shader.
+//*****************************************************************************
+
+#if defined(DEBUG_OUTPUT)
+
+vec4 DEBUG_COLOR = vec4(0.0);
+
+void SetDebugColor(vec3 col) {
+    DEBUG_COLOR.rgb = col;
+    DEBUG_COLOR.a = 1.0f;
+}
+
+vec3 GetDebugColor() {
+    return DEBUG_COLOR.rgb;
+}
+
+bool WasDebugSet() {
+    return DEBUG_COLOR.a != 0.0f;
+}
+
+#else
+
+void SetDebugColor(vec3 col) {}
+vec3 GetDebugColor() {
+    return vec3(0.0);
+}
+bool WasDebugSet() {
+    return false;
+}
+
+#endif
+
+void SetDebugColor(float r, float g, float b) {
+    SetDebugColor(vec3(r, g, b));
+}

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -47,4 +47,10 @@ void main() {
 #if defined(MATERIAL_HAS_POST_LIGHTING_COLOR)
     blendPostLightingColor(inputs, fragColor);
 #endif
+
+#if defined(DEBUG_OUTPUT)
+    if (WasDebugSet()) {
+        fragColor.rgb = GetDebugColor();
+    }
+#endif
 }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1529](https://shapr3d.atlassian.net/browse/GFX-1529)

## Short description (What? How?) 📖
Previously, we used the postlighting color in Filament material shaders whenever we wanted to debug a quantity or signal an event (such as the occurance on NaNs). This PR adds a simple API to make these efforts more uniform:
* `void SetDebugColor(vec3 col)`
* `void SetDebugColor(float r, float g, float b)`
* `vec3 GetDebugColor()`
* `bool WasDebugSet()`

The PR also modifies the `main.fs` Filament shader skeleton to use this API, provided `DEBUG_OUTPUT` is defined via compiler settings. If `DEBUG_OUTPUT` is not set, there's no overhead of this functionality. 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Filament shader debugging

### Special use-cases to test 🧷
Add `SetDebugColor` calls to your favorite .mat files and see if the appropriate colors are output.

### How did you test it? 🤔
Manual 💁‍♂️
As above

Automated 💻
n/a