### PR TITLE
[GFX-1566] Fix skipped depth bias set in Metal backend

### DIFF
--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -94,6 +94,8 @@ struct MetalContext {
     PipelineStateCache pipelineStateCache;
     SamplerStateCache samplerStateCache;
 
+    PolygonOffset currentPolygonOffset = {0.0f, 0.0f};
+
     MetalSamplerGroup* samplerBindings[SAMPLER_BINDING_COUNT] = {};
 
     // Keeps track of all alive sampler groups, textures.

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -874,6 +874,7 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     mContext->depthStencilState.invalidate();
     mContext->cullModeState.invalidate();
     mContext->windingState.invalidate();
+    mContext->currentPolygonOffset = {0.0f, 0.0f};
 }
 
 void MetalDriver::nextSubpass(int dummy) {}
@@ -1265,10 +1266,12 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
         [mContext->currentRenderPassEncoder setStencilReferenceValue:1];
     }
 
-    if (ps.polygonOffset.constant != 0.0 || ps.polygonOffset.slope != 0.0) {
+    if (ps.polygonOffset.constant != mContext->currentPolygonOffset.constant ||
+        ps.polygonOffset.slope != mContext->currentPolygonOffset.slope) {
         [mContext->currentRenderPassEncoder setDepthBias:ps.polygonOffset.constant
                                               slopeScale:ps.polygonOffset.slope
                                                    clamp:0.0];
+        mContext->currentPolygonOffset = ps.polygonOffset;
     }
 
     // FIXME: implement take ps.scissor into account


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1566](https://shapr3d.atlassian.net/browse/GFX-1566)

## Short description (What? How?) 📖
The depth bias values cached now in MetalContext. The driver will insert the depth bias set command in the command buffer, if it differ from the cached ones, this minimise the setDepthBias calls and resets properly the bias, when the driver encounters a geometry with a non depth bias material instance.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Filament rendering, Metal backend

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
n/a

Automated 💻
Run the rendertests with a low threshold (0.5). There was no deviations in the visualization images (all epsilon = 0).