### PR TITLE
[GFX-1741] Re-enable multithreading

### DIFF
--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -428,6 +428,12 @@ DECL_DRIVER_API_N(commit,
         backend::SwapChainHandle, sch)
 
 /*
+ * Offscreen
+ */
+
+DECL_DRIVER_API_0(makeCurrentOffscreen)
+
+/*
  * Setting rendering state
  * -----------------------
  */

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -58,7 +58,7 @@ public:
 
     // Called to make the OpenGL context active on the calling thread.
     virtual void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept = 0;
-    virtual void makeCurrent() noexcept = 0;
+    virtual void makeCurrentOffscreen() noexcept = 0;
 
     // Called once the current frame finishes drawing. Typically this should
     // swap draw buffers (i.e. for double-buffered rendering).

--- a/filament/backend/include/private/backend/OpenGLPlatform.h
+++ b/filament/backend/include/private/backend/OpenGLPlatform.h
@@ -58,6 +58,7 @@ public:
 
     // Called to make the OpenGL context active on the calling thread.
     virtual void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept = 0;
+    virtual void makeCurrent() noexcept = 0;
 
     // Called once the current frame finishes drawing. Typically this should
     // swap draw buffers (i.e. for double-buffered rendering).

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -926,6 +926,8 @@ void MetalDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> s
     }
 }
 
+void MetalDriver::makeCurrentOffscreen(int) {}
+
 void MetalDriver::commit(Handle<HwSwapChain> sch) {
     auto* swapChain = handle_cast<MetalSwapChain>(sch);
     swapChain->present();

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -275,6 +275,8 @@ void NoopDriver::setRenderPrimitiveRange(Handle<HwRenderPrimitive> rph,
 void NoopDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> readSch) {
 }
 
+void NoopDriver::makeCurrentOffscreen(int) {}
+
 void NoopDriver::commit(Handle<HwSwapChain> sch) {
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1621,6 +1621,11 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
     mPlatform.makeCurrent(scDraw->swapChain, scRead->swapChain);
 }
 
+void OpenGLDriver::makeCurrentOffscreen(int) {
+    DEBUG_MARKER()
+    mPlatform.makeCurrent();
+}
+
 // ------------------------------------------------------------------------------------------------
 // Updating driver objects
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1623,7 +1623,7 @@ void OpenGLDriver::makeCurrent(Handle<HwSwapChain> schDraw, Handle<HwSwapChain> 
 
 void OpenGLDriver::makeCurrentOffscreen(int) {
     DEBUG_MARKER()
-    mPlatform.makeCurrent();
+    mPlatform.makeCurrentOffscreen();
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/backend/src/opengl/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaGL.h
@@ -39,6 +39,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final;
     void destroySwapChain(SwapChain* swapChain) noexcept final;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
+    void makeCurrent() noexcept final;
     void commit(SwapChain* swapChain) noexcept final;
 
     Fence* createFence() noexcept final { return nullptr; }

--- a/filament/backend/src/opengl/PlatformCocoaGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaGL.h
@@ -39,7 +39,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final;
     void destroySwapChain(SwapChain* swapChain) noexcept final;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
-    void makeCurrent() noexcept final;
+    void makeCurrentOffscreen() noexcept final;
     void commit(SwapChain* swapChain) noexcept final;
 
     Fence* createFence() noexcept final { return nullptr; }

--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -62,7 +62,7 @@ CocoaGLSwapChain::CocoaGLSwapChain( NSView* inView )
         , currentWindowFrame(NSZeroRect) {
     NSView* __weak weakView = view;
     NSMutableArray* __weak weakObservers = observers;
-    
+
     void (^notificationHandler)(NSNotification *notification) = ^(NSNotification *notification) {
         NSView* strongView = weakView;
         if ((weakView != nil) && (weakObservers != nil)) {
@@ -70,7 +70,7 @@ CocoaGLSwapChain::CocoaGLSwapChain( NSView* inView )
             this->currentWindowFrame = strongView.window.frame;
         }
     };
-    
+
     // Various methods below should only be called from the main thread:
     // -[NSView bounds], -[NSView convertRectToBacking:], -[NSView window],
     // -[NSWindow frame], -[NSView superview],
@@ -115,7 +115,7 @@ CocoaGLSwapChain::CocoaGLSwapChain( NSView* inView )
                     queue: nil
                     usingBlock: notificationHandler];
                 [strongObservers addObject: observer];
-                
+
                 aView = aView.superview;
             }
         }
@@ -253,6 +253,8 @@ void PlatformCocoaGL::makeCurrent(Platform::SwapChain* drawSwapChain,
     swapChain->previousBounds = currentBounds;
     swapChain->previousWindowFrame = currentWindowFrame;
 }
+
+void PlatformCocoaGL::makeCurrent() noexcept {}
 
 void PlatformCocoaGL::commit(Platform::SwapChain* swapChain) noexcept {
     [pImpl->mGLContext flushBuffer];

--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -62,7 +62,7 @@ CocoaGLSwapChain::CocoaGLSwapChain( NSView* inView )
         , currentWindowFrame(NSZeroRect) {
     NSView* __weak weakView = view;
     NSMutableArray* __weak weakObservers = observers;
-
+    
     void (^notificationHandler)(NSNotification *notification) = ^(NSNotification *notification) {
         NSView* strongView = weakView;
         if ((weakView != nil) && (weakObservers != nil)) {
@@ -70,7 +70,7 @@ CocoaGLSwapChain::CocoaGLSwapChain( NSView* inView )
             this->currentWindowFrame = strongView.window.frame;
         }
     };
-
+    
     // Various methods below should only be called from the main thread:
     // -[NSView bounds], -[NSView convertRectToBacking:], -[NSView window],
     // -[NSWindow frame], -[NSView superview],
@@ -115,7 +115,7 @@ CocoaGLSwapChain::CocoaGLSwapChain( NSView* inView )
                     queue: nil
                     usingBlock: notificationHandler];
                 [strongObservers addObject: observer];
-
+                
                 aView = aView.superview;
             }
         }

--- a/filament/backend/src/opengl/PlatformCocoaGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaGL.mm
@@ -254,7 +254,7 @@ void PlatformCocoaGL::makeCurrent(Platform::SwapChain* drawSwapChain,
     swapChain->previousWindowFrame = currentWindowFrame;
 }
 
-void PlatformCocoaGL::makeCurrent() noexcept {}
+void PlatformCocoaGL::makeCurrentOffscreen() noexcept {}
 
 void PlatformCocoaGL::commit(Platform::SwapChain* swapChain) noexcept {
     [pImpl->mGLContext flushBuffer];

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.h
@@ -39,6 +39,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final;
     void destroySwapChain(SwapChain* swapChain) noexcept final;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
+    void makeCurrent() noexcept final;
     void commit(SwapChain* swapChain) noexcept final;
     void createDefaultRenderTarget(uint32_t& framebuffer, uint32_t& colorbuffer,
             uint32_t& depthbuffer) noexcept final;

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.h
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.h
@@ -39,7 +39,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final;
     void destroySwapChain(SwapChain* swapChain) noexcept final;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final;
-    void makeCurrent() noexcept final;
+    void makeCurrentOffscreen() noexcept final;
     void commit(SwapChain* swapChain) noexcept final;
     void createDefaultRenderTarget(uint32_t& framebuffer, uint32_t& colorbuffer,
             uint32_t& depthbuffer) noexcept final;

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
@@ -154,7 +154,7 @@ void PlatformCocoaTouchGL::makeCurrent(SwapChain* drawSwapChain, SwapChain* read
     }
 }
 
-void PlatformCocoaTouchGL::makeCurrent() noexcept {
+void PlatformCocoaTouchGL::makeCurrentOffscreen() noexcept {
   [EAGLContext setCurrentContext:pImpl->mGLContext];
 }
 

--- a/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
+++ b/filament/backend/src/opengl/PlatformCocoaTouchGL.mm
@@ -154,6 +154,10 @@ void PlatformCocoaTouchGL::makeCurrent(SwapChain* drawSwapChain, SwapChain* read
     }
 }
 
+void PlatformCocoaTouchGL::makeCurrent() noexcept {
+  [EAGLContext setCurrentContext:pImpl->mGLContext];
+}
+
 void PlatformCocoaTouchGL::commit(Platform::SwapChain* swapChain) noexcept {
     glBindRenderbuffer(GL_RENDERBUFFER, pImpl->mDefaultColorbuffer);
     [pImpl->mGLContext presentRenderbuffer:GL_RENDERBUFFER];

--- a/filament/backend/src/opengl/PlatformDummyGL.h
+++ b/filament/backend/src/opengl/PlatformDummyGL.h
@@ -37,6 +37,7 @@ public:
     }
     void destroySwapChain(SwapChain* swapChain) noexcept final override {}
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final override {}
+    void makeCurrent() noexcept final override {}
     void commit(SwapChain* swapChain) noexcept final override {}
 
     Fence* createFence() noexcept final override { return nullptr; }

--- a/filament/backend/src/opengl/PlatformDummyGL.h
+++ b/filament/backend/src/opengl/PlatformDummyGL.h
@@ -37,7 +37,7 @@ public:
     }
     void destroySwapChain(SwapChain* swapChain) noexcept final override {}
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final override {}
-    void makeCurrent() noexcept final override {}
+    void makeCurrentOffscreen() noexcept final override {}
     void commit(SwapChain* swapChain) noexcept final override {}
 
     Fence* createFence() noexcept final override { return nullptr; }

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -76,7 +76,7 @@ static void clearGlError() noexcept {
 // ---------------------------------------------------------------------------------------------
 
 PlatformEGL::PlatformEGL(EGLDisplay display) noexcept :
-        mEGLDisplay(display), mExternalEGLDisplay(display != EGL_NO_DISPLAY) {
+        mEGLDisplay(display), mIsEGLDisplayExternal(display != EGL_NO_DISPLAY) {
 }
 
 Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
@@ -235,7 +235,7 @@ error:
     mEGLDummySurface = EGL_NO_SURFACE;
     mEGLContext = EGL_NO_CONTEXT;
 
-    if (!mExternalEGLDisplay) {
+    if (!mIsEGLDisplayExternal) {
         eglTerminate(mEGLDisplay);
     }
     eglReleaseThread();
@@ -256,7 +256,7 @@ void PlatformEGL::terminate() noexcept {
     eglMakeCurrent(mEGLDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     eglDestroySurface(mEGLDisplay, mEGLDummySurface);
     eglDestroyContext(mEGLDisplay, mEGLContext);
-    if (!mExternalEGLDisplay) {
+    if (!mIsEGLDisplayExternal) {
         eglTerminate(mEGLDisplay);
     }
     eglReleaseThread();

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -80,7 +80,7 @@ PlatformEGL::PlatformEGL(EGLDisplay display) noexcept :
 }
 
 Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
-    if (mEGLDisplay == EGL_NO_DISPLAY) {
+    if (!mIsEGLDisplayExternal) {
         mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
         assert_invariant(mEGLDisplay != EGL_NO_DISPLAY);
 

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -75,21 +75,22 @@ static void clearGlError() noexcept {
 
 // ---------------------------------------------------------------------------------------------
 
-PlatformEGL::PlatformEGL(EGLDisplay display) noexcept : 
-        mEGLDisplay(display) {
+PlatformEGL::PlatformEGL(EGLDisplay display) noexcept :
+        mEGLDisplay(display), mExternalEGLDisplay(display != EGL_NO_DISPLAY) {
 }
 
 Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
     if (mEGLDisplay == EGL_NO_DISPLAY) {
         mEGLDisplay = eglGetDisplay(EGL_DEFAULT_DISPLAY);
         assert_invariant(mEGLDisplay != EGL_NO_DISPLAY);
-    }
 
-    EGLint major, minor;
-    EGLBoolean initialized = eglInitialize(mEGLDisplay, &major, &minor);
-    if (UTILS_UNLIKELY(!initialized)) {
-        slog.e << "eglInitialize failed" << io::endl;
-        return nullptr;
+        EGLint major, minor;
+        EGLBoolean initialized = eglInitialize(mEGLDisplay, &major, &minor);
+        if (UTILS_UNLIKELY(!initialized)) {
+            slog.e << "eglInitialize failed" << io::endl;
+            return nullptr;
+        }
+
     }
 
     importGLESExtensionsEntryPoints();
@@ -234,7 +235,9 @@ error:
     mEGLDummySurface = EGL_NO_SURFACE;
     mEGLContext = EGL_NO_CONTEXT;
 
-    eglTerminate(mEGLDisplay);
+    if (!mExternalEGLDisplay) {
+        eglTerminate(mEGLDisplay);
+    }
     eglReleaseThread();
 
     return nullptr;
@@ -253,7 +256,9 @@ void PlatformEGL::terminate() noexcept {
     eglMakeCurrent(mEGLDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
     eglDestroySurface(mEGLDisplay, mEGLDummySurface);
     eglDestroyContext(mEGLDisplay, mEGLContext);
-    eglTerminate(mEGLDisplay);
+    if (!mExternalEGLDisplay) {
+        eglTerminate(mEGLDisplay);
+    }
     eglReleaseThread();
 }
 

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -317,7 +317,7 @@ void PlatformEGL::makeCurrent(Platform::SwapChain* drawSwapChain,
     }
 }
 
-void PlatformEGL::makeCurrent() noexcept {
+void PlatformEGL::makeCurrentOffscreen() noexcept {
     makeCurrent(mEGLDummySurface, mEGLDummySurface);
 }
 

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -317,6 +317,10 @@ void PlatformEGL::makeCurrent(Platform::SwapChain* drawSwapChain,
     }
 }
 
+void PlatformEGL::makeCurrent() noexcept {
+    makeCurrent(mEGLDummySurface, mEGLDummySurface);
+}
+
 void PlatformEGL::commit(Platform::SwapChain* swapChain) noexcept {
     EGLSurface sur = (EGLSurface) swapChain;
     if (sur != EGL_NO_SURFACE) {

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -40,6 +40,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
+    void makeCurrent() noexcept override;
     void commit(SwapChain* swapChain) noexcept override;
 
     bool canCreateFence() noexcept override { return true; }
@@ -82,6 +83,7 @@ protected:
     EGLConfig mEGLConfig = EGL_NO_CONFIG_KHR;
     EGLConfig mEGLTransparentConfig = EGL_NO_CONFIG_KHR;
 
+    bool mExternalEGLDisplay = false;
     // supported extensions detected at runtime
     struct {
         bool OES_EGL_image_external_essl3 = false;

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -83,7 +83,7 @@ protected:
     EGLConfig mEGLConfig = EGL_NO_CONFIG_KHR;
     EGLConfig mEGLTransparentConfig = EGL_NO_CONFIG_KHR;
 
-    bool mExternalEGLDisplay = false;
+    bool mIsEGLDisplayExternal = false;
     // supported extensions detected at runtime
     struct {
         bool OES_EGL_image_external_essl3 = false;

--- a/filament/backend/src/opengl/PlatformEGL.h
+++ b/filament/backend/src/opengl/PlatformEGL.h
@@ -40,7 +40,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
-    void makeCurrent() noexcept override;
+    void makeCurrentOffscreen() noexcept override;
     void commit(SwapChain* swapChain) noexcept override;
 
     bool canCreateFence() noexcept override { return true; }

--- a/filament/backend/src/opengl/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/PlatformGLX.cpp
@@ -45,7 +45,7 @@ struct GLXFunctions {
     PFNGLXDESTROYPBUFFERPROC destroyPbuffer;
     PFNGLXMAKECONTEXTCURRENTPROC setCurrentContext;
 
-    /* 
+    /*
        When creating a shared GL context, we query the used
        GLX_FBCONFIG_ID to make sure our display framebuffer
        attributes match; otherwise making our context current
@@ -54,7 +54,7 @@ struct GLXFunctions {
     */
     PFNGLXQUERYCONTEXTPROC queryContext;
 
-    /* 
+    /*
        When creating a shared GL context, we select the matching
        GLXFBConfig that is used by the shared GL context. `getFBConfigs`
        will return all the available GLXFBConfigs.
@@ -274,6 +274,11 @@ void PlatformGLX::makeCurrent(
         Platform::SwapChain* drawSwapChain, Platform::SwapChain* readSwapChain) noexcept {
     g_glx.setCurrentContext(mGLXDisplay,
             (GLXDrawable)drawSwapChain, (GLXDrawable)readSwapChain, mGLXContext);
+}
+
+void PlatformGLX::makeCurrent() noexcept {
+    g_glx.setCurrentContext(mGLXDisplay,
+            (GLXDrawable)mDummySurface, (GLXDrawable)mDummySurface, mGLXContext);
 }
 
 void PlatformGLX::commit(Platform::SwapChain* swapChain) noexcept {

--- a/filament/backend/src/opengl/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/PlatformGLX.cpp
@@ -45,7 +45,7 @@ struct GLXFunctions {
     PFNGLXDESTROYPBUFFERPROC destroyPbuffer;
     PFNGLXMAKECONTEXTCURRENTPROC setCurrentContext;
 
-    /*
+    /* 
        When creating a shared GL context, we query the used
        GLX_FBCONFIG_ID to make sure our display framebuffer
        attributes match; otherwise making our context current
@@ -54,7 +54,7 @@ struct GLXFunctions {
     */
     PFNGLXQUERYCONTEXTPROC queryContext;
 
-    /*
+    /* 
        When creating a shared GL context, we select the matching
        GLXFBConfig that is used by the shared GL context. `getFBConfigs`
        will return all the available GLXFBConfigs.

--- a/filament/backend/src/opengl/PlatformGLX.cpp
+++ b/filament/backend/src/opengl/PlatformGLX.cpp
@@ -276,7 +276,7 @@ void PlatformGLX::makeCurrent(
             (GLXDrawable)drawSwapChain, (GLXDrawable)readSwapChain, mGLXContext);
 }
 
-void PlatformGLX::makeCurrent() noexcept {
+void PlatformGLX::makeCurrentOffscreen() noexcept {
     g_glx.setCurrentContext(mGLXDisplay,
             (GLXDrawable)mDummySurface, (GLXDrawable)mDummySurface, mGLXContext);
 }

--- a/filament/backend/src/opengl/PlatformGLX.h
+++ b/filament/backend/src/opengl/PlatformGLX.h
@@ -41,7 +41,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
-    void makeCurrent() noexcept override;
+    void makeCurrentOffscreen() noexcept override;
     void commit(SwapChain* swapChain) noexcept override;
 
     Fence* createFence() noexcept override;

--- a/filament/backend/src/opengl/PlatformGLX.h
+++ b/filament/backend/src/opengl/PlatformGLX.h
@@ -41,6 +41,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
+    void makeCurrent() noexcept override;
     void commit(SwapChain* swapChain) noexcept override;
 
     Fence* createFence() noexcept override;

--- a/filament/backend/src/opengl/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/PlatformWGL.cpp
@@ -21,8 +21,8 @@
 #include "OpenGLDriverFactory.h"
 
 #ifdef _MSC_VER
-    // this variable is checked in BlueGL.h (included from "gl_headers.h" right after this), 
-    // and prevents duplicate definition of OpenGL apis when building this file. 
+    // this variable is checked in BlueGL.h (included from "gl_headers.h" right after this),
+    // and prevents duplicate definition of OpenGL apis when building this file.
     // However, GL_GLEXT_PROTOTYPES need to be defined in BlueGL.h when included from other files.
     #define FILAMENT_PLATFORM_WGL
 #endif
@@ -247,6 +247,10 @@ void PlatformWGL::makeCurrent(Platform::SwapChain* drawSwapChain,
             wglMakeCurrent(0, NULL);
         }
     }
+}
+
+void PlatformWGL::makeCurrent() noexcept {
+    assert_invariant(false);
 }
 
 void PlatformWGL::commit(Platform::SwapChain* swapChain) noexcept {

--- a/filament/backend/src/opengl/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/PlatformWGL.cpp
@@ -21,8 +21,8 @@
 #include "OpenGLDriverFactory.h"
 
 #ifdef _MSC_VER
-    // this variable is checked in BlueGL.h (included from "gl_headers.h" right after this),
-    // and prevents duplicate definition of OpenGL apis when building this file.
+    // this variable is checked in BlueGL.h (included from "gl_headers.h" right after this), 
+    // and prevents duplicate definition of OpenGL apis when building this file. 
     // However, GL_GLEXT_PROTOTYPES need to be defined in BlueGL.h when included from other files.
     #define FILAMENT_PLATFORM_WGL
 #endif

--- a/filament/backend/src/opengl/PlatformWGL.cpp
+++ b/filament/backend/src/opengl/PlatformWGL.cpp
@@ -249,7 +249,7 @@ void PlatformWGL::makeCurrent(Platform::SwapChain* drawSwapChain,
     }
 }
 
-void PlatformWGL::makeCurrent() noexcept {
+void PlatformWGL::makeCurrentOffscreen() noexcept {
     assert_invariant(false);
 }
 

--- a/filament/backend/src/opengl/PlatformWGL.h
+++ b/filament/backend/src/opengl/PlatformWGL.h
@@ -37,7 +37,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
-    void makeCurrent() noexcept final override;
+    void makeCurrentOffscreen() noexcept final override;
     void commit(SwapChain* swapChain) noexcept override;
 
     Fence* createFence() noexcept override;

--- a/filament/backend/src/opengl/PlatformWGL.h
+++ b/filament/backend/src/opengl/PlatformWGL.h
@@ -37,6 +37,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept override;
     void destroySwapChain(SwapChain* swapChain) noexcept override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept override;
+    void makeCurrent() noexcept final override;
     void commit(SwapChain* swapChain) noexcept override;
 
     Fence* createFence() noexcept override;

--- a/filament/backend/src/opengl/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/PlatformWebGL.cpp
@@ -46,6 +46,8 @@ void PlatformWebGL::makeCurrent(Platform::SwapChain* drawSwapChain,
         Platform::SwapChain* readSwapChain) noexcept {
 }
 
+void PlatformWebGL::makeCurrent() noexcept {}
+
 void PlatformWebGL::commit(Platform::SwapChain* swapChain) noexcept {
 }
 

--- a/filament/backend/src/opengl/PlatformWebGL.cpp
+++ b/filament/backend/src/opengl/PlatformWebGL.cpp
@@ -46,7 +46,7 @@ void PlatformWebGL::makeCurrent(Platform::SwapChain* drawSwapChain,
         Platform::SwapChain* readSwapChain) noexcept {
 }
 
-void PlatformWebGL::makeCurrent() noexcept {}
+void PlatformWebGL::makeCurrentOffscreen() noexcept {}
 
 void PlatformWebGL::commit(Platform::SwapChain* swapChain) noexcept {
 }

--- a/filament/backend/src/opengl/PlatformWebGL.h
+++ b/filament/backend/src/opengl/PlatformWebGL.h
@@ -38,7 +38,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final override;
     void destroySwapChain(SwapChain* swapChain) noexcept final override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final override;
-    void makeCurrent() noexcept final override;
+    void makeCurrentOffscreen() noexcept final override;
     void commit(SwapChain* swapChain) noexcept final override;
 
     Fence* createFence() noexcept final override;

--- a/filament/backend/src/opengl/PlatformWebGL.h
+++ b/filament/backend/src/opengl/PlatformWebGL.h
@@ -38,6 +38,7 @@ public:
     SwapChain* createSwapChain(uint32_t width, uint32_t height, uint64_t& flags) noexcept final override;
     void destroySwapChain(SwapChain* swapChain) noexcept final override;
     void makeCurrent(SwapChain* drawSwapChain, SwapChain* readSwapChain) noexcept final override;
+    void makeCurrent() noexcept final override;
     void commit(SwapChain* swapChain) noexcept final override;
 
     Fence* createFence() noexcept final override;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1300,6 +1300,8 @@ void VulkanDriver::makeCurrent(Handle<HwSwapChain> drawSch, Handle<HwSwapChain> 
     surf.acquire();
 }
 
+void VulkanDriver::makeCurrentOffscreen(int) {}
+
 void VulkanDriver::commit(Handle<HwSwapChain> sch) {
     VulkanSwapChain& surface = *handle_cast<VulkanSwapChain*>(sch);
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -172,6 +172,7 @@ void FRenderer::renderStandaloneView(FView const* view) {
         engine.prepare();
 
         FEngine::DriverApi& driver = engine.getDriverApi();
+        driver.makeCurrentOffscreen();
         driver.beginFrame(steady_clock::now().time_since_epoch().count(), mFrameId);
 
         renderInternal(view);

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -33,7 +33,7 @@
 #if __has_attribute(visibility)
 #    define UTILS_PUBLIC  __attribute__((visibility("default")))
 #else
-#    define UTILS_PUBLIC  
+#    define UTILS_PUBLIC
 #endif
 
 #if __has_attribute(deprecated)
@@ -118,7 +118,7 @@
 #   define UTILS_HAS_HYPER_THREADING 0
 #endif
 
-#if defined(__EMSCRIPTEN__) || defined(FILAMENT_SINGLE_THREADED) || defined(FILAMENT_USE_ANGLE)
+#if defined(__EMSCRIPTEN__) || defined(FILAMENT_SINGLE_THREADED)
 #   define UTILS_HAS_THREADING 0
 #else
 #   define UTILS_HAS_THREADING 1
@@ -223,7 +223,7 @@ typedef SSIZE_T ssize_t;
 
 #if defined(_MSC_VER) && !defined(__PRETTY_FUNCTION__)
 #    define __PRETTY_FUNCTION__ __FUNCSIG__
-#endif 
+#endif
 
 
 

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -33,7 +33,7 @@
 #if __has_attribute(visibility)
 #    define UTILS_PUBLIC  __attribute__((visibility("default")))
 #else
-#    define UTILS_PUBLIC
+#    define UTILS_PUBLIC  
 #endif
 
 #if __has_attribute(deprecated)
@@ -223,7 +223,7 @@ typedef SSIZE_T ssize_t;
 
 #if defined(_MSC_VER) && !defined(__PRETTY_FUNCTION__)
 #    define __PRETTY_FUNCTION__ __FUNCSIG__
-#endif
+#endif 
 
 
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1741](https://shapr3d.atlassian.net/browse/GFX-1741)

## Short description (What? How?) 📖

For faster development previously we disabled threading in Filament, because the `OpenGL` backend wasn't prepared for the way we used it as an offscreen renderer. The resources were created on `Shapr3D`'s renderer thread, but was used in Filament on another thread, which only permitted according to the `OpenGL` specs, if the `OpenGL` context are shared between the threads. To re-enable multithreading, changes were made to the backend to make the thread current, on which the driver commands are executed. 

Furthermore an issue with `EGLDisplay`'s lifetime ownership was addressed: from now on Filament doesn't own the display.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Offscreen rendering

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Checked on my local Windows 10 machine, with the modification on the Shapr3D side. The build didn't generate any validation errors and the PhysicallyBasedRenderer startup performance became significantly better. 
![image](https://user-images.githubusercontent.com/100697016/177302600-ffa93af2-fc3b-4a9b-8198-87d5dcfcc8b2.png)

Automated 💻
n/a