### PR TITLE
[GFX-594] External buffer support

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -288,6 +288,7 @@ enum class ElementType : uint8_t {
 //! Buffer object binding type
 enum class BufferObjectBinding : uint8_t {
     VERTEX,
+    INDEX,
     UNIFORM
 };
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -182,7 +182,8 @@ DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
 DECL_DRIVER_API_R_N(backend::BufferObjectHandle, importBufferObject,
         intptr_t, id,
         backend::BufferObjectBinding, bindingType,
-        backend::BufferUsage, usage)
+        backend::BufferUsage, usage,
+        uint32_t, byteCount)
 
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -171,8 +171,7 @@ DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
 
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
-        uint32_t, indexCount,
-        backend::BufferUsage, usage)
+        uint32_t, indexCount)
 
 DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
         uint32_t, byteCount,
@@ -321,11 +320,6 @@ DECL_DRIVER_API_N(setVertexBufferObject,
         backend::VertexBufferHandle, vbh,
         uint32_t, index,
         backend::BufferObjectHandle, bufferObject)
-
-DECL_DRIVER_API_N(updateIndexBuffer,
-        backend::IndexBufferHandle, ibh,
-        backend::BufferDescriptor&&, data,
-        uint32_t, byteOffset)
 
 DECL_DRIVER_API_N(updateBufferObject,
         backend::BufferObjectHandle, ibh,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -178,8 +178,7 @@ DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
 DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
         uint32_t, byteCount,
         backend::BufferObjectBinding, bindingType,
-        backend::BufferUsage, usage,
-        intptr_t, importedId)
+        backend::BufferUsage, usage)
 
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -172,8 +172,7 @@ DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
         uint32_t, indexCount,
-        backend::BufferUsage, usage,
-        intptr_t, importedId)
+        backend::BufferUsage, usage)
 
 DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
         uint32_t, byteCount,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -173,13 +173,13 @@ DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
         uint32_t, indexCount,
         backend::BufferUsage, usage,
-        bool, wrapsExternalBuffer)
+        intptr_t, importedId)
 
 DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
         uint32_t, byteCount,
         backend::BufferObjectBinding, bindingType,
         backend::BufferUsage, usage,
-        bool, wrapsExternalBuffer)
+        intptr_t, importedId)
 
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,
@@ -308,14 +308,6 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, isDepthResolveSupported)
  * Updating driver objects
  * -----------------------
  */
-
-DECL_DRIVER_API_N(setExternalIndexBuffer,
-        backend::IndexBufferHandle, ibh,
-        intptr_t, externalBuffer)
-
-DECL_DRIVER_API_N(setExternalBuffer,
-        backend::BufferObjectHandle, boh,
-        intptr_t, externalBuffer)
 
 DECL_DRIVER_API_N(setVertexBufferObject,
         backend::VertexBufferHandle, vbh,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -180,6 +180,11 @@ DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
         backend::BufferObjectBinding, bindingType,
         backend::BufferUsage, usage)
 
+DECL_DRIVER_API_R_N(backend::BufferObjectHandle, importBufferObject,
+        intptr_t, id,
+        backend::BufferObjectBinding, bindingType,
+        backend::BufferUsage, usage)
+
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,
         uint8_t, levels,

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -312,6 +312,10 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, isDepthResolveSupported)
  * -----------------------
  */
 
+DECL_DRIVER_API_N(setIndexBufferObject,
+        backend::IndexBufferHandle, ibh,
+        backend::BufferObjectHandle, bufferObject)
+
 DECL_DRIVER_API_N(setVertexBufferObject,
         backend::VertexBufferHandle, vbh,
         uint32_t, index,

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -75,6 +75,7 @@ struct HwBufferObject : public HwBase {
 struct HwIndexBuffer : public HwBase {
     uint32_t count : 27;
     uint32_t elementSize : 5;
+    uint8_t bufferVersion{};      
 
     HwIndexBuffer() noexcept : count{}, elementSize{} { }
     HwIndexBuffer(uint8_t elementSize, uint32_t indexCount) noexcept :

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -75,7 +75,7 @@ struct HwBufferObject : public HwBase {
 struct HwIndexBuffer : public HwBase {
     uint32_t count : 27;
     uint32_t elementSize : 5;
-    uint8_t bufferVersion{};      
+    uint8_t bufferObjectVersion{};      
 
     HwIndexBuffer() noexcept : count{}, elementSize{} { }
     HwIndexBuffer(uint8_t elementSize, uint32_t indexCount) noexcept :

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -34,7 +34,7 @@ public:
     MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, bool forceGpuBuffer = false);
 
     // Constructor for importing an id<MTLBuffer> outside of Filament.
-    MetalBuffer(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer);
+    MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, id<MTLBuffer> buffer);
 
     ~MetalBuffer();
 

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -32,22 +32,16 @@ class MetalBuffer {
 public:
 
     MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, bool forceGpuBuffer = false);
+
+    // Constructor for importing an id<MTLBuffer> outside of Filament.
+    MetalBuffer(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer);
+
     ~MetalBuffer();
 
     MetalBuffer(const MetalBuffer& rhs) = delete;
     MetalBuffer& operator=(const MetalBuffer& rhs) = delete;
 
     size_t getSize() const noexcept { return mBufferSize; }
-
-    /**
-     * Wrap an external Metal buffer. Stores a strong reference to it.
-     */
-    void wrapExternalBuffer(id<MTLBuffer> buffer);
-
-    /**
-     * Release the external Metal buffer, if wrapping any.
-     */
-    bool releaseExternalBuffer();
 
     /**
      * Update the buffer with data inside src. Potentially allocates a new buffer allocation to hold

--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -45,7 +45,7 @@ MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, 
 }
 
 MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer)
-        : mBufferSize(buffer.length), mContext(context), mUsage(usage), mExternalBuffer(buffer) {
+        : mUsage(usage), mBufferSize(buffer.length), mExternalBuffer(buffer), mContext(context) {
     ASSERT_PRECONDITION(buffer, "External buffer cannot be nil");
 #if TARGET_OS_SIMULATOR
     // TODO: must check if MTLBuffer.length or MTLBuffer.allocatedSize returns 0 on iOS simulator or not

--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -44,13 +44,9 @@ MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, 
     mUsage = usage;
 }
 
-MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer)
-        : mUsage(usage), mBufferSize(buffer.length), mExternalBuffer(buffer), mContext(context) {
+MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, id<MTLBuffer> buffer)
+        : mUsage(usage), mBufferSize(size), mExternalBuffer(buffer), mContext(context) {
     ASSERT_PRECONDITION(buffer, "External buffer cannot be nil");
-#if TARGET_OS_SIMULATOR
-    // TODO: must check if MTLBuffer.length or MTLBuffer.allocatedSize returns 0 on iOS simulator or not
-    static_assert(false, "TODO!!!");
-#endif
 }
 
 MetalBuffer::~MetalBuffer() {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -239,9 +239,9 @@ void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t buffer
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage) {
+        uint32_t indexCount) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
-    construct_handle<MetalIndexBuffer>(ibh, *mContext, usage, elementSize, indexCount);
+    construct_handle<MetalIndexBuffer>(ibh, *mContext, elementSize, indexCount);
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
@@ -724,13 +724,6 @@ math::float2 MetalDriver::getClipSpaceParams() {
 
 uint8_t MetalDriver::getMaxDrawBuffers() {
     return std::min(mContext->maxColorRenderTargets, MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT);
-}
-
-void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& data,
-        uint32_t byteOffset) {
-    auto* ib = handle_cast<MetalIndexBuffer>(ibh);
-    ib->buffer->copyIntoBuffer(data.buffer, data.size, byteOffset);
-    scheduleDestroy(std::move(data));
 }
 
 void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescriptor&& data,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -751,6 +751,12 @@ void MetalDriver::setupExternalResource(intptr_t externalResource) {
     }
 }
 
+void MetalDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBufferObject> boh) {
+    auto* indexBuffer = handle_cast<MetalIndexBuffer>(ibh);
+    auto* bufferObject = handle_cast<MetalBufferObject>(boh);
+    indexBuffer->buffer = bufferObject->getBuffer();
+}
+
 void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
     auto* vertexBuffer = handle_cast<MetalVertexBuffer>(vbh);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -251,6 +251,12 @@ void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteC
     construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount);
 }
 
+void MetalDriver::importBufferObjectR(Handle<HwBufferObject> boh, intptr_t i,
+        BufferObjectBinding bindingType, BufferUsage usage) {
+    id<MTLBuffer> metalBuffer = (id<MTLBuffer>) CFBridgingRelease((void*) i);
+    construct_handle<MetalBufferObject>(boh, *mContext, usage, metalBuffer);
+}
+
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
         TextureFormat format, uint8_t samples, uint32_t width, uint32_t height,
         uint32_t depth, TextureUsage usage) {
@@ -403,6 +409,10 @@ Handle<HwIndexBuffer> MetalDriver::createIndexBufferS() noexcept {
 }
 
 Handle<HwBufferObject> MetalDriver::createBufferObjectS() noexcept {
+    return alloc_handle<MetalBufferObject>();
+}
+
+Handle<HwBufferObject> MetalDriver::importBufferObjectS() noexcept {
     return alloc_handle<MetalBufferObject>();
 }
 

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -729,7 +729,7 @@ uint8_t MetalDriver::getMaxDrawBuffers() {
 void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& data,
         uint32_t byteOffset) {
     auto* ib = handle_cast<MetalIndexBuffer>(ibh);
-    ib->buffer.copyIntoBuffer(data.buffer, data.size, byteOffset);
+    ib->buffer->copyIntoBuffer(data.buffer, data.size, byteOffset);
     scheduleDestroy(std::move(data));
 }
 
@@ -1396,8 +1396,8 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     MetalIndexBuffer* indexBuffer = primitive->indexBuffer;
 
     id<MTLCommandBuffer> cmdBuffer = getPendingCommandBuffer(mContext);
-    id<MTLBuffer> metalIndexBuffer = indexBuffer->buffer.getGpuBufferForDraw(cmdBuffer);
-    size_t offset = indexBuffer->buffer.getGpuBufferStreamOffset();
+    id<MTLBuffer> metalIndexBuffer = indexBuffer->buffer->getGpuBufferForDraw(cmdBuffer);
+    size_t offset = indexBuffer->buffer->getGpuBufferStreamOffset();
     [mContext->currentRenderPassEncoder drawIndexedPrimitives:getMetalPrimitiveType(primitive->type)
                                                    indexCount:primitive->count
                                                     indexType:getIndexType(indexBuffer->elementSize)

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -250,9 +250,9 @@ void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteC
 }
 
 void MetalDriver::importBufferObjectR(Handle<HwBufferObject> boh, intptr_t i,
-        BufferObjectBinding bindingType, BufferUsage usage) {
+        BufferObjectBinding bindingType, BufferUsage usage, uint32_t byteCount) {
     id<MTLBuffer> metalBuffer = (id<MTLBuffer>) CFBridgingRelease((void*) i);
-    construct_handle<MetalBufferObject>(boh, *mContext, usage, metalBuffer);
+    construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount, metalBuffer);
 }
 
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -239,11 +239,9 @@ void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t buffer
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage, intptr_t importedId) {
+        uint32_t indexCount, BufferUsage usage) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
-    auto* ib = construct_handle<MetalIndexBuffer>(ibh, *mContext, usage, elementSize, indexCount);
-    ib->buffer.wrapExternalBuffer((id<MTLBuffer>) CFBridgingRelease((void*) importedId));
-    
+    construct_handle<MetalIndexBuffer>(ibh, *mContext, usage, elementSize, indexCount);
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -247,9 +247,8 @@ void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elem
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, intptr_t importedId) {
-    auto* bo = construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount, importedId > 0);
-    bo->getBuffer()->wrapExternalBuffer((id<MTLBuffer>) CFBridgingRelease((void*) importedId));
+        BufferObjectBinding bindingType, BufferUsage usage) {
+    construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount);
 }
 
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -117,6 +117,9 @@ class MetalBufferObject : public HwBufferObject {
 public:
     MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount);
 
+    // Constructor for importing an id<MTLBuffer> outside of Filament.
+    MetalBufferObject(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer);
+
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
     MetalBuffer* getBuffer() { return &buffer; }
 

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -142,7 +142,7 @@ struct MetalIndexBuffer : public HwIndexBuffer {
     MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
             uint32_t indexCount);
 
-    MetalBuffer* buffer;
+    MetalBuffer* buffer = nullptr;
 };
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -142,7 +142,7 @@ struct MetalIndexBuffer : public HwIndexBuffer {
     MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
             uint32_t indexCount);
 
-    MetalBuffer buffer;
+    MetalBuffer* buffer;
 };
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -139,7 +139,7 @@ struct MetalVertexBuffer : public HwVertexBuffer {
 };
 
 struct MetalIndexBuffer : public HwIndexBuffer {
-    MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
+    MetalIndexBuffer(MetalContext& context, uint8_t elementSize,
             uint32_t indexCount);
 
     MetalBuffer* buffer = nullptr;

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -118,7 +118,7 @@ public:
     MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount);
 
     // Constructor for importing an id<MTLBuffer> outside of Filament.
-    MetalBufferObject(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer);
+    MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount, id<MTLBuffer> buffer);
 
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
     MetalBuffer* getBuffer() { return &buffer; }

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -115,8 +115,7 @@ private:
 
 class MetalBufferObject : public HwBufferObject {
 public:
-    MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount,
-            bool wrapsExternalBuffer);
+    MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount);
 
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
     MetalBuffer* getBuffer() { return &buffer; }

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -266,6 +266,9 @@ void MetalSwapChain::scheduleFrameCompletedCallback() {
 MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount)
         : HwBufferObject(byteCount), buffer(context, usage, byteCount) {}
 
+MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer)
+        : HwBufferObject(buffer.length), buffer(context, usage, buffer) {}
+
 void MetalBufferObject::updateBuffer(void* data, size_t size, uint32_t byteOffset) {
     buffer.copyIntoBuffer(data, size, byteOffset);
 }

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -278,8 +278,7 @@ MetalVertexBuffer::MetalVertexBuffer(MetalContext& context, uint8_t bufferCount,
     : HwVertexBuffer(bufferCount, attributeCount, vertexCount, attributes), buffers(bufferCount, nullptr) {}
 
 MetalIndexBuffer::MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
-        uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
-        buffer(context, usage, elementSize * indexCount, true) { }
+        uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount) { }
 
 void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer*
         indexBuffer) {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -263,8 +263,8 @@ void MetalSwapChain::scheduleFrameCompletedCallback() {
     }];
 }
 
-MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount,bool wrapsExternalBuffer)
-        : HwBufferObject(byteCount), buffer(context, usage, byteCount, wrapsExternalBuffer) {}
+MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount)
+        : HwBufferObject(byteCount), buffer(context, usage, byteCount) {}
 
 void MetalBufferObject::updateBuffer(void* data, size_t size, uint32_t byteOffset) {
     buffer.copyIntoBuffer(data, size, byteOffset);

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -266,8 +266,8 @@ void MetalSwapChain::scheduleFrameCompletedCallback() {
 MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount)
         : HwBufferObject(byteCount), buffer(context, usage, byteCount) {}
 
-MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, id<MTLBuffer> buffer)
-        : HwBufferObject(buffer.length), buffer(context, usage, buffer) {}
+MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount, id<MTLBuffer> buffer)
+        : HwBufferObject(byteCount), buffer(context, usage, byteCount, buffer) {}
 
 void MetalBufferObject::updateBuffer(void* data, size_t size, uint32_t byteOffset) {
     buffer.copyIntoBuffer(data, size, byteOffset);

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -277,7 +277,7 @@ MetalVertexBuffer::MetalVertexBuffer(MetalContext& context, uint8_t bufferCount,
             uint8_t attributeCount, uint32_t vertexCount, AttributeArray const& attributes)
     : HwVertexBuffer(bufferCount, attributeCount, vertexCount, attributes), buffers(bufferCount, nullptr) {}
 
-MetalIndexBuffer::MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
+MetalIndexBuffer::MetalIndexBuffer(MetalContext& context, uint8_t elementSize,
         uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount) { }
 
 void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer*

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -193,12 +193,6 @@ void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor
 void NoopDriver::setupExternalResource(intptr_t externalResource) {
 }
 
-void NoopDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, intptr_t externalBuffer) {
-}
-
-void NoopDriver::setExternalBuffer(Handle<HwBufferObject> boh, intptr_t externalBuffer) {
-}
-
 void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
 }

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -180,11 +180,6 @@ uint8_t NoopDriver::getMaxDrawBuffers() {
     return backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT;
 }
 
-void NoopDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
-        uint32_t byteOffset) {
-    scheduleDestroy(std::move(p));
-}
-
 void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
     scheduleDestroy(std::move(p));

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -193,6 +193,9 @@ void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor
 void NoopDriver::setupExternalResource(intptr_t externalResource) {
 }
 
+void NoopDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBufferObject> boh) {
+}
+
 void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
 }

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -119,6 +119,8 @@ constexpr inline GLenum getBufferBindingType(backend::BufferObjectBinding bindin
     switch (bindingType) {
         case backend::BufferObjectBinding::VERTEX:
             return GL_ARRAY_BUFFER;
+        case backend::BufferObjectBinding::INDEX:
+            return GL_ELEMENT_ARRAY_BUFFER;
         case backend::BufferObjectBinding::UNIFORM:
             return GL_UNIFORM_BUFFER;
     }

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -55,6 +55,9 @@ public:
         // If this version number does not match vertexBufferWithObjects->bufferObjectsVersion,
         // then the VAO needs to be updated.
         uint8_t vertexBufferVersion = 0;
+        
+        // If this version number does not match indexBuffer->bufferObjectVersion,
+        // then the VAO needs to be updated.
         uint8_t indexBufferVersion = 0;
     } gl;
 

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -50,10 +50,12 @@ public:
         // VertexBuffer supports buffer objects. If this is zero, then the VBO handles array is
         // immutable.
         backend::Handle<backend::HwVertexBuffer> vertexBufferWithObjects = {};
+        backend::Handle<backend::HwIndexBuffer> indexBuffer = {};
 
         // If this version number does not match vertexBufferWithObjects->bufferObjectsVersion,
         // then the VAO needs to be updated.
         uint8_t vertexBufferVersion = 0;
+        uint8_t indexBufferVersion = 0;
     } gl;
 
     OpenGLContext() noexcept;

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -167,7 +167,7 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
           mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U), // TODO: set the amount in configuration
           mSamplerMap(32),
           mPlatform(*platform) {
-  
+
     std::fill(mSamplerBindings.begin(), mSamplerBindings.end(), nullptr);
 
     // set a reasonable default value for our stream array
@@ -1724,7 +1724,7 @@ void OpenGLDriver::updateBufferObject(
         // TODO: use updateBuffer() for all types of buffer? Make sure GL supports that.
         updateBuffer(bo, bd, byteOffset, (uint32_t)gl.gets.uniform_buffer_offset_alignment);
     } else {
-        if (bo->gl.binding == GL_ARRAY_BUFFER) {
+        if (bo->gl.binding == GL_ARRAY_BUFFER || bo->gl.binding == GL_ELEMENT_ARRAY_BUFFER) {
             gl.bindVertexArray(nullptr);
         }
         gl.bindBuffer(bo->gl.binding, bo->gl.id);

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -424,8 +424,7 @@ void OpenGLDriver::createVertexBufferR(
 void OpenGLDriver::createIndexBufferR(
         Handle<HwIndexBuffer> ibh,
         ElementType elementType,
-        uint32_t indexCount,
-        BufferUsage) {
+        uint32_t indexCount) {
     DEBUG_MARKER()
     const uint8_t elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
     construct<GLIndexBuffer>(ibh, elementSize, indexCount);
@@ -1680,23 +1679,6 @@ void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,
         const uint32_t version = vb->bufferObjectsVersion;
         vb->bufferObjectsVersion = (version + 1) % kMaxVersion;
     }
-
-    CHECK_GL_ERROR(utils::slog.e)
-}
-
-void OpenGLDriver::updateIndexBuffer(
-        Handle<HwIndexBuffer> ibh, BufferDescriptor&& p, uint32_t byteOffset) {
-    DEBUG_MARKER()
-
-    auto& gl = mContext;
-    GLIndexBuffer* ib = handle_cast<GLIndexBuffer *>(ibh);
-    assert_invariant(ib->elementSize == 2 || ib->elementSize == 4);
-
-    gl.bindVertexArray(nullptr);
-    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
-    glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, byteOffset, p.size, p.buffer);
-
-    scheduleDestroy(std::move(p));
 
     CHECK_GL_ERROR(utils::slog.e)
 }

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -445,7 +445,7 @@ void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh,
     assert_invariant(byteCount > 0);
 
     auto& gl = mContext;
-    if (bindingType == BufferObjectBinding::VERTEX) {
+    if (bindingType == BufferObjectBinding::VERTEX || bindingType == BufferObjectBinding::INDEX) {
         gl.bindVertexArray(nullptr);
     }
 
@@ -461,7 +461,8 @@ void OpenGLDriver::importBufferObjectR(Handle<HwBufferObject> boh,
     DEBUG_MARKER()
 
     auto& gl = mContext;
-    if (bindingType == BufferObjectBinding::VERTEX && id == 0) {
+    if ((bindingType == BufferObjectBinding::VERTEX || bindingType == BufferObjectBinding::INDEX) &&
+        id == 0) {
         gl.bindVertexArray(nullptr);
     }
 
@@ -1648,6 +1649,21 @@ void OpenGLDriver::makeCurrentOffscreen(int) {
 
 void OpenGLDriver::setupExternalResource(intptr_t externalResource) {
     mPlatform.retainExternalResource(externalResource);
+}
+
+void OpenGLDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBufferObject> boh) {
+   DEBUG_MARKER()
+
+    GLIndexBuffer* ib = handle_cast<GLIndexBuffer *>(ibh);
+    GLBufferObject* bo = handle_cast<GLBufferObject *>(boh);
+
+    assert_invariant(bo->gl.binding == GL_ELEMENT_ARRAY_BUFFER);
+
+    if (ib->gl.buffer != bo->gl.id) {
+        ib->gl.buffer = bo->gl.id;
+    }
+
+    CHECK_GL_ERROR(utils::slog.e)
 }
 
 void OpenGLDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh,

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -425,18 +425,10 @@ void OpenGLDriver::createIndexBufferR(
         Handle<HwIndexBuffer> ibh,
         ElementType elementType,
         uint32_t indexCount,
-        BufferUsage usage) {
+        BufferUsage) {
     DEBUG_MARKER()
-
-    auto& gl = mContext;
-    uint8_t elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
-    GLIndexBuffer* ib = construct<GLIndexBuffer>(ibh, elementSize, indexCount);
-    glGenBuffers(1, &ib->gl.buffer);
-    GLsizeiptr size = elementSize * indexCount;
-    gl.bindVertexArray(nullptr);
-    gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, size, nullptr, getBufferUsage(usage));
-    CHECK_GL_ERROR(utils::slog.e)
+    const uint8_t elementSize = static_cast<uint8_t>(getElementTypeSize(elementType));
+    construct<GLIndexBuffer>(ibh, elementSize, indexCount);
 }
 
 void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh,
@@ -457,10 +449,11 @@ void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh,
 }
 
 void OpenGLDriver::importBufferObjectR(Handle<HwBufferObject> boh,
-        intptr_t id, BufferObjectBinding bindingType, BufferUsage usage) {
+        intptr_t id, BufferObjectBinding bindingType, BufferUsage usage, uint32_t byteCount) {
     DEBUG_MARKER()
 
     assert_invariant(id);
+    assert_invariant(byteCount > 0);
 
     auto& gl = mContext;
     if ((bindingType == BufferObjectBinding::VERTEX || bindingType == BufferObjectBinding::INDEX)) {
@@ -471,10 +464,7 @@ void OpenGLDriver::importBufferObjectR(Handle<HwBufferObject> boh,
     bo->gl.isExternal = id > 0;
     bo->gl.id = GLuint(id);
     gl.bindBuffer(bo->gl.binding, bo->gl.id);
-    GLint bufferSize;
-    glGetBufferParameteriv(GL_ARRAY_BUFFER, GL_BUFFER_SIZE, &bufferSize);
-    assert_invariant(bufferSize > 0);
-    bo->byteCount = bufferSize;
+    bo->byteCount = byteCount;
     CHECK_GL_ERROR(utils::slog.e)
 }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1663,9 +1663,9 @@ void OpenGLDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBuff
     if (ib->gl.buffer != bo->gl.id) {
         ib->gl.buffer = bo->gl.id;
         static constexpr uint32_t kMaxVersion =
-            std::numeric_limits<decltype(ib->bufferVersion)>::max();
-        const uint32_t version = ib->bufferVersion;
-        ib->bufferVersion = (version + 1) % kMaxVersion;
+            std::numeric_limits<decltype(ib->bufferObjectVersion)>::max();
+        const uint32_t version = ib->bufferObjectVersion;
+        ib->bufferObjectVersion = (version + 1) % kMaxVersion;
     }
 
     CHECK_GL_ERROR(utils::slog.e)
@@ -2488,7 +2488,7 @@ void OpenGLDriver::setRenderPrimitiveBuffer(Handle<HwRenderPrimitive> rph,
         // update the VBO bindings in the VAO
         updateVertexArrayObject(rp, eb);
 
-        rp->gl.indexBufferVersion = ib->bufferVersion;
+        rp->gl.indexBufferVersion = ib->bufferObjectVersion;
         // this records the index buffer into the currently bound VAO
         gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, ib->gl.buffer);
 
@@ -3223,8 +3223,8 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph) {
         updateVertexArrayObject(rp, glvb);
     }
 
-    if (UTILS_UNLIKELY(rp->gl.indexBufferVersion != glib->bufferVersion)) {
-        rp->gl.indexBufferVersion = glib->bufferVersion;
+    if (UTILS_UNLIKELY(rp->gl.indexBufferVersion != glib->bufferObjectVersion)) {
+        rp->gl.indexBufferVersion = glib->bufferObjectVersion;
         gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, glib->gl.buffer);
     }
 

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -167,7 +167,7 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
           mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U), // TODO: set the amount in configuration
           mSamplerMap(32),
           mPlatform(*platform) {
-
+  
     std::fill(mSamplerBindings.begin(), mSamplerBindings.end(), nullptr);
 
     // set a reasonable default value for our stream array

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -167,7 +167,7 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
           mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U), // TODO: set the amount in configuration
           mSamplerMap(32),
           mPlatform(*platform) {
-
+  
     std::fill(mSamplerBindings.begin(), mSamplerBindings.end(), nullptr);
 
     // set a reasonable default value for our stream array
@@ -440,7 +440,6 @@ void OpenGLDriver::createIndexBufferR(
         ib->gl.id = GLuint(importedId);
     }
 }
-
 
 void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh,
         uint32_t byteCount, BufferObjectBinding bindingType, BufferUsage usage,

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -442,26 +442,20 @@ void OpenGLDriver::createIndexBufferR(
 }
 
 void OpenGLDriver::createBufferObjectR(Handle<HwBufferObject> boh,
-        uint32_t byteCount, BufferObjectBinding bindingType, BufferUsage usage,
-        intptr_t importedId) {
+        uint32_t byteCount, BufferObjectBinding bindingType, BufferUsage usage) {
     DEBUG_MARKER()
     assert_invariant(byteCount > 0);
 
     auto& gl = mContext;
-    if (bindingType == BufferObjectBinding::VERTEX && importedId == 0) {
+    if (bindingType == BufferObjectBinding::VERTEX) {
         gl.bindVertexArray(nullptr);
     }
 
     GLBufferObject* bo = construct<GLBufferObject>(boh, byteCount, bindingType, usage);
-    bo->gl.isExternal = importedId > 0;
-    if (!bo->gl.isExternal) {
-        glGenBuffers(1, &bo->gl.id);
-        gl.bindBuffer(bo->gl.binding, bo->gl.id);
-        glBufferData(bo->gl.binding, byteCount, nullptr, getBufferUsage(usage));
-        CHECK_GL_ERROR(utils::slog.e)
-    } else {
-        bo->gl.id = GLuint(importedId);
-    }
+    glGenBuffers(1, &bo->gl.id);
+    gl.bindBuffer(bo->gl.binding, bo->gl.id);
+    glBufferData(bo->gl.binding, byteCount, nullptr, getBufferUsage(usage));
+    CHECK_GL_ERROR(utils::slog.e)
 }
 
 void OpenGLDriver::createRenderPrimitiveR(Handle<HwRenderPrimitive> rph, int) {
@@ -1689,7 +1683,6 @@ void OpenGLDriver::updateBufferObject(
     auto& gl = mContext;
     GLBufferObject* bo = handle_cast<GLBufferObject *>(boh);
 
-    assert_invariant(!bo->gl.isExternal);
     assert_invariant(bd.size + byteOffset <= bo->byteCount);
 
     if (bo->gl.binding == GL_UNIFORM_BUFFER) {

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -67,12 +67,6 @@ public:
 
     // OpenGLDriver specific fields
 
-    struct GLBufferHandle {
-        GLuint id = 0;
-        GLenum binding = 0;
-        bool isExternal = false;
-    };
-
     struct GLBufferObject : public backend::HwBufferObject {
         using HwBufferObject::HwBufferObject;
         GLBufferObject(uint32_t size,
@@ -100,7 +94,9 @@ public:
 
     struct GLIndexBuffer : public backend::HwIndexBuffer {
         using HwIndexBuffer::HwIndexBuffer;
-        GLBufferHandle gl;
+        struct {
+            GLuint buffer{};
+        } gl;
     };
 
     struct GLSamplerGroup : public backend::HwSamplerGroup {

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -80,7 +80,11 @@ public:
                 : HwBufferObject(size), usage(usage) {
             gl.binding = GLUtils::getBufferBindingType(bindingType);
         }
-        GLBufferHandle gl;
+        struct {
+            GLuint id = 0;
+            GLenum binding = 0;
+            bool isExternal = false;
+        } gl;
         uint32_t base = 0;
         uint32_t size = 0;
         backend::BufferUsage usage = {};

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -48,6 +48,7 @@ PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
 #ifdef GL_EXT_clip_control
 PFNGLCLIPCONTROLEXTPROC glClipControl;
 #endif
+
 static std::once_flag sGlExtInitialized;
 
 void importGLESExtensionsEntryPoints() {
@@ -108,7 +109,6 @@ void importGLESExtensionsEntryPoints() {
             (PFNGLCLIPCONTROLEXTPROC)eglGetProcAddress(
                     "glClipControlEXT");
 #endif
-
 }
 
 } // namespace glext

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -48,11 +48,6 @@ PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
 #ifdef GL_EXT_clip_control
 PFNGLCLIPCONTROLEXTPROC glClipControl;
 #endif
-#ifdef GL_EXT_external_buffer
-PFNGLBUFFERSTORAGEEXTERNALEXTPROC glBufferStorageExternalEXT;
-PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC glNamedBufferStorageExternalEXT;
-#endif
-
 static std::once_flag sGlExtInitialized;
 
 void importGLESExtensionsEntryPoints() {
@@ -114,12 +109,6 @@ void importGLESExtensionsEntryPoints() {
                     "glClipControlEXT");
 #endif
 
-#ifdef GL_EXT_external_buffer
-     glBufferStorageExternalEXT = (PFNGLBUFFERSTORAGEEXTERNALEXTPROC)eglGetProcAddress(
-        "glBufferStorageExternalEXT");
-     glNamedBufferStorageExternalEXT = (PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC)eglGetProcAddress(
-        "glNamedBufferStorageExternalEXT");
-#endif
 }
 
 } // namespace glext

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -61,10 +61,6 @@
         #define GL_ZERO_TO_ONE GL_ZERO_TO_ONE_EXT
         #endif
 #endif
-#ifdef GL_EXT_external_buffer
-        extern PFNGLBUFFERSTORAGEEXTERNALEXTPROC glBufferStorageExternalEXT;
-        extern PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC glNamedBufferStorageExternalEXT;
-#endif
     }
 
     // Prevent lots of #ifdef's between desktop and mobile by providing some suffix-free constants:

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -365,6 +365,7 @@ io::ostream& operator<<(io::ostream& out, SamplerCompareFunc func) {
 io::ostream& operator<<(io::ostream& out, BufferObjectBinding binding) {
     switch (binding) {
         CASE(BufferObjectBinding, VERTEX)
+        CASE(BufferObjectBinding, INDEX)
         CASE(BufferObjectBinding, UNIFORM)
     }
     return out;

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -433,7 +433,7 @@ void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh,
     auto indexBuffer = construct<VulkanIndexBuffer>(ibh, mContext, mStagePool,
             elementSize, indexCount);
     mDisposer.createDisposable(indexBuffer, [this, ibh] () {
-        destruct<VulkanIndexBuffer>(mContext, ibh);
+        destruct<VulkanIndexBuffer>(ibh);
     });
 }
 
@@ -859,7 +859,7 @@ void VulkanDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBuff
     auto& ib = *handle_cast<VulkanIndexBuffer*>(ibh);
     auto& bo = *handle_cast<VulkanBufferObject*>(boh);
     assert_invariant(bo.bindingType == BufferObjectBinding::INDEX);
-    ub.buffer = &bo.buffer;
+    ib.buffer = &bo.buffer;
 }
 
 void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
@@ -873,7 +873,7 @@ void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t in
 void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
     auto ib = handle_cast<VulkanIndexBuffer*>(ibh);
-    ib->buffer.loadFromCpu(mContext, mStagePool, p.buffer, byteOffset, p.size);
+    ib->buffer->loadFromCpu(mContext, mStagePool, p.buffer, byteOffset, p.size);
     mDisposer.acquire(ib);
     scheduleDestroy(std::move(p));
 }
@@ -1886,7 +1886,7 @@ void VulkanDriver::draw(PipelineState pipelineState, Handle<HwRenderPrimitive> r
     // avoid rebinding these if they are already bound, but since we do not (yet) support subranges
     // it would be rare for a client to make consecutive draw calls with the same render primitive.
     vkCmdBindVertexBuffers(cmdbuffer, 0, bufferCount, buffers, offsets);
-    vkCmdBindIndexBuffer(cmdbuffer, prim.indexBuffer->buffer.getGpuBuffer(), 0,
+    vkCmdBindIndexBuffer(cmdbuffer, prim.indexBuffer->buffer->getGpuBuffer(), 0,
             prim.indexBuffer->indexType);
 
     // Finally, make the actual draw call. TODO: support subranges

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -453,6 +453,11 @@ void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh,
     });
 }
 
+void VulkanDriver::importBufferObjectR(Handle<HwBufferObject> boh,
+        intptr_t id, BufferObjectBinding bindingType, BufferUsage usage) {
+    // not supported in this backend
+}
+
 void VulkanDriver::destroyBufferObject(Handle<HwBufferObject> boh) {
     if (boh) {
        auto bufferObject = handle_cast<VulkanBufferObject*>(boh);
@@ -601,6 +606,10 @@ Handle<HwIndexBuffer> VulkanDriver::createIndexBufferS() noexcept {
 }
 
 Handle<HwBufferObject> VulkanDriver::createBufferObjectS() noexcept {
+    return allocHandle<VulkanBufferObject>();
+}
+
+Handle<HwBufferObject> VulkanDriver::importBufferObjectS() noexcept {
     return allocHandle<VulkanBufferObject>();
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -428,7 +428,7 @@ void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
 }
 
 void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh,
-        ElementType elementType, uint32_t indexCount, BufferUsage usage) {
+        ElementType elementType, uint32_t indexCount, BufferUsage) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto indexBuffer = construct<VulkanIndexBuffer>(ibh, mContext, mStagePool,
             elementSize, indexCount);
@@ -454,7 +454,7 @@ void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh,
 }
 
 void VulkanDriver::importBufferObjectR(Handle<HwBufferObject> boh,
-        intptr_t id, BufferObjectBinding bindingType, BufferUsage usage) {
+        intptr_t id, BufferObjectBinding bindingType, BufferUsage usage, uint32_t byteCount) {
     // not supported in this backend
 }
 

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -428,7 +428,7 @@ void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
 }
 
 void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh,
-        ElementType elementType, uint32_t indexCount, BufferUsage) {
+        ElementType elementType, uint32_t indexCount) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto indexBuffer = construct<VulkanIndexBuffer>(ibh, mContext, mStagePool,
             elementSize, indexCount);
@@ -868,14 +868,6 @@ void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t in
     auto& bo = *handle_cast<VulkanBufferObject*>(boh);
     assert_invariant(bo.bindingType == BufferObjectBinding::VERTEX);
     vb.buffers[index] = &bo.buffer;
-}
-
-void VulkanDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
-        uint32_t byteOffset) {
-    auto ib = handle_cast<VulkanIndexBuffer*>(ibh);
-    ib->buffer->loadFromCpu(mContext, mStagePool, p.buffer, byteOffset, p.size);
-    mDisposer.acquire(ib);
-    scheduleDestroy(std::move(p));
 }
 
 void VulkanDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescriptor&& bd,

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -428,7 +428,7 @@ void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
 }
 
 void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage, bool wrapsExternalBuffer) {
+        uint32_t indexCount, BufferUsage usage, intptr_t importedId) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto indexBuffer = construct<VulkanIndexBuffer>(ibh, mContext, mStagePool,
             elementSize, indexCount);
@@ -445,7 +445,7 @@ void VulkanDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
 }
 
 void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, bool wrapsExternalBuffer) {
+        BufferObjectBinding bindingType, BufferUsage usage, intptr_t importedId) {
     auto bufferObject = construct<VulkanBufferObject>(boh, mContext, mStagePool, byteCount,
             bindingType, usage);
     mDisposer.createDisposable(bufferObject, [this, boh] () {
@@ -844,14 +844,6 @@ uint8_t VulkanDriver::getMaxDrawBuffers() {
 }
 
 void VulkanDriver::setupExternalResource(intptr_t externalResource) {
-}
-
-void VulkanDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, intptr_t externalBuffer) {
-    ASSERT_PRECONDITION(false, "setExternalIndexBuffer() is not implemented for backend!");
-}
-
-void VulkanDriver::setExternalBuffer(Handle<HwBufferObject> boh, intptr_t externalBuffer) {
-    ASSERT_PRECONDITION(false, "setExternalBuffer() is not implemented for backend!");
 }
 
 void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -427,8 +427,8 @@ void VulkanDriver::destroyVertexBuffer(Handle<HwVertexBuffer> vbh) {
     }
 }
 
-void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage, intptr_t importedId) {
+void VulkanDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh,
+        ElementType elementType, uint32_t indexCount, BufferUsage usage) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
     auto indexBuffer = construct<VulkanIndexBuffer>(ibh, mContext, mStagePool,
             elementSize, indexCount);

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -444,8 +444,8 @@ void VulkanDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     }
 }
 
-void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, intptr_t importedId) {
+void VulkanDriver::createBufferObjectR(Handle<HwBufferObject> boh,
+        uint32_t byteCount, BufferObjectBinding bindingType, BufferUsage usage) {
     auto bufferObject = construct<VulkanBufferObject>(boh, mContext, mStagePool, byteCount,
             bindingType, usage);
     mDisposer.createDisposable(bufferObject, [this, boh] () {

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -855,6 +855,13 @@ uint8_t VulkanDriver::getMaxDrawBuffers() {
 void VulkanDriver::setupExternalResource(intptr_t externalResource) {
 }
 
+void VulkanDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBufferObject> boh) {
+    auto& ib = *handle_cast<VulkanIndexBuffer*>(ibh);
+    auto& bo = *handle_cast<VulkanBufferObject*>(boh);
+    assert_invariant(bo.bindingType == BufferObjectBinding::INDEX);
+    ub.buffer = &bo.buffer;
+}
+
 void VulkanDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
         Handle<HwBufferObject> boh) {
     auto& vb = *handle_cast<VulkanVertexBuffer*>(vbh);

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -84,11 +84,8 @@ struct VulkanVertexBuffer : public HwVertexBuffer {
 struct VulkanIndexBuffer : public HwIndexBuffer {
     VulkanIndexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
             uint8_t elementSize, uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
-            buffer(context, stagePool,
-                    VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount),
             indexType(elementSize == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32) {}
-    void terminate(VulkanContext& context) { buffer.terminate(context); }
-    VulkanBuffer buffer;
+    VulkanBuffer* buffer;
     const VkIndexType indexType;
 };
 
@@ -137,6 +134,8 @@ inline constexpr VkBufferUsageFlagBits getBufferObjectUsage(
     switch(bindingType) {
         case BufferObjectBinding::VERTEX:
             return VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+        case BufferObjectBinding::INDEX:
+            return VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
         case BufferObjectBinding::UNIFORM:
             return VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         // when adding more buffer types here, make sure to update VulkanBuffer::loadFromCpu()

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -60,8 +60,7 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     BufferDescriptor vertexBufferDesc(gVertices, size, nullptr);
     mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);
 
-    mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount,
-            BufferUsage::STATIC);
+    mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount);
     BufferDescriptor indexBufferDesc(gIndices, sizeof(short) * 3, nullptr);
     mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(indexBufferDesc), 0);
 

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -53,16 +53,19 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     AttributeBitset enabledAttributes;
     enabledAttributes.set(VertexAttribute::POSITION);
 
-    const size_t size = sizeof(math::float2) * 3;
-    mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX, BufferUsage::STATIC);
+    const size_t vertexBufferSize = sizeof(math::float2) * 3;
+    mVertexBufferObject = mDriverApi.createBufferObject(vertexBufferSize, BufferObjectBinding::VERTEX, BufferUsage::STATIC);
     mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes);
-    mDriverApi.setVertexBufferObject(mVertexBuffer, 0, mBufferObject);
-    BufferDescriptor vertexBufferDesc(gVertices, size, nullptr);
-    mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);
+    mDriverApi.setVertexBufferObject(mVertexBuffer, 0, mVertexBufferObject);
+    BufferDescriptor vertexBufferDesc(gVertices, vertexBufferSize, nullptr);
+    mDriverApi.updateBufferObject(mVertexBufferObject, std::move(vertexBufferDesc), 0);
 
+    const size_t indexBufferSize = sizeof(short) * 3;
+    mIndexBufferObject = mDriverApi.createBufferObject(indexBufferSize, BufferObjectBinding::INDEX, BufferUsage::STATIC);
     mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount);
-    BufferDescriptor indexBufferDesc(gIndices, sizeof(short) * 3, nullptr);
-    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(indexBufferDesc), 0);
+    mDriverApi.setIndexBufferObject(mIndexBuffer, mIndexBufferObject);
+    BufferDescriptor indexBufferDesc(gIndices, indexBufferSize, nullptr);
+    mDriverApi.updateBufferObject(mIndexBufferObject, std::move(indexBufferDesc), 0);
 
     mRenderPrimitive = mDriverApi.createRenderPrimitive(0);
 
@@ -79,7 +82,7 @@ void TrianglePrimitive::updateVertices(const filament::math::float2 vertices[3])
             [] (void* buffer, size_t size, void* user) {
         free(buffer);
     });
-    mDriverApi.updateBufferObject(mBufferObject, std::move(vBuffer), 0);
+    mDriverApi.updateBufferObject(mVertexBufferObject, std::move(vBuffer), 0);
 }
 
 void TrianglePrimitive::updateIndices(const short indices[3]) noexcept {
@@ -91,7 +94,7 @@ void TrianglePrimitive::updateIndices(const short indices[3]) noexcept {
             [] (void* buffer, size_t size, void* user) {
         free(buffer);
     });
-    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(bufferDesc), 0);
+    mDriverApi.updateBufferObject(mIndexBufferObject, std::move(bufferDesc), 0);
 }
 
 void TrianglePrimitive::updateIndices(const short* indices, int count, int offset) noexcept {
@@ -103,11 +106,12 @@ void TrianglePrimitive::updateIndices(const short* indices, int count, int offse
             [] (void* buffer, size_t size, void* user) {
         free(buffer);
     });
-    mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(bufferDesc), offset * sizeof(short));
+    mDriverApi.updateBufferObject(mIndexBufferObject, std::move(bufferDesc), offset * sizeof(short));
 }
 
 TrianglePrimitive::~TrianglePrimitive() {
-    mDriverApi.destroyBufferObject(mBufferObject);
+    mDriverApi.destroyBufferObject(mVertexBufferObject);
+    mDriverApi.destroyBufferObject(mIndexBufferObject);
     mDriverApi.destroyVertexBuffer(mVertexBuffer);
     mDriverApi.destroyIndexBuffer(mIndexBuffer);
     mDriverApi.destroyRenderPrimitive(mRenderPrimitive);

--- a/filament/backend/test/TrianglePrimitive.cpp
+++ b/filament/backend/test/TrianglePrimitive.cpp
@@ -54,14 +54,14 @@ TrianglePrimitive::TrianglePrimitive(filament::backend::DriverApi& driverApi,
     enabledAttributes.set(VertexAttribute::POSITION);
 
     const size_t size = sizeof(math::float2) * 3;
-    mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX, BufferUsage::STATIC, false);
+    mBufferObject = mDriverApi.createBufferObject(size, BufferObjectBinding::VERTEX, BufferUsage::STATIC);
     mVertexBuffer = mDriverApi.createVertexBuffer(1, 1, mVertexCount, attributes);
     mDriverApi.setVertexBufferObject(mVertexBuffer, 0, mBufferObject);
     BufferDescriptor vertexBufferDesc(gVertices, size, nullptr);
     mDriverApi.updateBufferObject(mBufferObject, std::move(vertexBufferDesc), 0);
 
     mIndexBuffer = mDriverApi.createIndexBuffer(ElementType::SHORT, mIndexCount,
-            BufferUsage::STATIC, false);
+            BufferUsage::STATIC);
     BufferDescriptor indexBufferDesc(gIndices, sizeof(short) * 3, nullptr);
     mDriverApi.updateIndexBuffer(mIndexBuffer, std::move(indexBufferDesc), 0);
 

--- a/filament/backend/test/TrianglePrimitive.h
+++ b/filament/backend/test/TrianglePrimitive.h
@@ -52,7 +52,8 @@ private:
     filament::backend::DriverApi& mDriverApi;
 
     PrimitiveHandle mRenderPrimitive;
-    BufferObjectHandle mBufferObject;
+    BufferObjectHandle mVertexBufferObject;
+    BufferObjectHandle mIndexBufferObject;
     VertexHandle mVertexBuffer;
     IndexHandle mIndexBuffer;
 

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -449,7 +449,7 @@ TEST_F(BackendTest, DepthMinify) {
     state.rasterState.culling = RasterState::CullingMode::NONE;
     state.program = program;
     auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
     api.bindUniformBuffer(0, ubuffer);
@@ -573,7 +573,7 @@ TEST_F(BackendTest, ColorResolve) {
     state.rasterState.culling = RasterState::CullingMode::NONE;
     state.program = program;
     auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
     api.bindUniformBuffer(0, ubuffer);
@@ -695,7 +695,7 @@ TEST_F(BackendTest, DepthResolve) {
     state.rasterState.culling = RasterState::CullingMode::NONE;
     state.program = program;
     auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
     api.bindUniformBuffer(0, ubuffer);

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -175,7 +175,7 @@ TEST_F(BackendTest, BufferObjectUpdateWithOffset) {
 
     // Create a uniform buffer.
     auto ubuffer = getDriverApi().createBufferObject(sizeof(MaterialParams) + 64,
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     getDriverApi().bindUniformBuffer(0, ubuffer);
 
     // Upload uniforms.

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -188,7 +188,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             auto sgroup = api.createSamplerGroup(samplers.getSize());
             api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
             auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-                    BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+                    BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
             api.makeCurrent(swapChain, swapChain);
             api.beginFrame(0, 0);
             api.bindSamplers(0, sgroup);

--- a/filament/include/filament/BufferObject.h
+++ b/filament/include/filament/BufferObject.h
@@ -92,6 +92,36 @@ public:
          * @see IndexBuffer::setBuffer
          */
         BufferObject* build(Engine& engine);
+        
+        /**
+         * Specify a native buffer to import as a Filament buffer.
+         *
+         * The texture id is backend-specific:
+         *   - OpenGL: GLuint buffer object ID
+         *   - Metal: id<MTLBuffer>
+         *
+         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
+         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
+         *
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+         *  id<MTLBuffer> metalBuffer = ...
+         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
+         *
+         *  // after using buffer:
+         *  engine->destroy(filamentBuffer);   // only filamentBuffer handle is released
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         *
+         * @warning This method should be used as a last resort. This API is subject to change or
+         * removal.
+         *
+         * @param ids a backend specific buffer identifiers (should be the same amount of items as 
+         * bufferCount). If there are buffers among the ids which are not external, then
+         * it should marked with the value of NotExternal. 
+         *
+         * @return This Builder, for chaining calls.
+         */
+        Builder& import(intptr_t id) noexcept;
+        
     private:
         friend class FBufferObject;
     };

--- a/filament/include/filament/BufferObject.h
+++ b/filament/include/filament/BufferObject.h
@@ -77,25 +77,9 @@ public:
         Builder& bindingType(BindingType bindingType) noexcept;
 
         /**
-         * Creates the BufferObject and returns a pointer to it. After creation, the buffer
-         * object is uninitialized. Use BufferObject::setBuffer() to initialize it.
-         *
-         * @param engine Reference to the filament::Engine to associate this BufferObject with.
-         *
-         * @return pointer to the newly created object or nullptr if exceptions are disabled and
-         *         an error occurred.
-         *
-         * @exception utils::PostConditionPanic if a runtime error occurred, such as running out of
-         *            memory or other resources.
-         * @exception utils::PreConditionPanic if a parameter to a builder function was invalid.
-         *
-         * @see IndexBuffer::setBuffer
-         */
-        BufferObject* build(Engine& engine);
-        /**
          * Specify a native buffer to import as a Filament buffer.
          *
-         * The texture id is backend-specific:
+         * The buffer id is backend-specific:
          *   - OpenGL: GLuint buffer object ID
          *   - Metal: id<MTLBuffer>
          *
@@ -113,14 +97,29 @@ public:
          * @warning This method should be used as a last resort. This API is subject to change or
          * removal.
          *
-         * @param ids a backend specific buffer identifiers (should be the same amount of items as 
-         * bufferCount). If there are buffers among the ids which are not external, then
-         * it should marked with the value of NotExternal. 
+         * @param id a backend specific buffer identifier
          *
          * @return This Builder, for chaining calls.
          */
         Builder& import(intptr_t id) noexcept;
-        
+
+        /**
+         * Creates the BufferObject and returns a pointer to it. After creation, the buffer
+         * object is uninitialized. Use BufferObject::setBuffer() to initialize it.
+         *
+         * @param engine Reference to the filament::Engine to associate this BufferObject with.
+         *
+         * @return pointer to the newly created object or nullptr if exceptions are disabled and
+         *         an error occurred.
+         *
+         * @exception utils::PostConditionPanic if a runtime error occurred, such as running out of
+         *            memory or other resources.
+         * @exception utils::PreConditionPanic if a parameter to a builder function was invalid.
+         *
+         * @see IndexBuffer::setBuffer
+         */
+        BufferObject* build(Engine& engine);
+
     private:
         friend class FBufferObject;
     };

--- a/filament/include/filament/BufferObject.h
+++ b/filament/include/filament/BufferObject.h
@@ -92,7 +92,6 @@ public:
          * @see IndexBuffer::setBuffer
          */
         BufferObject* build(Engine& engine);
-        
         /**
          * Specify a native buffer to import as a Filament buffer.
          *

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -33,6 +33,7 @@ namespace filament {
 
 class FIndexBuffer;
 
+class BufferObject;
 class Engine;
 
 /**
@@ -76,6 +77,17 @@ public:
         Builder& indexCount(uint32_t indexCount) noexcept;
 
         /**
+         * Allows buffer to be swapped out and shared using BufferObject.
+         *
+         * If buffer object mode is enabled, clients must call setBufferObject rather than
+         * setBuffer. This allows sharing of data between IndexBuffer objects, but it may
+         * slightly increase the memory footprint of Filament's internal bookkeeping.
+         *
+         * @param enabled If true, enables buffer object mode.  False by default.
+         */
+        Builder& enableBufferObject(bool enabled = true) noexcept;
+
+        /**
          * Type of the index buffer, 16-bit or 32-bit.
          * @param indexType Type of indices stored in the IndexBuffer.
          * @return A reference to this Builder for chaining calls.
@@ -112,6 +124,16 @@ public:
      * @param byteOffset Offset in *bytes* into the IndexBuffer
      */
     void setBuffer(Engine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
+
+    /**
+     * Swaps in the given buffer object.
+     *
+     * To use this, you must first call enableBufferObject() on the Builder.
+     *
+     * @param engine Reference to the filament::Engine to associate this IndexBuffer with.
+     * @param bufferObject The handle to the GPU data that will be used in this buffer.
+     */
+    void setBufferObject(Engine& engine, BufferObject const* bufferObject);
 
     /**
      * Returns the size of this IndexBuffer in elements.

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -83,16 +83,6 @@ public:
         Builder& bufferType(IndexType indexType) noexcept;
 
         /**
-        * Allows buffers to wrap external (backend-specific) buffers.
-        *
-        * If external buffer mode is enabled, clients must call setExternalBuffer rather than
-        * setBuffer.
-        *
-        * @param enabled If true, enables external buffer mode.  False by default.
-        */
-        Builder& enableExternalBuffer(bool enabled = true) noexcept;
-
-        /**
          * Creates the IndexBuffer object and returns a pointer to it. After creation, the index
          * buffer is uninitialized. Use IndexBuffer::setBuffer() to initialize the IndexBuffer.
          *
@@ -108,6 +98,33 @@ public:
          * @see IndexBuffer::setBuffer
          */
         IndexBuffer* build(Engine& engine);
+
+        /**
+         * Specify a native buffer to import as a Filament index buffer.
+         *
+         * The texture id is backend-specific:
+         *   - OpenGL: GLuint buffer object ID
+         *   - Metal: id<MTLBuffer>
+         *
+         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
+         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
+         *
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+         *  id<MTLBuffer> metalBuffer = ...
+         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
+         *
+         *  // after using buffer:
+         *  engine->destroy(filamentBuffer);   // filamentBuffer is released
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         *
+         * @warning This method should be used as a last resort. This API is subject to change or
+         * removal.
+         *
+         * @param id a backend specific buffer identifier
+         *
+         * @return This Builder, for chaining calls.
+         */
+        Builder& import(intptr_t id) noexcept;
     private:
         friend class FIndexBuffer;
     };
@@ -122,23 +139,6 @@ public:
      * @param byteOffset Offset in *bytes* into the IndexBuffer
      */
     void setBuffer(Engine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
-
-
-    /**
-     * Specify a native buffer to import as a Filament index buffer.
-     *
-     * The externalBuffer pointer is backend-specific:
-     *   - Metal: id<MTLBuffer>
-     *
-     * With Metal, the id<MTLTexture> object should be cast to an intptr_t using
-     * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
-     *
-     * To use this, you must first call enableExternalBuffer() on the Builder.
-     *
-     * @param engine Reference to the filament::Engine to associate this IndexBuffer with.
-     * @param externalBuffer Pointer to the external buffer that will be used.
-     */
-    void setExternalBuffer(Engine& engine, intptr_t externalBuffer);
 
     /**
      * Returns the size of this IndexBuffer in elements.

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -98,33 +98,6 @@ public:
          * @see IndexBuffer::setBuffer
          */
         IndexBuffer* build(Engine& engine);
-
-        /**
-         * Specify a native buffer to import as a Filament index buffer.
-         *
-         * The texture id is backend-specific:
-         *   - OpenGL: GLuint buffer object ID
-         *   - Metal: id<MTLBuffer>
-         *
-         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
-         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
-         *
-         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-         *  id<MTLBuffer> metalBuffer = ...
-         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
-         *
-         *  // after using buffer:
-         *  engine->destroy(filamentBuffer);   // filamentBuffer is released
-         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-         *
-         * @warning This method should be used as a last resort. This API is subject to change or
-         * removal.
-         *
-         * @param id a backend specific buffer identifier
-         *
-         * @return This Builder, for chaining calls.
-         */
-        Builder& import(intptr_t id) noexcept;
     private:
         friend class FIndexBuffer;
     };

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -229,9 +229,10 @@ public:
          * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
          *  id <MTLTexture> metalTexture = ...
          *  filamentTexture->import(intptr_t((__bridge void*) metalTexture));
+         *  // free to release metalTexture
          *
          *  // after using texture:
-         *  engine->destroy(filamentTexture);   // only filamentTexture handle is released
+         *  engine->destroy(filamentTexture);   // metalTexture is released
          * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          *
          * @warning This method should be used as a last resort. This API is subject to change or

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -229,10 +229,9 @@ public:
          * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
          *  id <MTLTexture> metalTexture = ...
          *  filamentTexture->import(intptr_t((__bridge void*) metalTexture));
-         *  // free to release metalTexture
          *
          *  // after using texture:
-         *  engine->destroy(filamentTexture);   // metalTexture is released
+         *  engine->destroy(filamentTexture);   // only filamentTexture handle is released
          * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          *
          * @warning This method should be used as a last resort. This API is subject to change or

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -254,7 +254,6 @@ public:
      * @param bufferObject The handle to the GPU data that will be used in this buffer slot.
      */
     void setBufferObjectAt(Engine& engine, uint8_t bufferIndex, BufferObject const* bufferObject);
-
 };
 
 } // namespace filament

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -55,6 +55,9 @@ class UTILS_PUBLIC VertexBuffer : public FilamentAPI {
     struct BuilderDetails;
 
 public:
+
+    constexpr static intptr_t NotExternal = 0; 
+
     using AttributeType = backend::ElementType;
     using BufferDescriptor = backend::BufferDescriptor;
 
@@ -97,16 +100,6 @@ public:
          * @param enabled If true, enables buffer object mode.  False by default.
          */
         Builder& enableBufferObjects(bool enabled = true) noexcept;
-
-        /**
-         * Allows buffers to wrap external (backend-specific) buffers.
-         *
-         * If external buffer mode is enabled, clients must call setExternalBufferAt rather than
-         * setBufferAt.
-         *
-         * @param enabled If true, enables external buffer mode.  False by default.
-         */
-        Builder& enableExternalBuffer(bool enabled = true) noexcept;
 
         /**
          * Sets up an attribute for this vertex buffer set.
@@ -166,6 +159,63 @@ public:
          */
         VertexBuffer* build(Engine& engine);
 
+        /**
+         * Specify a native buffer to import as a Filament vertex buffer.
+         *
+         * The texture id is backend-specific:
+         *   - OpenGL: GLuint buffer object ID
+         *   - Metal: id<MTLBuffer>
+         *
+         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
+         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
+         *
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+         *  id<MTLBuffer> metalBuffer = ...
+         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
+         *
+         *  // after using buffer:
+         *  engine->destroy(filamentBuffer);   // only filamentBuffer handle is released
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         *
+         * @warning This method should be used as a last resort. This API is subject to change or
+         * removal.
+         *
+         * @param id a backend specific buffer identifier
+         *
+         * @return This Builder, for chaining calls.
+         */
+        
+        Builder& import(intptr_t id) noexcept;
+        /**
+         * Specify a native buffer to import as a Filament vertex buffer.
+         *
+         * The texture id is backend-specific:
+         *   - OpenGL: GLuint buffer object ID
+         *   - Metal: id<MTLBuffer>
+         *
+         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
+         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
+         *
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+         *  id<MTLBuffer> metalBuffer = ...
+         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
+         *
+         *  // after using buffer:
+         *  engine->destroy(filamentBuffer);   // only filamentBuffer handle is released
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         *
+         * @warning This method should be used as a last resort. This API is subject to change or
+         * removal.
+         *
+         * @param ids a backend specific buffer identifiers (should be the same amount of items as 
+         * bufferCount). If there are buffers among the ids which are not external, then
+         * it should marked with the value of NotExternal. 
+         *
+         * @return This Builder, for chaining calls.
+         */
+        Builder& import(intptr_t* ids) noexcept;
+
+
     private:
         friend class FVertexBuffer;
     };
@@ -205,23 +255,6 @@ public:
      */
     void setBufferObjectAt(Engine& engine, uint8_t bufferIndex, BufferObject const* bufferObject);
 
-    /**
-     * Specify a native buffer to import as a Filament vertex buffer.
-     *
-     * The externalBuffer pointer is backend-specific:
-     *   - Metal: id<MTLBuffer>
-     *
-     * With Metal, the id<MTLTexture> object should be cast to an intptr_t using
-     * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
-     *
-     * To use this, you must first call enableExternalBuffer() on the Builder.
-     *
-     * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
-     * @param bufferIndex Index of the buffer to initialize. Must be between 0
-     *                    and Builder::bufferCount() - 1.
-     * @param externalBuffer Pointer to the external buffer that will be used in this buffer slot.
-     */
-    void setExternalBufferAt(Engine& engine, uint8_t bufferIndex, intptr_t externalBuffer);
 };
 
 } // namespace filament

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -55,9 +55,6 @@ class UTILS_PUBLIC VertexBuffer : public FilamentAPI {
     struct BuilderDetails;
 
 public:
-
-    constexpr static intptr_t NotExternal = 0; 
-
     using AttributeType = backend::ElementType;
     using BufferDescriptor = backend::BufferDescriptor;
 
@@ -158,63 +155,6 @@ public:
          * @exception utils::PreConditionPanic if a parameter to a builder function was invalid.
          */
         VertexBuffer* build(Engine& engine);
-
-        /**
-         * Specify a native buffer to import as a Filament vertex buffer.
-         *
-         * The texture id is backend-specific:
-         *   - OpenGL: GLuint buffer object ID
-         *   - Metal: id<MTLBuffer>
-         *
-         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
-         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
-         *
-         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-         *  id<MTLBuffer> metalBuffer = ...
-         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
-         *
-         *  // after using buffer:
-         *  engine->destroy(filamentBuffer);   // only filamentBuffer handle is released
-         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-         *
-         * @warning This method should be used as a last resort. This API is subject to change or
-         * removal.
-         *
-         * @param id a backend specific buffer identifier
-         *
-         * @return This Builder, for chaining calls.
-         */
-        
-        Builder& import(intptr_t id) noexcept;
-        /**
-         * Specify a native buffer to import as a Filament vertex buffer.
-         *
-         * The texture id is backend-specific:
-         *   - OpenGL: GLuint buffer object ID
-         *   - Metal: id<MTLBuffer>
-         *
-         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
-         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
-         *
-         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-         *  id<MTLBuffer> metalBuffer = ...
-         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
-         *
-         *  // after using buffer:
-         *  engine->destroy(filamentBuffer);   // only filamentBuffer handle is released
-         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-         *
-         * @warning This method should be used as a last resort. This API is subject to change or
-         * removal.
-         *
-         * @param ids a backend specific buffer identifiers (should be the same amount of items as 
-         * bufferCount). If there are buffers among the ids which are not external, then
-         * it should marked with the value of NotExternal. 
-         *
-         * @return This Builder, for chaining calls.
-         */
-        Builder& import(intptr_t* ids) noexcept;
-
 
     private:
         friend class FVertexBuffer;

--- a/filament/src/BufferObject.cpp
+++ b/filament/src/BufferObject.cpp
@@ -67,7 +67,7 @@ FBufferObject::FBufferObject(FEngine& engine, const BufferObject::Builder& build
     } else {
         driver.setupExternalResource(mImportedId);
         mHandle = driver.importBufferObject(mImportedId, builder->mBindingType,
-                backend::BufferUsage::STATIC);
+                backend::BufferUsage::STATIC, builder->mByteCount);
     }
 }
 

--- a/filament/src/BufferObject.cpp
+++ b/filament/src/BufferObject.cpp
@@ -64,7 +64,7 @@ FBufferObject::FBufferObject(FEngine& engine, const BufferObject::Builder& build
         driver.setupExternalResource(mImportedId);
     }
     mHandle = driver.createBufferObject(builder->mByteCount, builder->mBindingType,
-            backend::BufferUsage::STATIC, mImportedId);
+            backend::BufferUsage::STATIC);
 }
 
 void FBufferObject::terminate(FEngine& engine) {

--- a/filament/src/BufferObject.cpp
+++ b/filament/src/BufferObject.cpp
@@ -59,7 +59,7 @@ BufferObject::Builder& BufferObject::Builder::import(intptr_t id) noexcept {
 // ------------------------------------------------------------------------------------------------
 
 FBufferObject::FBufferObject(FEngine& engine, const BufferObject::Builder& builder)
-        : mByteCount(builder->mByteCount), mBindingType(builder->mBindingType), mImportedId(builder->mImportedId) {
+        : mImportedId(builder->mImportedId), mByteCount(builder->mByteCount), mBindingType(builder->mBindingType) {
     FEngine::DriverApi& driver = engine.getDriverApi();
     if (UTILS_LIKELY(mImportedId == 0)) {
         mHandle = driver.createBufferObject(builder->mByteCount, builder->mBindingType,

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -88,7 +88,7 @@ Froxelizer::Froxelizer(FEngine& engine)
             "Record Buffer must use bytes");
 
     mRecordsBuffer = driverApi.createBufferObject(RECORD_BUFFER_ENTRY_COUNT,
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     mFroxelTexture = driverApi.createTexture(SamplerType::SAMPLER_2D, 1,
             backend::TextureFormat::RG16UI, 1,

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -63,8 +63,7 @@ FIndexBuffer::FIndexBuffer(FEngine& engine, const IndexBuffer::Builder& builder)
     FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createIndexBuffer(
             (backend::ElementType)builder->mIndexType,
-            uint32_t(builder->mIndexCount),
-            backend::BufferUsage::STATIC);
+            uint32_t(builder->mIndexCount));
 
     // If buffer objects are not enabled at the API level, then we create them internally.
     if (!mBufferObjectEnabled) {

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -23,7 +23,6 @@
 namespace filament {
 
 struct IndexBuffer::BuilderDetails {
-    intptr_t mImportedId = 0;
     uint32_t mIndexCount = 0;
     IndexType mIndexType = IndexType::UINT;
 };
@@ -50,23 +49,15 @@ IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
     return upcast(engine).createIndexBuffer(*this);
 }
 
-IndexBuffer::Builder& IndexBuffer::Builder::import(intptr_t id) noexcept {
-    assert_invariant(id); // imported id can't be zero
-    mImpl->mImportedId = id;
-    return *this;
-}
-
 // ------------------------------------------------------------------------------------------------
 
 FIndexBuffer::FIndexBuffer(FEngine& engine, const IndexBuffer::Builder& builder)
-        : mIndexCount(builder->mIndexCount),
-          mImportedId(builder->mImportedId) {
+        : mIndexCount(builder->mIndexCount) {
     FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createIndexBuffer(
             (backend::ElementType)builder->mIndexType,
             uint32_t(builder->mIndexCount),
-            backend::BufferUsage::STATIC, 
-            mExternalBuffersEnabled);
+            backend::BufferUsage::STATIC);
 }
 
 void FIndexBuffer::terminate(FEngine& engine) {
@@ -75,8 +66,7 @@ void FIndexBuffer::terminate(FEngine& engine) {
 }
 
 void FIndexBuffer::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset) {
-        ASSERT_PRECONDITION(mImportedId == 0, "Imported buffer can't be modified");
-        engine.getDriverApi().updateIndexBuffer(mHandle, std::move(buffer), byteOffset);
+    engine.getDriverApi().updateIndexBuffer(mHandle, std::move(buffer), byteOffset);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -69,7 +69,7 @@ FIndexBuffer::FIndexBuffer(FEngine& engine, const IndexBuffer::Builder& builder)
     // If buffer objects are not enabled at the API level, then we create them internally.
     if (!mBufferObjectEnabled) {
         mObjectHandle = engine.getDriverApi().createBufferObject(
-            mIndexCount * ((builder->mIndexType == IndexType::UINT) ? 4U : 2U),
+            mIndexCount * backend::Driver::getElementTypeSize((backend::ElementType)builder->mIndexType),
             filament::backend::BufferObjectBinding::INDEX,
             backend::BufferUsage::STATIC);
             engine.getDriverApi().setIndexBufferObject(mHandle, mObjectHandle);

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -197,7 +197,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
     if (!material->getUniformInterfaceBlock().isEmpty()) {
         mUniforms.setUniforms(other->getUniformBuffer());
         mUbHandle = driver.createBufferObject(mUniforms.getSize(),
-                BufferObjectBinding::UNIFORM, backend::BufferUsage::DYNAMIC, false);
+                BufferObjectBinding::UNIFORM, backend::BufferUsage::DYNAMIC);
     }
 
     if (!material->getSamplerInterfaceBlock().isEmpty()) {
@@ -226,7 +226,7 @@ void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* ma
     if (!material->getUniformInterfaceBlock().isEmpty()) {
         mUniforms = UniformBuffer(material->getUniformInterfaceBlock().getSize());
         mUbHandle = driver.createBufferObject(mUniforms.getSize(),
-                BufferObjectBinding::UNIFORM, backend::BufferUsage::STATIC, false);
+                BufferObjectBinding::UNIFORM, backend::BufferUsage::STATIC);
     }
 
     if (!material->getSamplerInterfaceBlock().isEmpty()) {

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -46,7 +46,7 @@ PerViewUniforms::PerViewUniforms(FEngine& engine) noexcept
     mPerViewSbh = driver.createSamplerGroup(mPerViewSb.getSize());
 
     mPerViewUbh = driver.createBufferObject(mPerViewUb.getSize(),
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     // with a clip-space of [-w, w] ==> z' = -z
     // with a clip-space of [0,  w] ==> z' = (w - z)/2

--- a/filament/src/SkinningBuffer.cpp
+++ b/filament/src/SkinningBuffer.cpp
@@ -73,8 +73,7 @@ FSkinningBuffer::FSkinningBuffer(FEngine& engine, const Builder& builder)
     mHandle = driver.createBufferObject(
             getPhysicalBoneCount(mBoneCount) * sizeof(PerRenderableUibBone),
             BufferObjectBinding::UNIFORM,
-            BufferUsage::DYNAMIC,
-            false);
+            BufferUsage::DYNAMIC);
 
     if (builder->mInitialize) {
         // initialize the bones to identity (before rounding up)

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -126,7 +126,6 @@ Texture* Texture::Builder::build(Engine& engine) {
 
     const bool sampleable = bool(mImpl->mUsage & TextureUsage::SAMPLEABLE);
     const bool swizzled = mImpl->mTextureIsSwizzled;
-    const bool imported = mImpl->mImportedId;
 
     #if defined(__EMSCRIPTEN__)
     ASSERT_POSTCONDITION_NON_FATAL(!swizzled, "WebGL does not support texture swizzling.");

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -216,8 +216,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
                     driver.setupExternalResource(builder->mImportedId[i]);
                 }
                 BufferObjectHandle bo = driver.createBufferObject(bufferSizes[i],
-                        backend::BufferObjectBinding::VERTEX, backend::BufferUsage::STATIC,
-                        builder->mImportedId[i]);
+                        backend::BufferObjectBinding::VERTEX, backend::BufferUsage::STATIC);
                 driver.setVertexBufferObject(mHandle, i, bo);
                 mBufferObjects[i] = bo;
             }

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -264,6 +264,7 @@ void FVertexBuffer::setBufferObjectAt(FEngine& engine, uint8_t bufferIndex,
         ASSERT_PRECONDITION(bufferIndex < mBufferCount, "bufferIndex must be < bufferCount");
     }
 }
+
 // ------------------------------------------------------------------------------------------------
 // Trampoline calling into private implementation
 // ------------------------------------------------------------------------------------------------

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -65,10 +65,10 @@ FView::FView(FEngine& engine)
 
     // allocate ubos
     mLightUbh = driver.createBufferObject(CONFIG_MAX_LIGHT_COUNT * sizeof(LightsUib),
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     mShadowUbh = driver.createBufferObject(mShadowUb.getSize(),
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     mIsDynamicResolutionSupported = driver.isFrameTimeSupported();
 
@@ -470,7 +470,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
                 mRenderableUBOSize = uint32_t(count * sizeof(PerRenderableUib));
                 driver.destroyBufferObject(mRenderableUbh);
                 mRenderableUbh = driver.createBufferObject(mRenderableUBOSize,
-                        BufferObjectBinding::UNIFORM, BufferUsage::STREAM, false);
+                        BufferObjectBinding::UNIFORM, BufferUsage::STREAM);
             } else {
                 // TODO: should we shrink the underlying UBO at some point?
             }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -350,8 +350,7 @@ void FRenderableManager::create(
                         .handle = driver.createBufferObject(
                                 CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone),
                                 BufferObjectBinding::UNIFORM,
-                                backend::BufferUsage::DYNAMIC,
-                                false),
+                                backend::BufferUsage::DYNAMIC),
                         .count = (uint16_t)count,
                         .offset = 0,
                         .skinningBufferMode = false };

--- a/filament/src/details/BufferObject.h
+++ b/filament/src/details/BufferObject.h
@@ -47,6 +47,7 @@ public:
 private:
     friend class BufferObject;
     backend::Handle<backend::HwBufferObject> mHandle;
+    intptr_t mImportedId;
     uint32_t mByteCount;
     BindingType mBindingType;
 };

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -27,6 +27,7 @@
 
 namespace filament {
 
+class FBufferObject;
 class FEngine;
 
 class FIndexBuffer : public IndexBuffer {
@@ -41,11 +42,13 @@ public:
     size_t getIndexCount() const noexcept { return mIndexCount; }
 
     void setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
+    void setBufferObject(FEngine& engine, FBufferObject const* bufferObject);
 
 private:
     friend class IndexBuffer;
     backend::Handle<backend::HwIndexBuffer> mHandle;
     uint32_t mIndexCount;
+    bool mBufferObjectEnabled = false;
 };
 
 FILAMENT_UPCAST(IndexBuffer)

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -45,9 +45,7 @@ public:
 private:
     friend class IndexBuffer;
     backend::Handle<backend::HwIndexBuffer> mHandle;
-    intptr_t mImportedId;
     uint32_t mIndexCount;
-    bool mExternalBuffersEnabled = false;
 };
 
 FILAMENT_UPCAST(IndexBuffer)

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -42,11 +42,10 @@ public:
 
     void setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
 
-    void setExternalBuffer(FEngine& engine, intptr_t externalBuffer);
-
 private:
     friend class IndexBuffer;
     backend::Handle<backend::HwIndexBuffer> mHandle;
+    intptr_t mImportedId;
     uint32_t mIndexCount;
     bool mExternalBuffersEnabled = false;
 };

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -32,12 +32,15 @@ class FEngine;
 
 class FIndexBuffer : public IndexBuffer {
 public:
+    using IndexBufferHandle = backend::IndexBufferHandle;
+    using BufferObjectHandle = backend::BufferObjectHandle;
+
     FIndexBuffer(FEngine& engine, const Builder& builder);
 
     // frees driver resources, object becomes invalid
     void terminate(FEngine& engine);
 
-    backend::Handle<backend::HwIndexBuffer> getHwHandle() const noexcept { return mHandle; }
+    IndexBufferHandle getHwHandle() const noexcept { return mHandle; }
 
     size_t getIndexCount() const noexcept { return mIndexCount; }
 
@@ -46,7 +49,8 @@ public:
 
 private:
     friend class IndexBuffer;
-    backend::Handle<backend::HwIndexBuffer> mHandle;
+    IndexBufferHandle mHandle;
+    BufferObjectHandle mObjectHandle;
     uint32_t mIndexCount;
     bool mBufferObjectEnabled = false;
 };

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -60,9 +60,6 @@ public:
     void setBufferObjectAt(FEngine& engine, uint8_t bufferIndex,
             FBufferObject const * bufferObject);
 
-    void setExternalBufferAt(FEngine& engine, uint8_t bufferIndex,
-            intptr_t externalBuffer);
-
 private:
     friend class VertexBuffer;
 
@@ -73,6 +70,7 @@ private:
     VertexBufferHandle mHandle;
     std::array<AttributeData, backend::MAX_VERTEX_ATTRIBUTE_COUNT> mAttributes;
     std::array<BufferObjectHandle, backend::MAX_VERTEX_BUFFER_COUNT> mBufferObjects;
+    std::array<intptr_t, backend::MAX_VERTEX_BUFFER_COUNT> mImportedId = {0};
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -70,12 +70,10 @@ private:
     VertexBufferHandle mHandle;
     std::array<AttributeData, backend::MAX_VERTEX_ATTRIBUTE_COUNT> mAttributes;
     std::array<BufferObjectHandle, backend::MAX_VERTEX_BUFFER_COUNT> mBufferObjects;
-    std::array<intptr_t, backend::MAX_VERTEX_BUFFER_COUNT> mImportedId = {0};
     AttributeBitset mDeclaredAttributes;
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;
     bool mBufferObjectsEnabled = false;
-    bool mExternalBuffersEnabled = false;
 };
 
 FILAMENT_UPCAST(VertexBuffer)


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-594](https://shapr3d.atlassian.net/browse/GFX-594)

## Short description (What? How?) 📖
This PR introduces proper external buffer support to filament. The external buffers are imported through the means of `BufferObject` class and later attachted to a `VertexBuffer` or `IndexBuffer` object. The `BufferObject::Builder::import` function behaves just like the `Texture::Builder::import` function. To pass the API-specific buffer handle to the function, it must be converted to `intptr_t`:
| API | External buffer type |
| ------------- | ------------- |
| `OpenGL`    | `GLuint` |
| `Metal`        | `id<MTLBuffer>` |

## Upstreaming scope
[GFX-1976](https://shapr3d.atlassian.net/browse/GFX-1976)

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Driver backend

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
I used Shapr3D's Visualization mode to test, because in Visualization the shape-parts loaded into Filament as external resources. Device: 
- OS: Windows 10.0.19043 build 19043
- GPU: NVIDIA Geforce RTX 2070 with Max-Q Design

Automated 💻
n/a