### PR TITLE
[GFX-2038] Implement setThreadName() on Windows

### DIFF
--- a/libs/utils/src/JobSystem.cpp
+++ b/libs/utils/src/JobSystem.cpp
@@ -35,7 +35,11 @@ static constexpr bool DEBUG_FINISH_HANGS = false;
 
 #include <math.h>
 
-#if !defined(WIN32)
+#if defined(WIN32)
+#    define NOMINMAX
+#    include <windows.h>
+#    include <string>
+# else
 #    include <pthread.h>
 #endif
 
@@ -75,8 +79,15 @@ void JobSystem::setThreadName(const char* name) noexcept {
     pthread_setname_np(pthread_self(), name);
 #elif defined(__APPLE__)
     pthread_setname_np(name);
-#else
-// TODO: implement setting thread name on WIN32
+#elif defined(WIN32)
+    std::string_view u8name(name);
+    size_t size = MultiByteToWideChar(CP_UTF8, 0, u8name.data(), u8name.size(), nullptr, 0);
+
+    std::wstring u16name;
+    u16name.resize(size);
+    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, u8name.data(), u8name.size(), u16name.data(), u16name.size());
+    
+    SetThreadDescription(GetCurrentThread(), u16name.data());
 #endif
 }
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2038](https://shapr3d.atlassian.net/browse/GFX-2038)

## Short description (What? How?) 📖
Apply thread names (`FEngine::loop`, `JobSystem::loop`) on Windows, useful in debuggers and crash dumps.  

Debugging for [GFX-2017](https://shapr3d.atlassian.net/browse/GFX-2017) required me finding Filament driver thread in Visual Studio. 

## Upstreaming scope
My intention is to open an upstream PR right after getting approved here.

## Testing

### Affected areas 🧭
Thread initialization on Windows.

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
![filament-threadname](https://user-images.githubusercontent.com/53563131/185571715-eb61e8af-966e-47ed-b64c-89793a1790f6.png)

