### PR TITLE
[GFX-1277] UWP support for relevant Filament libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -708,7 +708,7 @@ if (IS_HOST_PLATFORM)
     add_subdirectory(${TOOLS}/specular-color)
 endif()
 
-# Generate exported executables for cross-compiled builds (Android, WebGL, and iOS)
+# Generate exported executables for cross-compiled builds (Android, WebGL, iOS and Windows)
 if (NOT CMAKE_CROSSCOMPILING)
     export(TARGETS matc cmgen filamesh mipgen resgen glslminifier FILE ${IMPORT_EXECUTABLES})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,7 @@ endif()
 
 if (MSVC)
     set(CXX_STANDARD "/std:c++latest")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} /W0 /Zc:__cplusplus")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} /W0 /Zc:__cplusplus /sdl-")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} -fstrict-aliasing -Wno-unknown-pragmas -Wno-unused-function")
 endif()

--- a/filament/backend/CMakeLists.txt
+++ b/filament/backend/CMakeLists.txt
@@ -284,8 +284,8 @@ endif()
 target_link_libraries(${TARGET} PUBLIC math)
 target_link_libraries(${TARGET} PUBLIC utils)
 
-# Android, iOS, and WebGL do not use bluegl.
-if(FILAMENT_SUPPORTS_OPENGL AND NOT IOS AND NOT ANDROID AND NOT WEBGL)
+# Android, iOS, WebGL and WinRT do not use bluegl.
+if(FILAMENT_SUPPORTS_OPENGL AND NOT IOS AND NOT ANDROID AND NOT WEBGL AND NOT WINDOWS_STORE)
     target_link_libraries(${TARGET} PRIVATE bluegl)
 endif()
 

--- a/libs/utils/src/win32/Path.cpp
+++ b/libs/utils/src/win32/Path.cpp
@@ -23,6 +23,8 @@
 #include <windows.h>
 #include <shlwapi.h>
 
+#include <filesystem>
+
 namespace utils {
 
 bool Path::mkdir() const {
@@ -31,18 +33,18 @@ bool Path::mkdir() const {
 
 Path Path::getCurrentExecutable() {
     // First, need to establish resource path.
-    TCHAR path[MAX_PATH + 1];
+    CHAR path[MAX_PATH + 1];
     Path result;
 
-    GetModuleFileName(NULL, path, MAX_PATH + 1);
+    GetModuleFileNameA(NULL, path, MAX_PATH + 1);
     result.setPath(path);
 
     return result;
 }
 
 Path Path::getTemporaryDirectory() {
-    TCHAR lpTempPathBuffer[MAX_PATH];
-    DWORD dwRetVal = GetTempPath(MAX_PATH, lpTempPathBuffer);
+    CHAR lpTempPathBuffer[MAX_PATH];
+    DWORD dwRetVal = GetTempPathA(MAX_PATH, lpTempPathBuffer);
     return Path(lpTempPathBuffer);
 }
 
@@ -52,11 +54,11 @@ std::vector<Path> Path::listContents() const {
         return {};
     }
 
-    TCHAR dirName[MAX_PATH];
-    StringCchCopy(dirName, MAX_PATH, c_str());
+    CHAR dirName[MAX_PATH];
+    StringCchCopyA(dirName, MAX_PATH, c_str());
 
-    WIN32_FIND_DATA findData;
-    HANDLE find = FindFirstFile(dirName, &findData);
+    WIN32_FIND_DATAA findData;
+    HANDLE find = FindFirstFileA(dirName, &findData);
 
     std::vector<Path> directory_contents;
     do
@@ -64,13 +66,13 @@ std::vector<Path> Path::listContents() const {
         if (findData.cFileName[0] != '.') {
             directory_contents.push_back(concat(findData.cFileName));
         }
-    } while (FindNextFile(find, &findData) != 0);
+    } while (FindNextFileA(find, &findData) != 0);
 
     return directory_contents;
 }
 
 bool Path::isAbsolute() const {
-    return !PathIsRelative(m_path.c_str());
+    return std::filesystem::path(m_path).is_absolute();
 }
 
 } // namespace utils

--- a/libs/utils/src/win32/Path.cpp
+++ b/libs/utils/src/win32/Path.cpp
@@ -17,7 +17,6 @@
 #include <utils/Path.h>
 
 #include <direct.h>
-#include <Strsafe.h>
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <windows.h>
@@ -54,11 +53,8 @@ std::vector<Path> Path::listContents() const {
         return {};
     }
 
-    CHAR dirName[MAX_PATH];
-    StringCchCopyA(dirName, MAX_PATH, c_str());
-
     WIN32_FIND_DATAA findData;
-    HANDLE find = FindFirstFileA(dirName, &findData);
+    HANDLE find = FindFirstFileA(&c_str()[0], &findData);
 
     std::vector<Path> directory_contents;
     do


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1277](https://shapr3d.atlassian.net/browse/GFX-1277)

## Short description (What? How?) 📖
Support for UWP for the libs that are neccessary to Shapr3D Visualization on Windows. We decided, that we're not going to build the samples for UWP, as they're require a much bigger change in the upstream. If you want to build them anyway, [here is how to do it](https://shapr3d.atlassian.net/wiki/spaces/DD/pages/2868347235/Filament+findings#UWP).

Changes introduced:
* `/sdl-` flag to disable compiler warning C4146
* not linking bluegl in the backend
* explicit ASCII version of WinAPI calls in `Path.cpp`

The last point was necessary to introduce because UWP uses the _'W'_ version of the WinAPI calls - as it defines the preprocessor directive `UNICODE` - and `Path` works with the regular `std::string`. We explored the possibility to leave the WinAPI calls as is, and convert the result with `WideCharToMultiByte`, but going with the ASCII solution was much simpler, and we'll carry on using many tools - e.g. `matc`, `cmgen` - on win32.

You can build the libs with
```
cmake -S . -B out-uwp 
        -DCMAKE_SYSTEM_NAME=WindowsStore 
        -DCMAKE_SYSTEM_VERSION="10.0.18362.0" 
        -DCMAKE_CONFIGURATION_TYPES="Debug;Release"
        -DUSE_STATIC_CRT=FALSE
        -DFILAMENT_USE_ANGLE=TRUE
        -DANGLE_INCLUDE_DIR="PATH_TO_ANGLE_INCLUDE"
```
and [use this guide](https://shapr3d.atlassian.net/wiki/spaces/DD/pages/2868347235/Filament+findings#UWP) to build the samples.
## Testing
### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Built samples `shadowtest` and `gltf_viewer`.
Automated 💻
n/a

[GFX-1277]: https://shapr3d.atlassian.net/browse/GFX-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ