### PR TITLE
[GFX-789] Add garbage collection of Engine to public API

### DIFF
--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -543,7 +543,6 @@ public:
 
     /**
      * Performs garbage collection on the Engine
-     *
      */
     void engineGC();
 };

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -540,6 +540,12 @@ public:
      * getUserTime()
      */
     void resetUserTime();
+
+    /**
+     * Performs garbage collection on the Engine
+     *
+     */
+    void engineGC();
 };
 
 } // namespace filament

--- a/filament/src/details/Renderer.h
+++ b/filament/src/details/Renderer.h
@@ -99,6 +99,8 @@ public:
     // Clean-up everything, this is typically called when the client calls Engine::destroyRenderer()
     void terminate(FEngine& engine);
 
+    void engineGC();
+
     void setDisplayInfo(DisplayInfo const& info) noexcept {
         mDisplayInfo = info;
     }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-789](https://shapr3d.atlassian.net/browse/GFX-789)

## Short description (What? How?) 📖
The stale `endFrame()` call was a hacky solution that we got away with on Apple platforms but won't on Windows.

`Renderer::endFrame()` -> `FrameInfoManager::endFrame()` -> `OpenGLDriver::endTimerQuery()` will crash in ANGLE, because you cannot end a query without starting any. This didn't cause problems in the Metal backend.

#### Solution

Wherever I put the garbage collection code, `PhysicallyBasedRenderer::Impl::Clear()` must access it. So I chose to add a new public method in Filament renderer. I chose not to call this new function from `renderStandaloneView()` because I feel it doesn't belong there (what if I want to render multiple views before performing a GC?)

## Testing

### Design review 🎨
<!--- List the design team members who approved the implementation -->

### Affected areas 🧭
<!--- List all areas that can be affected by the changes introduced -->

### Special use-cases to test 🧷
<!--- List special use-cases that could have changed -->

### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
Manual 💁‍♂️

Automated 💻
