### PR TITLE
[GFX-1868] Fix W3 level MSVC warnings in public headers

### DIFF
--- a/filament/backend/src/opengl/OpenGLContext.cpp
+++ b/filament/backend/src/opengl/OpenGLContext.cpp
@@ -374,7 +374,7 @@ void OpenGLContext::unbindTexture(GLenum target, GLuint texture_id) noexcept {
 
 void OpenGLContext::unbindSampler(GLuint sampler) noexcept {
     // unbind this sampler from all the units it might be bound to
-#pragma nounroll    // clang generates >800B of code!!!
+UTILS_NOUNROLL    // clang generates >800B of code!!!
     for (GLuint unit = 0; unit < MAX_TEXTURE_UNIT_COUNT; unit++) {
         if (state.textures.units[unit].sampler == sampler) {
             bindSampler(unit, 0);
@@ -387,7 +387,7 @@ void OpenGLContext::deleteBuffers(GLsizei n, const GLuint* buffers, GLenum targe
     // bindings of bound buffers are reset to 0
     const size_t targetIndex = getIndexForBufferTarget(target);
     auto& genericBuffer = state.buffers.genericBinding[targetIndex];
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (GLsizei i = 0; i < n; ++i) {
         if (genericBuffer == buffers[i]) {
             genericBuffer = 0;
@@ -395,9 +395,9 @@ void OpenGLContext::deleteBuffers(GLsizei n, const GLuint* buffers, GLenum targe
     }
     if (target == GL_UNIFORM_BUFFER || target == GL_TRANSFORM_FEEDBACK_BUFFER) {
         auto& indexedBuffer = state.buffers.targets[targetIndex];
-        #pragma nounroll // clang generates >1 KiB of code!!
+        UTILS_NOUNROLL // clang generates >1 KiB of code!!
         for (GLsizei i = 0; i < n; ++i) {
-            #pragma nounroll
+            UTILS_NOUNROLL
             for (auto& buffer : indexedBuffer.buffers) {
                 if (buffer.name == buffers[i]) {
                     buffer.name = 0;

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1974,7 +1974,7 @@ void OpenGLDriver::setTextureData(GLTexture* t,
             bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
             gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
             FaceOffsets const& offsets = *faceOffsets;
-#pragma nounroll
+UTILS_NOUNROLL
             for (size_t face = 0; face < 6; face++) {
                 GLenum target = getCubemapTarget(TextureCubemapFace(face));
                 glTexSubImage2D(target, GLint(level), 0, 0,
@@ -2059,7 +2059,7 @@ void OpenGLDriver::setCompressedTextureData(GLTexture* t,  uint32_t level,
             bindTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1, t);
             gl.activeTexture(OpenGLContext::MAX_TEXTURE_UNIT_COUNT - 1);
             FaceOffsets const& offsets = *faceOffsets;
-#pragma nounroll
+UTILS_NOUNROLL
             for (size_t face = 0; face < 6; face++) {
                 GLenum target = getCubemapTarget(TextureCubemapFace(face));
                 glCompressedTexSubImage2D(target, GLint(level), 0, 0,

--- a/filament/backend/src/opengl/OpenGLProgram.cpp
+++ b/filament/backend/src/opengl/OpenGLProgram.cpp
@@ -42,7 +42,7 @@ OpenGLProgram::OpenGLProgram(OpenGLDriver* gl, const Program& programBuilder) no
     OpenGLContext& context = gl->getContext();
 
     // build all shaders
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
         GLenum glShaderType;
         Shader type = (Shader)i;
@@ -166,7 +166,7 @@ highp uint packHalf2x16(vec2 v) {
 
         // Associate each UniformBlock in the program to a known binding.
         auto const& uniformBlockInfo = programBuilder.getUniformBlockInfo();
-        #pragma nounroll
+        UTILS_NOUNROLL
         for (GLuint binding = 0, n = uniformBlockInfo.size(); binding < n; binding++) {
             auto const& name = uniformBlockInfo[binding];
             if (!name.empty()) {
@@ -188,7 +188,7 @@ highp uint packHalf2x16(vec2 v) {
             uint8_t numUsedBindings = 0;
             uint8_t tmu = 0;
 
-            #pragma nounroll
+            UTILS_NOUNROLL
             for (size_t i = 0, c = samplerGroupInfo.size(); i < c; i++) {
                 auto const& groupInfo = samplerGroupInfo[i];
                 if (!groupInfo.empty()) {
@@ -233,7 +233,7 @@ OpenGLProgram::~OpenGLProgram() noexcept {
     const bool isValid = mIsValid;
     GLuint program = gl.program;
     if (validShaderSet) {
-        #pragma nounroll
+        UTILS_NOUNROLL
         for (size_t i = 0; i < Program::SHADER_TYPE_COUNT; i++) {
             if (validShaderSet & (1U << i)) {
                 const GLuint shader = gl.shaders[i];

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -247,7 +247,7 @@ void PostProcessManager::init() noexcept {
     mWorkaroundAllowReadOnlyAncillaryFeedbackLoop =
             driver.isWorkaroundNeeded(Workaround::ALLOW_READ_ONLY_ANCILLARY_FEEDBACK_LOOP);
 
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (auto const& info : sMaterialList) {
         registerPostProcessMaterial(info.name, info.data, info.size);
     }
@@ -2243,7 +2243,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::taa(FrameGraph& fg,
 
                 // this doesn't get vectorized (probably because of exp()), so don't bother
                 // unrolling it.
-                #pragma nounroll
+                UTILS_NOUNROLL
                 for (size_t i = 0; i < 9; i++) {
                     float2 d = sampleOffsets[i] - current.jitter;
                     d *= 1.0f / taaOptions.filterWidth;

--- a/filament/src/ShadowMap.cpp
+++ b/filament/src/ShadowMap.cpp
@@ -692,7 +692,7 @@ float2 ShadowMap::computeNearFar(const mat4f& view,
 float2 ShadowMap::computeNearFarOfWarpSpace(mat4f const& lightView,
         float3 const* wsVertices, size_t count) noexcept {
     float2 nearFar = { std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest() };
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (size_t i = 0; i < count; i++) {
         // we're on the y axis in light space (looking down to +y)
         float c = mat4f::project(lightView, wsVertices[i]).y;
@@ -833,7 +833,7 @@ size_t ShadowMap::intersectFrustumWithBox(
     const Aabb::Corners wsSceneReceiversCorners = wsBox.getCorners();
 
     // a) Keep the frustum's vertices that are known to be inside the scene's box
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (size_t i = 0; i < 8; i++) {
         float3 p = wsFrustumCorners[i];
         outVertices[vertexCount] = p;
@@ -856,7 +856,7 @@ size_t ShadowMap::intersectFrustumWithBox(
         // We need to handle the case where a corner of the box lies exactly on a plane of
         // the frustum. This actually happens often due to fitting light-space
         // We fudge the distance to the plane by a small amount.
-        #pragma nounroll
+        UTILS_NOUNROLL
         for (float3 p : wsSceneReceiversCorners) {
             outVertices[vertexCount] = p;
             float l = dot(wsFrustumPlanes[0].xyz, p) + wsFrustumPlanes[0].w;
@@ -919,7 +919,7 @@ size_t ShadowMap::intersectFrustum(
         float3 const* segmentsVertices,
         float3 const* quadsVertices) noexcept {
 
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (const Segment segment : sBoxSegments) {
         const float3 s0{ segmentsVertices[segment.v0] };
         const float3 s1{ segmentsVertices[segment.v1] };

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -171,7 +171,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
 
     auto const& declaredAttributes = mDeclaredAttributes;
     auto const& attributes = mAttributes;
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (size_t i = 0, n = attributeArray.size(); i < n; ++i) {
         if (declaredAttributes[i]) {
             const uint32_t offset = attributes[i].offset;
@@ -201,7 +201,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
 
     // If buffer objects are not enabled at the API level, then we create them internally.
     if (!mBufferObjectsEnabled) {
-        #pragma nounroll
+        UTILS_NOUNROLL
         for (size_t i = 0; i < MAX_VERTEX_BUFFER_COUNT; ++i) {
             if (bufferSizes[i] > 0) {
                 BufferObjectHandle bo = driver.createBufferObject(bufferSizes[i],

--- a/libs/filamentapp/include/filamentapp/MeshAssimp.h
+++ b/libs/filamentapp/include/filamentapp/MeshAssimp.h
@@ -131,8 +131,8 @@ private:
     mutable std::unordered_map<uint64_t, filament::Material*> mGltfMaterialCache;
     filament::Texture* mDefaultMap = nullptr;
     filament::Texture* mDefaultNormalMap = nullptr;
-    float mDefaultMetallic = 0.0;
-    float mDefaultRoughness = 0.4;
+    float mDefaultMetallic = 0.0f;
+    float mDefaultRoughness = 0.4f;
     filament::sRGBColor mDefaultEmissive = filament::sRGBColor({0.0f, 0.0f, 0.0f});
 
     std::vector<utils::Entity> mRenderables;

--- a/libs/image/include/image/ColorTransform.h
+++ b/libs/image/include/image/ColorTransform.h
@@ -150,7 +150,7 @@ template<>
 inline filament::math::float3 linearToSRGB(const filament::math::float3& color) {
     using filament::math::float3;
     float3 sRGBColor{color};
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (size_t i = 0; i < sRGBColor.size(); i++) {
         sRGBColor[i] = (sRGBColor[i] <= 0.0031308f) ?
                 sRGBColor[i] * 12.92f : (powf(sRGBColor[i], 1.0f / 2.4f) * 1.055f) - 0.055f;

--- a/libs/image/include/image/ColorTransform.h
+++ b/libs/image/include/image/ColorTransform.h
@@ -209,8 +209,7 @@ std::unique_ptr<uint8_t[]> fromLinearToRGBM(const LinearImage& image) {
     using namespace filament::math;
     size_t w = image.getWidth();
     size_t h = image.getHeight();
-    UTILS_UNUSED_IN_RELEASE size_t channels = image.getChannels();
-    assert(channels >= 3);
+    assert(image.getChannels() >= 3);
     std::unique_ptr<uint8_t[]> dst(new uint8_t[w * h * 4 * sizeof(T)]);
     T* d = reinterpret_cast<T*>(dst.get());
     for (size_t y = 0; y < h; ++y) {
@@ -231,8 +230,7 @@ inline std::unique_ptr<uint8_t[]> fromLinearToRGB_10_11_11_REV(const LinearImage
     using namespace filament::math;
     size_t w = image.getWidth();
     size_t h = image.getHeight();
-    UTILS_UNUSED_IN_RELEASE size_t channels = image.getChannels();
-    assert(channels >= 3);
+    assert(image.getChannels() >= 3);
     std::unique_ptr<uint8_t[]> dst(new uint8_t[w * h * sizeof(uint32_t)]);
     uint8_t* d = dst.get();
     for (size_t y = 0; y < h; ++y) {

--- a/libs/math/tests/test_half.cpp
+++ b/libs/math/tests/test_half.cpp
@@ -62,7 +62,7 @@ TEST_F(HalfTest, Basics) {
     EXPECT_EQ(0x8001, getBits(half(-5.96046e-8)));      // if handled, should be: 0x8001
 
     // test all exactly representable integers
-    #pragma nounroll
+    MATH_NOUNROLL
     for (int i = -2048; i <= 2048; ++i) {
         half h = float(i);
         EXPECT_EQ(i, float(h));
@@ -97,7 +97,7 @@ using fp11 = fp<0, 5, 6>;
 
 TEST_F(HalfTest, fp10) {
     // test all exactly representable integers
-    #pragma nounroll
+    MATH_NOUNROLL
     for (int i = 0; i <= 64; ++i) {
         fp10 h = fp10::fromf(float(i));
         EXPECT_EQ(i, fp10::tof(h));
@@ -106,7 +106,7 @@ TEST_F(HalfTest, fp10) {
 
 TEST_F(HalfTest, fp11) {
     // test all exactly representable integers
-    #pragma nounroll
+    MATH_NOUNROLL
     for (int i = 0; i <= 128; ++i) {
         fp11 h = fp11::fromf(float(i));
         EXPECT_EQ(i, fp11::tof(h));

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -129,7 +129,7 @@ public:
 private:
     void* end() UTILS_RESTRICT noexcept { return pointermath::add(mBegin, mSize); }
     void* current() UTILS_RESTRICT noexcept { return pointermath::add(mBegin, mCur); }
-    void set_current(void* p) UTILS_RESTRICT noexcept { mCur = uintptr_t(p) - uintptr_t(mBegin); }
+    void set_current(void* p) UTILS_RESTRICT noexcept { mCur = uint32_t(uintptr_t(p) - uintptr_t(mBegin)); }
 
     void* mBegin = nullptr;
     uint32_t mSize = 0;

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -51,7 +51,7 @@ static inline P* align(P* p, size_t alignment) noexcept {
 template <typename P>
 static inline P* align(P* p, size_t alignment, size_t offset) noexcept {
     P* const r = align(add(p, offset), alignment);
-    assert(pointermath::add(r, -offset) >= p);
+    assert(pointermath::add(r, ~(offset - 1)) >= p);
     return r;
 }
 

--- a/libs/utils/include/utils/Allocator.h
+++ b/libs/utils/include/utils/Allocator.h
@@ -51,7 +51,7 @@ static inline P* align(P* p, size_t alignment) noexcept {
 template <typename P>
 static inline P* align(P* p, size_t alignment, size_t offset) noexcept {
     P* const r = align(add(p, offset), alignment);
-    assert(pointermath::add(r, ~(offset - 1)) >= p);
+    assert(r >= add(p, offset));
     return r;
 }
 

--- a/libs/utils/include/utils/BinaryTreeArray.h
+++ b/libs/utils/include/utils/BinaryTreeArray.h
@@ -53,7 +53,7 @@ class BinaryTreeArray {
 public:
     static size_t count(size_t height) noexcept { return  (1u << height) - 1; }
     static size_t left(size_t i, size_t height) noexcept { return i + 1; }
-    static size_t right(size_t i, size_t height) noexcept { return i + (1u << (height - 1)); }
+    static size_t right(size_t i, size_t height) noexcept { return i + (1ull << (height - 1)); }
 
     // this builds the depth-first binary tree array top down (post-order)
     template<typename Leaf, typename Node>

--- a/libs/utils/include/utils/BinaryTreeArray.h
+++ b/libs/utils/include/utils/BinaryTreeArray.h
@@ -53,7 +53,7 @@ class BinaryTreeArray {
 public:
     static size_t count(size_t height) noexcept { return  (1u << height) - 1; }
     static size_t left(size_t i, size_t height) noexcept { return i + 1; }
-    static size_t right(size_t i, size_t height) noexcept { return i + (1ull << (height - 1)); }
+    static size_t right(size_t i, size_t height) noexcept { return i + (size_t(1) << (height - 1)); }
 
     // this builds the depth-first binary tree array top down (post-order)
     template<typename Leaf, typename Node>

--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -322,7 +322,7 @@ private:
     }
 
     void construct(iterator first, iterator last, const_reference proto) noexcept {
-        #pragma nounroll
+        UTILS_NOUNROLL
         while (first != last) {
             storage_traits::construct(allocator(), first++, proto);
         }
@@ -330,7 +330,7 @@ private:
 
     // should this be NOINLINE?
     void construct_non_trivial(iterator first, iterator last) noexcept {
-        #pragma nounroll
+        UTILS_NOUNROLL
         while (first != last) {
             storage_traits::construct(allocator(), first++);
         }
@@ -346,7 +346,7 @@ private:
 
     // should this be NOINLINE?
     void destroy_non_trivial(iterator first, iterator last) noexcept {
-        #pragma nounroll
+        UTILS_NOUNROLL
         while (first != last) {
             storage_traits::destroy(allocator(), --last);
         }

--- a/libs/utils/include/utils/SingleInstanceComponentManager.h
+++ b/libs/utils/include/utils/SingleInstanceComponentManager.h
@@ -237,7 +237,7 @@ protected:
         size_t count = getComponentCount();
         size_t aliveInARow = 0;
         default_random_engine& rng = mRng;
-        #pragma nounroll
+        UTILS_NOUNROLL
         while (count && aliveInARow < ratio) {
             // note: using the modulo favorizes lower number
             size_t i = rng() % count;

--- a/libs/utils/include/utils/StructureOfArrays.h
+++ b/libs/utils/include/utils/StructureOfArrays.h
@@ -525,7 +525,7 @@ private:
         // hopefully most of this gets unrolled and inlined
         std::array<size_t, kArrayCount> offsets;
         offsets[0] = 0;
-        #pragma unroll
+        UTILS_UNROLL
         for (size_t i = 1; i < kArrayCount; i++) {
             size_t unalignment = sizes[i - 1] % align;
             size_t alignment = unalignment ? (align - unalignment) : 0;

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -211,8 +211,13 @@ typedef SSIZE_T ssize_t;
 
 #ifdef _MSC_VER
 #   define UTILS_EMPTY_BASES __declspec(empty_bases)
+
+// MSVC does not support loop unrolling hints
+#   define UTILS_NOUNROLL
 #else
 #   define UTILS_EMPTY_BASES
+// C++11 allows pragmas to be specified as part of defines using the _Pragma syntax.
+#   define UTILS_NOUNROLL _Pragma("nounroll")
 #endif
 
 #if defined(WIN32) || defined(_WIN32)

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -212,6 +212,12 @@ typedef SSIZE_T ssize_t;
 #ifdef _MSC_VER
 #   define UTILS_EMPTY_BASES __declspec(empty_bases)
 
+// The ISO C and C++ standard didn't include strdup function up until 6/2019.
+// However, it reserved function names that begin with 'str' and a lowercase latter.
+// Even though strdup is a valid POSIX function and even though MSVC implements it,
+// it issues a warning about the non-standard naming and suggests using their naming: _strdup
+#define strdup _strdup
+
 // MSVC does not support loop unrolling hints
 #   define UTILS_UNROLL
 #   define UTILS_NOUNROLL

--- a/libs/utils/include/utils/compiler.h
+++ b/libs/utils/include/utils/compiler.h
@@ -213,10 +213,12 @@ typedef SSIZE_T ssize_t;
 #   define UTILS_EMPTY_BASES __declspec(empty_bases)
 
 // MSVC does not support loop unrolling hints
+#   define UTILS_UNROLL
 #   define UTILS_NOUNROLL
 #else
 #   define UTILS_EMPTY_BASES
 // C++11 allows pragmas to be specified as part of defines using the _Pragma syntax.
+#   define UTILS_UNROLL _Pragma("unroll")
 #   define UTILS_NOUNROLL _Pragma("nounroll")
 #endif
 

--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -142,7 +142,7 @@ JobSystem::JobSystem(const size_t userThreadCount, const size_t adoptableThreads
     const size_t hardwareThreadCount = mThreadCount;
     auto& states = mThreadStates;
 
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (size_t i = 0, n = states.size(); i < n; i++) {
         auto& state = states[i];
         state.rndGen = default_random_engine(rd());
@@ -158,7 +158,7 @@ JobSystem::JobSystem(const size_t userThreadCount, const size_t adoptableThreads
 JobSystem::~JobSystem() {
     requestExit();
 
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (auto &state : mThreadStates) {
         // adopted threads are not joinable
         if (state.thread.joinable()) {

--- a/libs/utils/src/Profiler.cpp
+++ b/libs/utils/src/Profiler.cpp
@@ -62,7 +62,7 @@ Profiler::Profiler(uint32_t eventMask) noexcept : Profiler() {
 }
 
 Profiler::~Profiler() noexcept {
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (int fd : mCountersFd) {
         if (fd >= 0) {
             close(fd);
@@ -72,7 +72,7 @@ Profiler::~Profiler() noexcept {
 
 uint32_t Profiler::resetEvents(uint32_t eventMask) noexcept {
     // close all counters
-    #pragma nounroll
+    UTILS_NOUNROLL
     for (int& fd : mCountersFd) {
         if (fd >= 0) {
             close(fd);

--- a/libs/viewer/include/viewer/AutomationEngine.h
+++ b/libs/viewer/include/viewer/AutomationEngine.h
@@ -60,7 +60,7 @@ public:
          * Minimum time that automation waits between applying a settings object and advancing
          * to the next test case. Specified in seconds.
          */
-        float sleepDuration = 0.2;
+        float sleepDuration = 0.2f;
 
         /**
          * Similar to sleepDuration, but expressed as a frame count. Both the minimum sleep time

--- a/tools/specular-color/src/main.cpp
+++ b/tools/specular-color/src/main.cpp
@@ -730,7 +730,7 @@ static float fresnel(const std::complex<float>& sample, float cosTheta) {
 
 static float3 linear_to_sRGB(float3 linear) noexcept {
     float3 sRGB{linear};
-#pragma nounroll
+UTILS_NOUNROLL
     for (size_t i = 0; i < sRGB.size(); i++) {
         sRGB[i] = (sRGB[i] <= 0.0031308f) ?
                 sRGB[i] * 12.92f : (powf(sRGB[i], 1.0f / 2.4f) * 1.055f) - 0.055f;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1868](https://shapr3d.atlassian.net/browse/GFX-1868)

## Short description (What? How?) 📖
We already fixed some MSVC warnings in #75 which was further optimized in #83. This got us so far that we could make an internal build with Vis. on Windows. But Filament contained many more public headers which we may not be using right now, but might need anytime in the future.

This PR fixes all W3 level MSVC warnings in the remaining public headers, regardless if it is used in Shapr or not.

## Upstreaming scope
[GFX-1891](https://shapr3d.atlassian.net/browse/GFX-1891)

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
I tested on VS2019 and V2022 with a .cpp file that includes all public headers of Filament (except for Apple/Linux only). You can test it too with https://github.com/shapr3d/shapr3d/tree/palver123/GFX-1868_filament_warnings_test (just have to change the path of your Filament git repo in Libraries.cmake)

Automated 💻
