### PR TITLE
[GFX-1438] Custom render command encoder injection

### DIFF
--- a/filament/backend/include/backend/MetalPlatform.h
+++ b/filament/backend/include/backend/MetalPlatform.h
@@ -49,6 +49,15 @@ public:
     virtual id<MTLCommandQueue> createCommandQueue(id<MTLDevice> device) noexcept;
 
     /**
+     * Create a render command encoder on the command buffer.
+     *
+     * @param commandBuffer A command buffer on the device which was returned from createDevice().
+     * @param renderPassDescriptor Description of the render pass which is started by the returned encoder.
+     */
+    virtual id<MTLRenderCommandEncoder> createRenderCommandEncoder(id<MTLCommandBuffer> commandBuffer,
+                                                                   MTLRenderPassDescriptor* renderPassDescriptor) noexcept;
+
+    /**
      * Obtain a MTLCommandBuffer enqueued on this Platform's MTLCommandQueue. The command buffer is
      * guaranteed to execute before all subsequent command buffers created either by Filament, or
      * further calls to this method.

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -854,7 +854,7 @@ void MetalDriver::beginRenderPass(Handle<HwRenderTarget> rth,
     renderTarget->setUpRenderPassAttachments(descriptor, params);
 
     mContext->currentRenderPassEncoder =
-            [getPendingCommandBuffer(mContext) renderCommandEncoderWithDescriptor:descriptor];
+       mPlatform.createRenderCommandEncoder(getPendingCommandBuffer(mContext), descriptor);
     if (!mContext->groupMarkers.empty()) {
         mContext->currentRenderPassEncoder.label =
                 [NSString stringWithCString:mContext->groupMarkers.top()

--- a/filament/backend/src/metal/MetalPlatform.mm
+++ b/filament/backend/src/metal/MetalPlatform.mm
@@ -69,6 +69,11 @@ id<MTLCommandQueue> MetalPlatform::createCommandQueue(id<MTLDevice> device) noex
     return mCommandQueue;
 }
 
+id<MTLRenderCommandEncoder> MetalPlatform::createRenderCommandEncoder(id<MTLCommandBuffer> commandBuffer,
+                                                                    MTLRenderPassDescriptor* renderPassDescriptor) noexcept {
+    return [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
+}
+
 id<MTLCommandBuffer> MetalPlatform::createAndEnqueueCommandBuffer() noexcept {
     id<MTLCommandBuffer> commandBuffer = [mCommandQueue commandBuffer];
     [commandBuffer enqueue];


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1438](https://shapr3d.atlassian.net/browse/GFX-1438)

## Short description (What? How?) 📖

@veghbalazs modified the filament's metal backend to enable us inject any custom metal render command encoder. The injection can be achieved by overloading the createRenderCommandEncoder virtual function of the MetalPlatform class.

## Testing

### Design review 🎨

### Affected areas 🧭

### Special use-cases to test 🧷

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻
