### PR TITLE
[GFX-1596] Stencil depth blit fix

### DIFF
--- a/filament/backend/src/metal/MetalBlitter.mm
+++ b/filament/backend/src/metal/MetalBlitter.mm
@@ -315,7 +315,7 @@ void MetalBlitter::blitDepthPlane(id<MTLCommandBuffer> cmdBuffer, bool blitColor
             MTLPixelFormatInvalid,
             MTLPixelFormatInvalid
         },
-        .depthStencilAttachmentPixelFormat =
+        .depthAttachmentPixelFormat =
                 blitDepth ? args.destination.depth.pixelFormat : MTLPixelFormatInvalid,
         .sampleCount = 1,
         .blendState = {}

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1212,7 +1212,8 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             colorPixelFormat[6],
             colorPixelFormat[7]
         },
-        .depthStencilAttachmentPixelFormat = depthStencilPixelFormat,
+        .depthAttachmentPixelFormat = depthStencilPixelFormat,
+        .stencilAttachmentPixelFormat = formatHasStencil(depthStencilPixelFormat) ? depthStencilPixelFormat : MTLPixelFormatInvalid,
         .sampleCount = mContext->currentRenderTarget->getSamples(),
         .blendState = BlendState {
             .blendingEnabled = rs.hasBlending(),
@@ -1223,8 +1224,7 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             .destinationRGBBlendFactor = getMetalBlendFactor(rs.blendFunctionDstRGB),
             .destinationAlphaBlendFactor = getMetalBlendFactor(rs.blendFunctionDstAlpha)
         },
-        .colorWrite = rs.colorWrite,
-        .stencilWrite = formatHasStencil(depthStencilPixelFormat)
+        .colorWrite = rs.colorWrite
     };
     mContext->pipelineState.updateState(pipelineState);
     if (mContext->pipelineState.stateChanged()) {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1223,7 +1223,8 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
             .destinationRGBBlendFactor = getMetalBlendFactor(rs.blendFunctionDstRGB),
             .destinationAlphaBlendFactor = getMetalBlendFactor(rs.blendFunctionDstAlpha)
         },
-        .colorWrite = rs.colorWrite
+        .colorWrite = rs.colorWrite,
+        .stencilWrite = formatHasStencil(depthStencilPixelFormat)
     };
     mContext->pipelineState.updateState(pipelineState);
     if (mContext->pipelineState.stateChanged()) {

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -217,11 +217,11 @@ struct PipelineState {
     id<MTLFunction> fragmentFunction = nil;                                    // 8 bytes
     VertexDescription vertexDescription;                                       // 528 bytes
     MTLPixelFormat colorAttachmentPixelFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = { MTLPixelFormatInvalid };  // 64 bytes
-    MTLPixelFormat depthStencilAttachmentPixelFormat = MTLPixelFormatInvalid;         // 8 bytes
-    NSUInteger sampleCount = 1;                                                // 8 bytes
+    MTLPixelFormat depthAttachmentPixelFormat = MTLPixelFormatInvalid;         // 8 bytes
+    MTLPixelFormat stencilAttachmentPixelFormat = MTLPixelFormatInvalid;       // 8 bytes
     BlendState blendState;                                                     // 56 bytes
+    uint8_t sampleCount = 1;                                                   // 1 bytes
     bool colorWrite = true;                                                    // 1 byte
-    bool stencilWrite = false;                                                 // 1 byte
     char padding[6] = { 0 };                                                   // 6 bytes
 
     bool operator==(const PipelineState& rhs) const noexcept {
@@ -231,11 +231,11 @@ struct PipelineState {
                 this->vertexDescription == rhs.vertexDescription &&
                 std::equal(this->colorAttachmentPixelFormat, this->colorAttachmentPixelFormat + MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT,
                         rhs.colorAttachmentPixelFormat) &&
-                this->depthStencilAttachmentPixelFormat == rhs.depthStencilAttachmentPixelFormat &&
+                this->depthAttachmentPixelFormat == rhs.depthAttachmentPixelFormat &&
+                this->stencilAttachmentPixelFormat == rhs.stencilAttachmentPixelFormat &&
                 this->sampleCount == rhs.sampleCount &&
                 this->blendState == rhs.blendState &&
-                this->colorWrite == rhs.colorWrite &&
-                this->stencilWrite == rhs.stencilWrite
+                this->colorWrite == rhs.colorWrite
         );
     }
 
@@ -271,8 +271,8 @@ struct DepthStencilState {
     bool operator==(const DepthStencilState& rhs) const noexcept {
         return this->compareFunction == rhs.compareFunction &&
                this->depthWriteEnabled == rhs.depthWriteEnabled &&
-               this->stencilWriteEnabled == rhs.stencilWriteEnabled && 
-               this->stencilDepthFail == rhs.stencilDepthFail && 
+               this->stencilWriteEnabled == rhs.stencilWriteEnabled &&
+               this->stencilDepthFail == rhs.stencilDepthFail &&
                this->stencilDepthPass == rhs.stencilDepthPass;
     }
 

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -221,7 +221,8 @@ struct PipelineState {
     NSUInteger sampleCount = 1;                                                // 8 bytes
     BlendState blendState;                                                     // 56 bytes
     bool colorWrite = true;                                                    // 1 byte
-    char padding[7] = { 0 };                                                   // 7 bytes
+    bool stencilWrite = false;                                                 // 1 byte
+    char padding[6] = { 0 };                                                   // 6 bytes
 
     bool operator==(const PipelineState& rhs) const noexcept {
         return (
@@ -233,7 +234,8 @@ struct PipelineState {
                 this->depthStencilAttachmentPixelFormat == rhs.depthStencilAttachmentPixelFormat &&
                 this->sampleCount == rhs.sampleCount &&
                 this->blendState == rhs.blendState &&
-                this->colorWrite == rhs.colorWrite
+                this->colorWrite == rhs.colorWrite &&
+                this->stencilWrite == rhs.stencilWrite
         );
     }
 

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -78,10 +78,8 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
     }
 
     // Depth attachment
-    descriptor.depthAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
-    if (state.stencilWrite) {
-        descriptor.stencilAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
-    }
+    descriptor.depthAttachmentPixelFormat = state.depthAttachmentPixelFormat;
+    descriptor.stencilAttachmentPixelFormat = state.stencilAttachmentPixelFormat;
 
     // MSAA
     descriptor.rasterSampleCount = state.sampleCount;

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -79,8 +79,7 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
 
     // Depth attachment
     descriptor.depthAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
-    const bool hasStencil = formatHasStencil(state.depthStencilAttachmentPixelFormat);
-    if (hasStencil) {
+    if (state.stencilWrite) {
         descriptor.stencilAttachmentPixelFormat = state.depthStencilAttachmentPixelFormat;
     }
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1596](https://shapr3d.atlassian.net/browse/GFX-1596)

## Short description (What? How?) 📖
Quick fix for filament's depth blit backend. Filament's depth blit doesn't use the stencil buffer, but the pipeline marked it as used, which resulted in a Metal error.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Repro: Disable automatic resolve and create an MSAA depth texture in the frame graph (preferably in corollas) and use the PostProcessManager::resolve() function on it. 

Automated 💻
n/a