### PR TITLE
[BUILD-676] Fix 'shift count too big' warning on VS 2022

### DIFF
--- a/libs/utils/include/utils/algorithm.h
+++ b/libs/utils/include/utils/algorithm.h
@@ -47,19 +47,12 @@ constexpr inline T clz(T x) noexcept {
     x |= (x >> 4u);
     x |= (x >> 8u);
     x |= (x >> 16u);
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4293)
-#endif
-    if (sizeof(T) * CHAR_BIT >= 64) {   // just to silence compiler warning
+    if constexpr (sizeof(T) * CHAR_BIT >= 64) {   // just to silence compiler warning
         x |= (x >> 32u);
     }
-    if (sizeof(T) * CHAR_BIT >= 128) {   // just to silence compiler warning
+    if constexpr (sizeof(T) * CHAR_BIT >= 128) {   // just to silence compiler warning
         x |= (x >> 64u);
     }
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
     return T(sizeof(T) * CHAR_BIT) - details::popcount(x);
 }
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[BUILD-676](https://shapr3d.atlassian.net/browse/BUILD-676)

## Short description (What? How?) 📖
Replace lengthy MSVC warning disable macros with `if constexpr()`, (continuing https://github.com/shapr3d/filament/pull/75). Visual Studio 2022 ignores the disabled warning for some reason, but we have a more robust alternative anyway.

## Testing

### Affected areas 🧭
Building the project with warnings treated as errors.

### Special use-cases to test 🧷
Use Visual Studio 2022.

### How did you test it? 🤔
Manual 💁‍♂️
Built sample apps and Shapr3D.
