### PR TITLE
[GFX-593] Preparations for Windows rendering 

### DIFF
--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -135,9 +135,6 @@ Texture* Texture::Builder::build(Engine& engine) {
     ASSERT_POSTCONDITION_NON_FATAL((swizzled && sampleable) || !swizzled,
             "Swizzled texture must be SAMPLEABLE");
 
-    ASSERT_POSTCONDITION_NON_FATAL((imported && sampleable) || !imported,
-            "Imported texture must be SAMPLEABLE");
-
     return upcast(engine).createTexture(*this);
 }
 

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -118,7 +118,7 @@
 #   define UTILS_HAS_HYPER_THREADING 0
 #endif
 
-#if defined(__EMSCRIPTEN__) || defined(FILAMENT_SINGLE_THREADED)
+#if defined(__EMSCRIPTEN__) || defined(FILAMENT_SINGLE_THREADED) || defined(FILAMENT_USE_ANGLE)
 #   define UTILS_HAS_THREADING 0
 #else
 #   define UTILS_HAS_THREADING 1


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-593](https://shapr3d.atlassian.net/browse/GFX-593)

## Short description (What? How?) 📖
This PR contains a few changes necessary to get offscreen rendering up and running on Windows with ANGLE.
 
### OpenGL context sharing

We use some OpenGL objects from both `PhysicallyBasedRenderer` and the OpenGL backend of Filament. This is needed to share the vertex/index buffer and the presentable texture between Gfx and Filament. However OGL objects belong to OGL contexts [which are thread local](https://www.khronos.org/opengl/wiki/OpenGL_Context):

> In order for any OpenGL commands to work, a **context must be current**... . The current **context is a thread-local** variable... . However, a single context **cannot be current in multiple threads** at the same time.

I chose to disable threading in Filament (Windows only!) as a quick fix and created [a follow-up ticket](https://shapr3d.atlassian.net/browse/GFX-1333) for a better solution.

### Non-sampleable imported textures

Filament only allows importing sampleable textures. This didn't work with ANGLE because we want to import the texture of the DXGI swap chain to Filament which is non-sampleable (and we can't change that). I loosened Filament validation to accept non-sampleable textures too. Checked the Metal backend and this change will cause no problems on Apple either.

## Testing

### Design review 🎨
<!--- List the design team members who approved the implementation -->

### Affected areas 🧭
<!--- List all areas that can be affected by the changes introduced -->

### Special use-cases to test 🧷
<!--- List special use-cases that could have changed -->

### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
Manual 💁‍♂️

Automated 💻
