### PR TITLE
[Added] Missing doublesided annotations

### DIFF
--- a/filament/src/materials/Cloth.mat
+++ b/filament/src/materials/Cloth.mat
@@ -2,6 +2,7 @@ material {
     name : Cloth,
     shadingModel : cloth,
     specularAntiAliasing : true,
+    doubleSided: true,
     postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/filament/src/materials/Opaque.mat
+++ b/filament/src/materials/Opaque.mat
@@ -1,6 +1,7 @@
 material {
     name : Opaque,
     specularAntiAliasing : true,
+    doubleSided: true,
     postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/filament/src/materials/Refractive.mat
+++ b/filament/src/materials/Refractive.mat
@@ -2,6 +2,7 @@ material {
     name : Refractive,
     shadingModel : lit,
     specularAntiAliasing : true,
+    doubleSided: true,
     refractionType : solid,
     refractionMode : screenspace,
     postLightingBlending : transparent,

--- a/filament/src/materials/Subsurface.mat
+++ b/filament/src/materials/Subsurface.mat
@@ -2,6 +2,7 @@ material {
     name : Subsurface,
     shadingModel : subsurface,
     specularAntiAliasing : true,
+    doubleSided: true,
     postLightingBlending : transparent,
     parameters : [
         //////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Jira ticket URL (Why?)
n/a

## Short description (What? How?) 📖
The doublesided rendering tag was only added in the Shapr3D repo to the materials. This PR backports those changes to the source repo.

## Upstreaming scope
n/a (Shapr only changes)

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
n/a

Automated 💻
n/a