### PR TITLE
[GFX-1796] Fix SSAO when using ANGLE

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -987,7 +987,11 @@ using FrameScheduledCallback = void(*)(PresentCallable callable, void* user);
 using FrameCompletedCallback = void(*)(void* user);
 
 enum class Workaround : uint16_t {
-    SPLIT_EASU
+    // The EASU pass must split because shader compiler flattens early-exit branch
+    SPLIT_EASU,
+    // Backend allows feedback loop with ancillary buffers (depth/stencil) as long as they're read-only for
+    // the whole render pass.
+    ALLOW_READ_ONLY_ANCILLARY_FEEDBACK_LOOP
 };
 
 } // namespace backend

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -702,6 +702,8 @@ bool MetalDriver::isWorkaroundNeeded(Workaround workaround) {
     switch (workaround) {
         case Workaround::SPLIT_EASU:
             return false;
+        case Workaround::ALLOW_READ_ONLY_ANCILLARY_FEEDBACK_LOOP:
+            return true;
     }
     return false;
 }

--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -71,7 +71,9 @@ OpenGLContext::OpenGLContext() noexcept {
         }
         initExtensionsGL(major, minor, exts);
         features.multisample_texture = true;
-    };
+        // feedback loops are allowed on GL desktop as long as writes are disabled
+        bugs.allow_read_only_ancillary_feedback_loop = true;
+    }
     assert_invariant(shaderModel != ShaderModel::UNKNOWN);
     mShaderModel = shaderModel;
 
@@ -83,6 +85,9 @@ OpenGLContext::OpenGLContext() noexcept {
         bugs.disable_sidecar_blit_into_texture_array = true;
         // early exit condition is flattened in EASU code
         bugs.split_easu = true;
+
+        // qualcomm seems to have no problem with this (which is good for us)
+        bugs.allow_read_only_ancillary_feedback_loop = true;
     } else if (strstr(renderer, "Mali")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
         if (strstr(renderer, "Mali-T")) {
@@ -95,9 +100,13 @@ OpenGLContext::OpenGLContext() noexcept {
         if (strstr(renderer, "Mali-G")) {
             // note: We have verified that timer queries work well at least on some Mali-G.
         }
+
+        // Mali seems to have no problem with this (which is good for us)
+        bugs.allow_read_only_ancillary_feedback_loop = true;
     } else if (strstr(renderer, "Intel")) {
         bugs.vao_doesnt_store_element_array_buffer_binding = true;
-    } else if (strstr(renderer, "PowerVR") || strstr(renderer, "Apple")) {
+    } else if (strstr(renderer, "PowerVR")) {
+    } else if (strstr(renderer, "Apple")) {
     } else if (strstr(renderer, "Tegra") || strstr(renderer, "GeForce") || strstr(renderer, "NV")) {
     } else if (strstr(renderer, "Vivante")) {
     } else if (strstr(renderer, "AMD") || strstr(renderer, "ATI")) {

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -196,6 +196,11 @@ public:
         // Some drivers incorrectly flatten the early exit condition in the EASU code, in which
         // case we need an alternative algorithm
         bool split_easu = false;
+
+        // GLES doesn't allow feedback loops even if writes are disabled. So take we the point of
+        // view that this is generally forbidden. However, this restriction is lifted on desktop
+        // GL and Vulkan and probably Metal.
+        bool allow_read_only_ancillary_feedback_loop = false;
     } bugs;
 
     // state getters -- as needed.

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1850,12 +1850,11 @@ void OpenGLDriver::setMinMaxLevels(Handle<HwTexture> th, uint32_t minLevel, uint
     // Must fit within int8_t.
     assert_invariant(minLevel <= 0x7f && maxLevel <= 0x7f);
 
-    // GFX-1583
-    //t->gl.baseLevel = minLevel;
-    //glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
+    t->gl.baseLevel = minLevel;
+    glTexParameteri(t->gl.target, GL_TEXTURE_BASE_LEVEL, t->gl.baseLevel);
 
-    //t->gl.maxLevel = maxLevel; // NOTE: according to the GL spec, the default value of this 1000
-    //glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
+    t->gl.maxLevel = maxLevel; // NOTE: according to the GL spec, the default value of this 1000
+    glTexParameteri(t->gl.target, GL_TEXTURE_MAX_LEVEL, t->gl.maxLevel);
 }
 
 void OpenGLDriver::update3DImage(Handle<HwTexture> th,
@@ -3184,15 +3183,14 @@ void OpenGLDriver::updateTextureLodRange(GLTexture* texture, int8_t targetLevel)
         if (targetLevel < texture->gl.baseLevel || targetLevel > texture->gl.maxLevel) {
             bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, texture);
             gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
-            // GFX-1583
-            //if (targetLevel < texture->gl.baseLevel) {
-            //    texture->gl.baseLevel = targetLevel;
-            //    glTexParameteri(texture->gl.target, GL_TEXTURE_BASE_LEVEL, targetLevel);
-            //}
-            //if (targetLevel > texture->gl.maxLevel) {
-            //    texture->gl.maxLevel = targetLevel;
-            //    glTexParameteri(texture->gl.target, GL_TEXTURE_MAX_LEVEL, targetLevel);
-            //}
+            if (targetLevel < texture->gl.baseLevel) {
+                texture->gl.baseLevel = targetLevel;
+                glTexParameteri(texture->gl.target, GL_TEXTURE_BASE_LEVEL, targetLevel);
+            }
+            if (targetLevel > texture->gl.maxLevel) {
+                texture->gl.maxLevel = targetLevel;
+                glTexParameteri(texture->gl.target, GL_TEXTURE_MAX_LEVEL, targetLevel);
+            }
         }
         CHECK_GL_ERROR(utils::slog.e)
     }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1585,6 +1585,8 @@ bool OpenGLDriver::isWorkaroundNeeded(Workaround workaround) {
     switch (workaround) {
         case Workaround::SPLIT_EASU:
             return mContext.bugs.split_easu;
+        case Workaround::ALLOW_READ_ONLY_ANCILLARY_FEEDBACK_LOOP:
+            return mContext.bugs.allow_read_only_ancillary_feedback_loop;
     }
     return false;
 }

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -829,6 +829,8 @@ bool VulkanDriver::isWorkaroundNeeded(Workaround workaround) {
         case Workaround::SPLIT_EASU:
             // early exit condition is flattened in EASU code
             return deviceProperties.vendorID == 0x5143; // Qualcomm
+        case Workaround::ALLOW_READ_ONLY_ANCILLARY_FEEDBACK_LOOP:
+            return true;
     }
     return false;
 }

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -242,7 +242,10 @@ void PostProcessManager::init() noexcept {
     //debugRegistry.registerProperty("d.ssao.kernelSize", &engine.debug.ssao.kernelSize);
     //debugRegistry.registerProperty("d.ssao.stddev", &engine.debug.ssao.stddev);
 
-    mWorkaroundSplitEasu = driver.isWorkaroundNeeded(Workaround::SPLIT_EASU);
+    mWorkaroundSplitEasu =
+            driver.isWorkaroundNeeded(Workaround::SPLIT_EASU);
+    mWorkaroundAllowReadOnlyAncillaryFeedbackLoop =
+            driver.isWorkaroundNeeded(Workaround::ALLOW_READ_ONLY_ANCILLARY_FEEDBACK_LOOP);
 
     #pragma nounroll
     for (auto const& info : sMaterialList) {
@@ -506,6 +509,48 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
 
     const bool lowPassFilterEnabled = options.lowPassFilter != QualityLevel::LOW;
 
+    /*
+     * GLES considers there is a feedback loop when a buffer is used as both a texture and
+     * attachment, even if writes are not enabled. This restriction is lifted on desktop GL and
+     * Vulkan. The Metal situation is unclear.
+     * In this case, we need to duplicate the depth texture to use it as an attachment.
+     * The pass below that does this is automatically culled if not needed, which is decided by
+     * each backend.
+     */
+
+    struct DuplicateDepthPassData {
+        FrameGraphId<FrameGraphTexture> input;
+        FrameGraphId<FrameGraphTexture> output;
+    };
+
+    auto& duplicateDepthPass = fg.addPass<DuplicateDepthPassData>("Duplicate Depth Pass",
+            [&](FrameGraph::Builder& builder, auto& data) {
+                // read the depth as an attachment
+                data.input = builder.read(depth,
+                        FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
+                auto desc = builder.getDescriptor(data.input);
+                desc.levels = 1; // only copy the base level
+                // create a new buffer for the copy
+                data.output = builder.createTexture("Depth Texture Copy", desc);
+                data.output = builder.write(data.output,
+                        FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
+                builder.declareRenderPass("Depth Copy RenderTarget", {{ .depth = data.output }});
+            },
+            [=](FrameGraphResources const& resources,
+                    auto const& data, DriverApi& driver) {
+                auto const& desc = resources.getDescriptor(data.input);
+                auto out = resources.getRenderPassInfo();
+                // create a temporary render target for source, needed for the blit.
+                auto inTarget = driver.createRenderTarget(TargetBufferFlags::DEPTH,
+                        desc.width, desc.height, desc.samples, {},
+                        resources.getTexture(data.input), {});
+                driver.blit(TargetBufferFlags::DEPTH,
+                        out.target, out.params.viewport,
+                        inTarget, out.params.viewport,
+                        SamplerMagFilter::NEAREST);
+                driver.destroyRenderTarget(inTarget);
+            });
+
     auto& SSAOPass = fg.addPass<SSAOPassData>("SSAO Pass",
             [&](FrameGraph::Builder& builder, auto& data) {
                 auto const& desc = builder.getDescriptor(depth);
@@ -535,9 +580,15 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::screenSpaceAmbientOcclusion(
                 // reading into it even though they were not written in the depth buffer.
                 // The bilateral filter in the blur pass will ignore pixels at infinity.
 
-                data.depth = builder.read(data.depth, FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
+                auto depthAttachment = data.depth;
+                if (!mWorkaroundAllowReadOnlyAncillaryFeedbackLoop) {
+                    depthAttachment = duplicateDepthPass->output;
+                }
+
+                depthAttachment = builder.read(depthAttachment,
+                        FrameGraphTexture::Usage::DEPTH_ATTACHMENT);
                 builder.declareRenderPass("SSAO Target", {
-                        .attachments = { .color = { data.ao, data.bn }, .depth = data.depth },
+                        .attachments = { .color = { data.ao, data.bn }, .depth = depthAttachment },
                         .clearColor = { 1.0f },
                         .clearFlags = TargetBufferFlags::COLOR0 | TargetBufferFlags::COLOR1
                 });

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -232,6 +232,7 @@ private:
     const math::float2 mHaltonSamples[16];
 
     bool mWorkaroundSplitEasu : 1;
+    bool mWorkaroundAllowReadOnlyAncillaryFeedbackLoop : 1;
 };
 
 } // namespace filament


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1796](https://shapr3d.atlassian.net/browse/GFX-1796)

## Short description (What? How?) 📖
The fix consists of two parts:
- First, the following upstream PR is cherry-picked: https://github.com/google/filament/pull/5226. It prevents a feedback loop disallowed in OpenGL ES (and D3D11), wherein the same depth texture is both used as a depth attachment and sampled in shader (while depth write is turned off).
- Second, it uncomments the two snippets of code in `OpenGLDriver` we had to comment out in https://github.com/shapr3d/filament/pull/64. We did that because it caused excessive copies and even D3D11 violations in ANGLE, but now that's fixed in https://github.com/shapr3d/angle/pull/10. Changing base-max levels of textures is required to avoid other feedback loops.

## Testing

### Affected areas 🧭
OpenGL backend. Post-process effects, primarily SSAO.

### Special use-cases to test 🧷
Use ANGLE.

### How did you test it? 🤔
Manual 💁‍♂️
Turned on SSAO in the `shadowtest` example project, and ran it using ANGLE. 
