### PR TITLE
[GFX-1565] Vertex buffer-size fix.

### DIFF
--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -184,7 +184,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
             attributeArray[i].type   = attributes[i].type;
             attributeArray[i].flags  = attributes[i].flags;
 
-            const size_t end = offset + mVertexCount * stride;
+            const size_t end = offset + (mVertexCount - 1) * stride + Driver::getElementTypeSize(attributes[i].type);
             bufferSizes[slot] = math::max(bufferSizes[slot], end);
         }
     }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1565](https://shapr3d.atlassian.net/browse/GFX-1565)

## Short description (What? How?) 📖
The problem was that filament doesn't know, where the attribute located in the stride, so it calculated the required buffer-size as the attribute would be the first member of the interleaved datatype.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Vertex buffer creation, model loading

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Checked with `rendertarget` sample project and with a Shapr3D workspace.

Automated 💻
n/a