### PR TITLE
[GFX-594] Reintroduce buffer objects

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -288,6 +288,7 @@ enum class ElementType : uint8_t {
 //! Buffer object binding type
 enum class BufferObjectBinding : uint8_t {
     VERTEX,
+    INDEX,
     UNIFORM
 };
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -171,15 +171,18 @@ DECL_DRIVER_API_R_N(backend::VertexBufferHandle, createVertexBuffer,
 
 DECL_DRIVER_API_R_N(backend::IndexBufferHandle, createIndexBuffer,
         backend::ElementType, elementType,
-        uint32_t, indexCount,
-        backend::BufferUsage, usage,
-        bool, wrapsExternalBuffer)
+        uint32_t, indexCount)
 
 DECL_DRIVER_API_R_N(backend::BufferObjectHandle, createBufferObject,
         uint32_t, byteCount,
         backend::BufferObjectBinding, bindingType,
+        backend::BufferUsage, usage)
+
+DECL_DRIVER_API_R_N(backend::BufferObjectHandle, importBufferObject,
+        intptr_t, id,
+        backend::BufferObjectBinding, bindingType,
         backend::BufferUsage, usage,
-        bool, wrapsExternalBuffer)
+        uint32_t, byteCount)
 
 DECL_DRIVER_API_R_N(backend::TextureHandle, createTexture,
         backend::SamplerType, target,
@@ -309,23 +312,14 @@ DECL_DRIVER_API_SYNCHRONOUS_0(bool, isDepthResolveSupported)
  * -----------------------
  */
 
-DECL_DRIVER_API_N(setExternalIndexBuffer,
+DECL_DRIVER_API_N(setIndexBufferObject,
         backend::IndexBufferHandle, ibh,
-        intptr_t, externalBuffer)
-
-DECL_DRIVER_API_N(setExternalBuffer,
-        backend::BufferObjectHandle, boh,
-        intptr_t, externalBuffer)
+        backend::BufferObjectHandle, bufferObject)
 
 DECL_DRIVER_API_N(setVertexBufferObject,
         backend::VertexBufferHandle, vbh,
         uint32_t, index,
         backend::BufferObjectHandle, bufferObject)
-
-DECL_DRIVER_API_N(updateIndexBuffer,
-        backend::IndexBufferHandle, ibh,
-        backend::BufferDescriptor&&, data,
-        uint32_t, byteOffset)
 
 DECL_DRIVER_API_N(updateBufferObject,
         backend::BufferObjectHandle, ibh,

--- a/filament/backend/src/DriverBase.h
+++ b/filament/backend/src/DriverBase.h
@@ -75,6 +75,7 @@ struct HwBufferObject : public HwBase {
 struct HwIndexBuffer : public HwBase {
     uint32_t count : 27;
     uint32_t elementSize : 5;
+    uint8_t bufferObjectVersion{};      
 
     HwIndexBuffer() noexcept : count{}, elementSize{} { }
     HwIndexBuffer(uint8_t elementSize, uint32_t indexCount) noexcept :

--- a/filament/backend/src/metal/MetalBuffer.h
+++ b/filament/backend/src/metal/MetalBuffer.h
@@ -32,22 +32,16 @@ class MetalBuffer {
 public:
 
     MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, bool forceGpuBuffer = false);
+
+    // Constructor for importing an id<MTLBuffer> outside of Filament.
+    MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, id<MTLBuffer> buffer);
+
     ~MetalBuffer();
 
     MetalBuffer(const MetalBuffer& rhs) = delete;
     MetalBuffer& operator=(const MetalBuffer& rhs) = delete;
 
     size_t getSize() const noexcept { return mBufferSize; }
-
-    /**
-     * Wrap an external Metal buffer. Stores a strong reference to it.
-     */
-    void wrapExternalBuffer(id<MTLBuffer> buffer);
-
-    /**
-     * Release the external Metal buffer, if wrapping any.
-     */
-    bool releaseExternalBuffer();
 
     /**
      * Update the buffer with data inside src. Potentially allocates a new buffer allocation to hold

--- a/filament/backend/src/metal/MetalBuffer.mm
+++ b/filament/backend/src/metal/MetalBuffer.mm
@@ -44,8 +44,13 @@ MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, 
     mUsage = usage;
 }
 
+MetalBuffer::MetalBuffer(MetalContext& context, BufferUsage usage, size_t size, id<MTLBuffer> buffer)
+        : mUsage(usage), mBufferSize(size), mExternalBuffer(buffer), mContext(context) {
+    ASSERT_PRECONDITION(buffer, "External buffer cannot be nil");
+}
+
 MetalBuffer::~MetalBuffer() {
-    releaseExternalBuffer();
+    mExternalBuffer = nil;
 
     if (mCpuBuffer) {
         free(mCpuBuffer);
@@ -55,22 +60,6 @@ MetalBuffer::~MetalBuffer() {
     if (mBufferPoolEntry) {
         mContext.bufferPool->releaseBuffer(mBufferPoolEntry);
     }
-}
-
-void MetalBuffer::wrapExternalBuffer(id<MTLBuffer> buffer) {
-    ASSERT_PRECONDITION(!mExternalBuffer, "A external buffer is already wrapped. Call releaseExternalBuffer()");
-    ASSERT_PRECONDITION(buffer, "External buffer cannot be nil");
-    ASSERT_PRECONDITION(!mCpuBuffer, "This buffer is backed by CPU memory");
-    mExternalBuffer = buffer;
-}
-
-bool MetalBuffer::releaseExternalBuffer() {
-    if (!mExternalBuffer) {
-        return false;
-    }
-
-    mExternalBuffer = nil;
-    return true;
 }
 
 void MetalBuffer::copyIntoBuffer(void* src, size_t size, size_t byteOffset) {

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -239,14 +239,20 @@ void MetalDriver::createVertexBufferR(Handle<HwVertexBuffer> vbh, uint8_t buffer
 }
 
 void MetalDriver::createIndexBufferR(Handle<HwIndexBuffer> ibh, ElementType elementType,
-        uint32_t indexCount, BufferUsage usage, bool wrapsExternalBuffer) {
+        uint32_t indexCount) {
     auto elementSize = (uint8_t) getElementTypeSize(elementType);
-    construct_handle<MetalIndexBuffer>(ibh, *mContext, usage, elementSize, indexCount);
+    construct_handle<MetalIndexBuffer>(ibh, *mContext, elementSize, indexCount);
 }
 
 void MetalDriver::createBufferObjectR(Handle<HwBufferObject> boh, uint32_t byteCount,
-        BufferObjectBinding bindingType, BufferUsage usage, bool wrapsExternalBuffer) {
-    construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount, wrapsExternalBuffer);
+        BufferObjectBinding bindingType, BufferUsage usage) {
+    construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount);
+}
+
+void MetalDriver::importBufferObjectR(Handle<HwBufferObject> boh, intptr_t i,
+        BufferObjectBinding bindingType, BufferUsage usage, uint32_t byteCount) {
+    id<MTLBuffer> metalBuffer = (id<MTLBuffer>) CFBridgingRelease((void*) i);
+    construct_handle<MetalBufferObject>(boh, *mContext, usage, byteCount, metalBuffer);
 }
 
 void MetalDriver::createTextureR(Handle<HwTexture> th, SamplerType target, uint8_t levels,
@@ -401,6 +407,10 @@ Handle<HwIndexBuffer> MetalDriver::createIndexBufferS() noexcept {
 }
 
 Handle<HwBufferObject> MetalDriver::createBufferObjectS() noexcept {
+    return alloc_handle<MetalBufferObject>();
+}
+
+Handle<HwBufferObject> MetalDriver::importBufferObjectS() noexcept {
     return alloc_handle<MetalBufferObject>();
 }
 
@@ -716,13 +726,6 @@ uint8_t MetalDriver::getMaxDrawBuffers() {
     return std::min(mContext->maxColorRenderTargets, MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT);
 }
 
-void MetalDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& data,
-        uint32_t byteOffset) {
-    auto* ib = handle_cast<MetalIndexBuffer>(ibh);
-    ib->buffer.copyIntoBuffer(data.buffer, data.size, byteOffset);
-    scheduleDestroy(std::move(data));
-}
-
 void MetalDriver::updateBufferObject(Handle<HwBufferObject> boh, BufferDescriptor&& data,
         uint32_t byteOffset) {
     auto* bo = handle_cast<MetalBufferObject>(boh);
@@ -741,16 +744,10 @@ void MetalDriver::setupExternalResource(intptr_t externalResource) {
     }
 }
 
-void MetalDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, intptr_t externalBuffer) {
-    auto* ib = handle_cast<MetalIndexBuffer>(ibh);
-    ib->buffer.releaseExternalBuffer();
-    ib->buffer.wrapExternalBuffer((id<MTLBuffer>) CFBridgingRelease((void*) externalBuffer));
-}
-
-void MetalDriver::setExternalBuffer(Handle<HwBufferObject> boh, intptr_t externalBuffer) {
-    auto* bo = handle_cast<MetalBufferObject>(boh);
-    bo->getBuffer()->releaseExternalBuffer();
-    bo->getBuffer()->wrapExternalBuffer((id<MTLBuffer>) CFBridgingRelease((void*) externalBuffer));
+void MetalDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBufferObject> boh) {
+    auto* indexBuffer = handle_cast<MetalIndexBuffer>(ibh);
+    auto* bufferObject = handle_cast<MetalBufferObject>(boh);
+    indexBuffer->buffer = bufferObject->getBuffer();
 }
 
 void MetalDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,
@@ -1392,8 +1389,8 @@ void MetalDriver::draw(backend::PipelineState ps, Handle<HwRenderPrimitive> rph)
     MetalIndexBuffer* indexBuffer = primitive->indexBuffer;
 
     id<MTLCommandBuffer> cmdBuffer = getPendingCommandBuffer(mContext);
-    id<MTLBuffer> metalIndexBuffer = indexBuffer->buffer.getGpuBufferForDraw(cmdBuffer);
-    size_t offset = indexBuffer->buffer.getGpuBufferStreamOffset();
+    id<MTLBuffer> metalIndexBuffer = indexBuffer->buffer->getGpuBufferForDraw(cmdBuffer);
+    size_t offset = indexBuffer->buffer->getGpuBufferStreamOffset();
     [mContext->currentRenderPassEncoder drawIndexedPrimitives:getMetalPrimitiveType(primitive->type)
                                                    indexCount:primitive->count
                                                     indexType:getIndexType(indexBuffer->elementSize)

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -115,8 +115,10 @@ private:
 
 class MetalBufferObject : public HwBufferObject {
 public:
-    MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount,
-            bool wrapsExternalBuffer);
+    MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount);
+
+    // Constructor for importing an id<MTLBuffer> outside of Filament.
+    MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount, id<MTLBuffer> buffer);
 
     void updateBuffer(void* data, size_t size, uint32_t byteOffset);
     MetalBuffer* getBuffer() { return &buffer; }
@@ -137,10 +139,10 @@ struct MetalVertexBuffer : public HwVertexBuffer {
 };
 
 struct MetalIndexBuffer : public HwIndexBuffer {
-    MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
+    MetalIndexBuffer(MetalContext& context, uint8_t elementSize,
             uint32_t indexCount);
 
-    MetalBuffer buffer;
+    MetalBuffer* buffer = nullptr;
 };
 
 struct MetalRenderPrimitive : public HwRenderPrimitive {

--- a/filament/backend/src/metal/MetalHandles.mm
+++ b/filament/backend/src/metal/MetalHandles.mm
@@ -263,8 +263,11 @@ void MetalSwapChain::scheduleFrameCompletedCallback() {
     }];
 }
 
-MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount,bool wrapsExternalBuffer)
-        : HwBufferObject(byteCount), buffer(context, usage, byteCount, wrapsExternalBuffer) {}
+MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount)
+        : HwBufferObject(byteCount), buffer(context, usage, byteCount) {}
+
+MetalBufferObject::MetalBufferObject(MetalContext& context, BufferUsage usage, uint32_t byteCount, id<MTLBuffer> buffer)
+        : HwBufferObject(byteCount), buffer(context, usage, byteCount, buffer) {}
 
 void MetalBufferObject::updateBuffer(void* data, size_t size, uint32_t byteOffset) {
     buffer.copyIntoBuffer(data, size, byteOffset);
@@ -274,9 +277,8 @@ MetalVertexBuffer::MetalVertexBuffer(MetalContext& context, uint8_t bufferCount,
             uint8_t attributeCount, uint32_t vertexCount, AttributeArray const& attributes)
     : HwVertexBuffer(bufferCount, attributeCount, vertexCount, attributes), buffers(bufferCount, nullptr) {}
 
-MetalIndexBuffer::MetalIndexBuffer(MetalContext& context, BufferUsage usage, uint8_t elementSize,
-        uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
-        buffer(context, usage, elementSize * indexCount, true) { }
+MetalIndexBuffer::MetalIndexBuffer(MetalContext& context, uint8_t elementSize,
+        uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount) { }
 
 void MetalRenderPrimitive::setBuffers(MetalVertexBuffer* vertexBuffer, MetalIndexBuffer*
         indexBuffer) {

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -180,11 +180,6 @@ uint8_t NoopDriver::getMaxDrawBuffers() {
     return backend::MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT;
 }
 
-void NoopDriver::updateIndexBuffer(Handle<HwIndexBuffer> ibh, BufferDescriptor&& p,
-        uint32_t byteOffset) {
-    scheduleDestroy(std::move(p));
-}
-
 void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor&& p,
         uint32_t byteOffset) {
     scheduleDestroy(std::move(p));
@@ -193,10 +188,7 @@ void NoopDriver::updateBufferObject(Handle<HwBufferObject> ibh, BufferDescriptor
 void NoopDriver::setupExternalResource(intptr_t externalResource) {
 }
 
-void NoopDriver::setExternalIndexBuffer(Handle<HwIndexBuffer> ibh, intptr_t externalBuffer) {
-}
-
-void NoopDriver::setExternalBuffer(Handle<HwBufferObject> boh, intptr_t externalBuffer) {
+void NoopDriver::setIndexBufferObject(Handle<HwIndexBuffer> ibh, Handle<HwBufferObject> boh) {
 }
 
 void NoopDriver::setVertexBufferObject(Handle<HwVertexBuffer> vbh, uint32_t index,

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -119,6 +119,8 @@ constexpr inline GLenum getBufferBindingType(backend::BufferObjectBinding bindin
     switch (bindingType) {
         case backend::BufferObjectBinding::VERTEX:
             return GL_ARRAY_BUFFER;
+        case backend::BufferObjectBinding::INDEX:
+            return GL_ELEMENT_ARRAY_BUFFER;
         case backend::BufferObjectBinding::UNIFORM:
             return GL_UNIFORM_BUFFER;
     }

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -50,10 +50,15 @@ public:
         // VertexBuffer supports buffer objects. If this is zero, then the VBO handles array is
         // immutable.
         backend::Handle<backend::HwVertexBuffer> vertexBufferWithObjects = {};
+        backend::Handle<backend::HwIndexBuffer> indexBuffer = {};
 
         // If this version number does not match vertexBufferWithObjects->bufferObjectsVersion,
         // then the VAO needs to be updated.
         uint8_t vertexBufferVersion = 0;
+        
+        // If this version number does not match indexBuffer->bufferObjectVersion,
+        // then the VAO needs to be updated.
+        uint8_t indexBufferVersion = 0;
     } gl;
 
     OpenGLContext() noexcept;

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -1214,7 +1214,6 @@ void OpenGLDriver::destroyIndexBuffer(Handle<HwIndexBuffer> ibh) {
     if (ibh) {
         auto& gl = mContext;
         GLIndexBuffer const* ib = handle_cast<const GLIndexBuffer*>(ibh);
-        gl.deleteBuffers(1, &ib->gl.buffer, GL_ELEMENT_ARRAY_BUFFER);
         destruct(ibh, ib);
     }
 }

--- a/filament/backend/src/opengl/OpenGLDriver.h
+++ b/filament/backend/src/opengl/OpenGLDriver.h
@@ -67,12 +67,6 @@ public:
 
     // OpenGLDriver specific fields
 
-    struct GLBufferHandle {
-        GLuint id = 0;
-        GLenum binding = 0;
-        bool isExternal = false;
-    };
-
     struct GLBufferObject : public backend::HwBufferObject {
         using HwBufferObject::HwBufferObject;
         GLBufferObject(uint32_t size,
@@ -80,7 +74,11 @@ public:
                 : HwBufferObject(size), usage(usage) {
             gl.binding = GLUtils::getBufferBindingType(bindingType);
         }
-        GLBufferHandle gl;
+        struct {
+            GLuint id = 0;
+            GLenum binding = 0;
+            bool isExternal = false;
+        } gl;
         uint32_t base = 0;
         uint32_t size = 0;
         backend::BufferUsage usage = {};
@@ -96,7 +94,9 @@ public:
 
     struct GLIndexBuffer : public backend::HwIndexBuffer {
         using HwIndexBuffer::HwIndexBuffer;
-        GLBufferHandle gl;
+        struct {
+            GLuint buffer{};
+        } gl;
     };
 
     struct GLSamplerGroup : public backend::HwSamplerGroup {

--- a/filament/backend/src/opengl/gl_headers.cpp
+++ b/filament/backend/src/opengl/gl_headers.cpp
@@ -48,10 +48,6 @@ PFNGLGETQUERYOBJECTUI64VEXTPROC glGetQueryObjectui64v;
 #ifdef GL_EXT_clip_control
 PFNGLCLIPCONTROLEXTPROC glClipControl;
 #endif
-#ifdef GL_EXT_external_buffer
-PFNGLBUFFERSTORAGEEXTERNALEXTPROC glBufferStorageExternalEXT;
-PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC glNamedBufferStorageExternalEXT;
-#endif
 
 static std::once_flag sGlExtInitialized;
 
@@ -112,13 +108,6 @@ void importGLESExtensionsEntryPoints() {
     glClipControl =
             (PFNGLCLIPCONTROLEXTPROC)eglGetProcAddress(
                     "glClipControlEXT");
-#endif
-
-#ifdef GL_EXT_external_buffer
-     glBufferStorageExternalEXT = (PFNGLBUFFERSTORAGEEXTERNALEXTPROC)eglGetProcAddress(
-        "glBufferStorageExternalEXT");
-     glNamedBufferStorageExternalEXT = (PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC)eglGetProcAddress(
-        "glNamedBufferStorageExternalEXT");
 #endif
 }
 

--- a/filament/backend/src/opengl/gl_headers.h
+++ b/filament/backend/src/opengl/gl_headers.h
@@ -61,10 +61,6 @@
         #define GL_ZERO_TO_ONE GL_ZERO_TO_ONE_EXT
         #endif
 #endif
-#ifdef GL_EXT_external_buffer
-        extern PFNGLBUFFERSTORAGEEXTERNALEXTPROC glBufferStorageExternalEXT;
-        extern PFNGLNAMEDBUFFERSTORAGEEXTERNALEXTPROC glNamedBufferStorageExternalEXT;
-#endif
     }
 
     // Prevent lots of #ifdef's between desktop and mobile by providing some suffix-free constants:

--- a/filament/backend/src/ostream.cpp
+++ b/filament/backend/src/ostream.cpp
@@ -365,6 +365,7 @@ io::ostream& operator<<(io::ostream& out, SamplerCompareFunc func) {
 io::ostream& operator<<(io::ostream& out, BufferObjectBinding binding) {
     switch (binding) {
         CASE(BufferObjectBinding, VERTEX)
+        CASE(BufferObjectBinding, INDEX)
         CASE(BufferObjectBinding, UNIFORM)
     }
     return out;

--- a/filament/backend/src/vulkan/VulkanHandles.h
+++ b/filament/backend/src/vulkan/VulkanHandles.h
@@ -84,11 +84,8 @@ struct VulkanVertexBuffer : public HwVertexBuffer {
 struct VulkanIndexBuffer : public HwIndexBuffer {
     VulkanIndexBuffer(VulkanContext& context, VulkanStagePool& stagePool,
             uint8_t elementSize, uint32_t indexCount) : HwIndexBuffer(elementSize, indexCount),
-            buffer(context, stagePool,
-                    VK_BUFFER_USAGE_INDEX_BUFFER_BIT, elementSize * indexCount),
             indexType(elementSize == 2 ? VK_INDEX_TYPE_UINT16 : VK_INDEX_TYPE_UINT32) {}
-    void terminate(VulkanContext& context) { buffer.terminate(context); }
-    VulkanBuffer buffer;
+    VulkanBuffer* buffer;
     const VkIndexType indexType;
 };
 
@@ -137,6 +134,8 @@ inline constexpr VkBufferUsageFlagBits getBufferObjectUsage(
     switch(bindingType) {
         case BufferObjectBinding::VERTEX:
             return VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+        case BufferObjectBinding::INDEX:
+            return VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
         case BufferObjectBinding::UNIFORM:
             return VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         // when adding more buffer types here, make sure to update VulkanBuffer::loadFromCpu()

--- a/filament/backend/test/TrianglePrimitive.h
+++ b/filament/backend/test/TrianglePrimitive.h
@@ -52,7 +52,8 @@ private:
     filament::backend::DriverApi& mDriverApi;
 
     PrimitiveHandle mRenderPrimitive;
-    BufferObjectHandle mBufferObject;
+    BufferObjectHandle mVertexBufferObject;
+    BufferObjectHandle mIndexBufferObject;
     VertexHandle mVertexBuffer;
     IndexHandle mIndexBuffer;
 

--- a/filament/backend/test/test_Blit.cpp
+++ b/filament/backend/test/test_Blit.cpp
@@ -449,7 +449,7 @@ TEST_F(BackendTest, DepthMinify) {
     state.rasterState.culling = RasterState::CullingMode::NONE;
     state.program = program;
     auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
     api.bindUniformBuffer(0, ubuffer);
@@ -573,7 +573,7 @@ TEST_F(BackendTest, ColorResolve) {
     state.rasterState.culling = RasterState::CullingMode::NONE;
     state.program = program;
     auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
     api.bindUniformBuffer(0, ubuffer);
@@ -695,7 +695,7 @@ TEST_F(BackendTest, DepthResolve) {
     state.rasterState.culling = RasterState::CullingMode::NONE;
     state.program = program;
     auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     api.makeCurrent(swapChain, swapChain);
     api.beginFrame(0, 0);
     api.bindUniformBuffer(0, ubuffer);

--- a/filament/backend/test/test_BufferUpdates.cpp
+++ b/filament/backend/test/test_BufferUpdates.cpp
@@ -175,7 +175,7 @@ TEST_F(BackendTest, BufferObjectUpdateWithOffset) {
 
     // Create a uniform buffer.
     auto ubuffer = getDriverApi().createBufferObject(sizeof(MaterialParams) + 64,
-            BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
     getDriverApi().bindUniformBuffer(0, ubuffer);
 
     // Upload uniforms.

--- a/filament/backend/test/test_FeedbackLoops.cpp
+++ b/filament/backend/test/test_FeedbackLoops.cpp
@@ -188,7 +188,7 @@ TEST_F(BackendTest, FeedbackLoops) {
             auto sgroup = api.createSamplerGroup(samplers.getSize());
             api.updateSamplerGroup(sgroup, std::move(samplers.toCommandStream()));
             auto ubuffer = api.createBufferObject(sizeof(MaterialParams),
-                    BufferObjectBinding::UNIFORM, BufferUsage::STATIC, false);
+                    BufferObjectBinding::UNIFORM, BufferUsage::STATIC);
             api.makeCurrent(swapChain, swapChain);
             api.beginFrame(0, 0);
             api.bindSamplers(0, sgroup);

--- a/filament/include/filament/BufferObject.h
+++ b/filament/include/filament/BufferObject.h
@@ -77,6 +77,33 @@ public:
         Builder& bindingType(BindingType bindingType) noexcept;
 
         /**
+         * Specify a native buffer to import as a Filament buffer.
+         *
+         * The buffer id is backend-specific:
+         *   - OpenGL: GLuint buffer object ID
+         *   - Metal: id<MTLBuffer>
+         *
+         * With Metal, the id<MTLBuffer> object should be cast to an intptr_t using
+         * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
+         *
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+         *  id<MTLBuffer> metalBuffer = ...
+         *  filamentBuffer->import(intptr_t((__bridge void*) metalBuffer));
+         *
+         *  // after using buffer:
+         *  engine->destroy(filamentBuffer);   // only filamentBuffer handle is released
+         * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         *
+         * @warning This method should be used as a last resort. This API is subject to change or
+         * removal.
+         *
+         * @param id a backend specific buffer identifier
+         *
+         * @return This Builder, for chaining calls.
+         */
+        Builder& import(intptr_t id) noexcept;
+
+        /**
          * Creates the BufferObject and returns a pointer to it. After creation, the buffer
          * object is uninitialized. Use BufferObject::setBuffer() to initialize it.
          *
@@ -92,6 +119,7 @@ public:
          * @see IndexBuffer::setBuffer
          */
         BufferObject* build(Engine& engine);
+
     private:
         friend class FBufferObject;
     };

--- a/filament/include/filament/IndexBuffer.h
+++ b/filament/include/filament/IndexBuffer.h
@@ -33,6 +33,7 @@ namespace filament {
 
 class FIndexBuffer;
 
+class BufferObject;
 class Engine;
 
 /**
@@ -76,21 +77,22 @@ public:
         Builder& indexCount(uint32_t indexCount) noexcept;
 
         /**
+         * Allows buffer to be swapped out and shared using BufferObject.
+         *
+         * If buffer object mode is enabled, clients must call setBufferObject rather than
+         * setBuffer. This allows sharing of data between IndexBuffer objects, but it may
+         * slightly increase the memory footprint of Filament's internal bookkeeping.
+         *
+         * @param enabled If true, enables buffer object mode.  False by default.
+         */
+        Builder& enableBufferObject(bool enabled = true) noexcept;
+
+        /**
          * Type of the index buffer, 16-bit or 32-bit.
          * @param indexType Type of indices stored in the IndexBuffer.
          * @return A reference to this Builder for chaining calls.
          */
         Builder& bufferType(IndexType indexType) noexcept;
-
-        /**
-        * Allows buffers to wrap external (backend-specific) buffers.
-        *
-        * If external buffer mode is enabled, clients must call setExternalBuffer rather than
-        * setBuffer.
-        *
-        * @param enabled If true, enables external buffer mode.  False by default.
-        */
-        Builder& enableExternalBuffer(bool enabled = true) noexcept;
 
         /**
          * Creates the IndexBuffer object and returns a pointer to it. After creation, the index
@@ -123,22 +125,15 @@ public:
      */
     void setBuffer(Engine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
 
-
     /**
-     * Specify a native buffer to import as a Filament index buffer.
+     * Swaps in the given buffer object.
      *
-     * The externalBuffer pointer is backend-specific:
-     *   - Metal: id<MTLBuffer>
-     *
-     * With Metal, the id<MTLTexture> object should be cast to an intptr_t using
-     * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
-     *
-     * To use this, you must first call enableExternalBuffer() on the Builder.
+     * To use this, you must first call enableBufferObject() on the Builder.
      *
      * @param engine Reference to the filament::Engine to associate this IndexBuffer with.
-     * @param externalBuffer Pointer to the external buffer that will be used.
+     * @param bufferObject The handle to the GPU data that will be used in this buffer.
      */
-    void setExternalBuffer(Engine& engine, intptr_t externalBuffer);
+    void setBufferObject(Engine& engine, BufferObject const* bufferObject);
 
     /**
      * Returns the size of this IndexBuffer in elements.

--- a/filament/include/filament/VertexBuffer.h
+++ b/filament/include/filament/VertexBuffer.h
@@ -99,16 +99,6 @@ public:
         Builder& enableBufferObjects(bool enabled = true) noexcept;
 
         /**
-         * Allows buffers to wrap external (backend-specific) buffers.
-         *
-         * If external buffer mode is enabled, clients must call setExternalBufferAt rather than
-         * setBufferAt.
-         *
-         * @param enabled If true, enables external buffer mode.  False by default.
-         */
-        Builder& enableExternalBuffer(bool enabled = true) noexcept;
-
-        /**
          * Sets up an attribute for this vertex buffer set.
          *
          * Using \p byteOffset and \p byteStride, attributes can be interleaved in the same buffer.
@@ -204,24 +194,6 @@ public:
      * @param bufferObject The handle to the GPU data that will be used in this buffer slot.
      */
     void setBufferObjectAt(Engine& engine, uint8_t bufferIndex, BufferObject const* bufferObject);
-
-    /**
-     * Specify a native buffer to import as a Filament vertex buffer.
-     *
-     * The externalBuffer pointer is backend-specific:
-     *   - Metal: id<MTLBuffer>
-     *
-     * With Metal, the id<MTLTexture> object should be cast to an intptr_t using
-     * __bridge cast to transfer to Filament. Management of ownership is done by Filament.
-     *
-     * To use this, you must first call enableExternalBuffer() on the Builder.
-     *
-     * @param engine Reference to the filament::Engine to associate this VertexBuffer with.
-     * @param bufferIndex Index of the buffer to initialize. Must be between 0
-     *                    and Builder::bufferCount() - 1.
-     * @param externalBuffer Pointer to the external buffer that will be used in this buffer slot.
-     */
-    void setExternalBufferAt(Engine& engine, uint8_t bufferIndex, intptr_t externalBuffer);
 };
 
 } // namespace filament

--- a/filament/src/Froxelizer.cpp
+++ b/filament/src/Froxelizer.cpp
@@ -88,7 +88,7 @@ Froxelizer::Froxelizer(FEngine& engine)
             "Record Buffer must use bytes");
 
     mRecordsBuffer = driverApi.createBufferObject(RECORD_BUFFER_ENTRY_COUNT,
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     mFroxelTexture = driverApi.createTexture(SamplerType::SAMPLER_2D, 1,
             backend::TextureFormat::RG16UI, 1,

--- a/filament/src/IndexBuffer.cpp
+++ b/filament/src/IndexBuffer.cpp
@@ -16,6 +16,7 @@
 
 #include "details/IndexBuffer.h"
 
+#include "details/BufferObject.h"
 #include "details/Engine.h"
 
 #include "FilamentAPI-impl.h"
@@ -25,7 +26,7 @@ namespace filament {
 struct IndexBuffer::BuilderDetails {
     uint32_t mIndexCount = 0;
     IndexType mIndexType = IndexType::UINT;
-    bool mExternalBuffersEnabled = false;
+    bool mBufferObjectEnabled = false;
 };
 
 using BuilderType = IndexBuffer;
@@ -41,13 +42,13 @@ IndexBuffer::Builder& IndexBuffer::Builder::indexCount(uint32_t indexCount) noex
     return *this;
 }
 
-IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType indexType) noexcept {
-    mImpl->mIndexType = indexType;
+IndexBuffer::Builder& IndexBuffer::Builder::enableBufferObject(bool enabled) noexcept {
+    mImpl->mBufferObjectEnabled = enabled;
     return *this;
 }
 
-IndexBuffer::Builder& IndexBuffer::Builder::enableExternalBuffer(bool enabled) noexcept {
-    mImpl->mExternalBuffersEnabled = enabled;
+IndexBuffer::Builder& IndexBuffer::Builder::bufferType(IndexType indexType) noexcept {
+    mImpl->mIndexType = indexType;
     return *this;
 }
 
@@ -58,30 +59,41 @@ IndexBuffer* IndexBuffer::Builder::build(Engine& engine) {
 // ------------------------------------------------------------------------------------------------
 
 FIndexBuffer::FIndexBuffer(FEngine& engine, const IndexBuffer::Builder& builder)
-        : mIndexCount(builder->mIndexCount),
-          mExternalBuffersEnabled(builder->mExternalBuffersEnabled) {
+        : mIndexCount(builder->mIndexCount), mBufferObjectEnabled(builder->mBufferObjectEnabled) {
     FEngine::DriverApi& driver = engine.getDriverApi();
     mHandle = driver.createIndexBuffer(
             (backend::ElementType)builder->mIndexType,
-            uint32_t(builder->mIndexCount),
-            backend::BufferUsage::STATIC, 
-            mExternalBuffersEnabled);
+            uint32_t(builder->mIndexCount));
+
+    // If buffer objects are not enabled at the API level, then we create them internally.
+    if (!mBufferObjectEnabled) {
+        mObjectHandle = engine.getDriverApi().createBufferObject(
+            mIndexCount * backend::Driver::getElementTypeSize((backend::ElementType)builder->mIndexType),
+            filament::backend::BufferObjectBinding::INDEX,
+            backend::BufferUsage::STATIC);
+            engine.getDriverApi().setIndexBufferObject(mHandle, mObjectHandle);
+    }
 }
 
 void FIndexBuffer::terminate(FEngine& engine) {
     FEngine::DriverApi& driver = engine.getDriverApi();
+    if (!mBufferObjectEnabled) {
+        driver.destroyBufferObject(mObjectHandle);
+    }
     driver.destroyIndexBuffer(mHandle);
 }
 
 void FIndexBuffer::setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset) {
-    ASSERT_PRECONDITION(!mExternalBuffersEnabled, "Please use setExternalBuffer()");
-    engine.getDriverApi().updateIndexBuffer(mHandle, std::move(buffer), byteOffset);
+    ASSERT_PRECONDITION(!mBufferObjectEnabled, "Please use setBufferObject()");
+    engine.getDriverApi().updateBufferObject(mObjectHandle, std::move(buffer), byteOffset);
 }
 
-void FIndexBuffer::setExternalBuffer(FEngine& engine, intptr_t externalBuffer) {
-    ASSERT_PRECONDITION(mExternalBuffersEnabled, "Please use setBuffer()");
-    engine.getDriverApi().setupExternalResource(externalBuffer);
-    engine.getDriverApi().setExternalIndexBuffer(mHandle, externalBuffer);
+void FIndexBuffer::setBufferObject(FEngine& engine, FBufferObject const* bufferObject) {
+    ASSERT_PRECONDITION(mBufferObjectEnabled, "Please use setBuffer()");
+    ASSERT_PRECONDITION(bufferObject->getBindingType() == BufferObject::BindingType::INDEX,
+        "Binding type must be INDEX.");
+    auto hwBufferObject = bufferObject->getHwHandle();
+    engine.getDriverApi().setIndexBufferObject(mHandle, hwBufferObject);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -93,12 +105,12 @@ void IndexBuffer::setBuffer(Engine& engine,
     upcast(this)->setBuffer(upcast(engine), std::move(buffer), byteOffset);
 }
 
-size_t IndexBuffer::getIndexCount() const noexcept {
-    return upcast(this)->getIndexCount();
+void IndexBuffer::setBufferObject(Engine& engine, BufferObject const* bufferObject) {
+    upcast(this)->setBufferObject(upcast(engine), upcast(bufferObject));
 }
 
-void IndexBuffer::setExternalBuffer(Engine& engine, intptr_t externalBuffer) {
-    upcast(this)->setExternalBuffer(upcast(engine), externalBuffer);
+size_t IndexBuffer::getIndexCount() const noexcept {
+    return upcast(this)->getIndexCount();
 }
 
 } // namespace filament

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -197,7 +197,7 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
     if (!material->getUniformInterfaceBlock().isEmpty()) {
         mUniforms.setUniforms(other->getUniformBuffer());
         mUbHandle = driver.createBufferObject(mUniforms.getSize(),
-                BufferObjectBinding::UNIFORM, backend::BufferUsage::DYNAMIC, false);
+                BufferObjectBinding::UNIFORM, backend::BufferUsage::DYNAMIC);
     }
 
     if (!material->getSamplerInterfaceBlock().isEmpty()) {
@@ -226,7 +226,7 @@ void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* ma
     if (!material->getUniformInterfaceBlock().isEmpty()) {
         mUniforms = UniformBuffer(material->getUniformInterfaceBlock().getSize());
         mUbHandle = driver.createBufferObject(mUniforms.getSize(),
-                BufferObjectBinding::UNIFORM, backend::BufferUsage::STATIC, false);
+                BufferObjectBinding::UNIFORM, backend::BufferUsage::STATIC);
     }
 
     if (!material->getSamplerInterfaceBlock().isEmpty()) {

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -46,7 +46,7 @@ PerViewUniforms::PerViewUniforms(FEngine& engine) noexcept
     mPerViewSbh = driver.createSamplerGroup(mPerViewSb.getSize());
 
     mPerViewUbh = driver.createBufferObject(mPerViewUb.getSize(),
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     // with a clip-space of [-w, w] ==> z' = -z
     // with a clip-space of [0,  w] ==> z' = (w - z)/2

--- a/filament/src/SkinningBuffer.cpp
+++ b/filament/src/SkinningBuffer.cpp
@@ -73,8 +73,7 @@ FSkinningBuffer::FSkinningBuffer(FEngine& engine, const Builder& builder)
     mHandle = driver.createBufferObject(
             getPhysicalBoneCount(mBoneCount) * sizeof(PerRenderableUibBone),
             BufferObjectBinding::UNIFORM,
-            BufferUsage::DYNAMIC,
-            false);
+            BufferUsage::DYNAMIC);
 
     if (builder->mInitialize) {
         // initialize the bones to identity (before rounding up)

--- a/filament/src/Texture.cpp
+++ b/filament/src/Texture.cpp
@@ -126,7 +126,6 @@ Texture* Texture::Builder::build(Engine& engine) {
 
     const bool sampleable = bool(mImpl->mUsage & TextureUsage::SAMPLEABLE);
     const bool swizzled = mImpl->mTextureIsSwizzled;
-    const bool imported = mImpl->mImportedId;
 
     #if defined(__EMSCRIPTEN__)
     ASSERT_POSTCONDITION_NON_FATAL(!swizzled, "WebGL does not support texture swizzling.");

--- a/filament/src/VertexBuffer.cpp
+++ b/filament/src/VertexBuffer.cpp
@@ -36,7 +36,6 @@ struct VertexBuffer::BuilderDetails {
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;
     bool mBufferObjectsEnabled = false;
-    bool mExternalBuffersEnabled = false;
 };
 
 using BuilderType = VertexBuffer;
@@ -54,11 +53,6 @@ VertexBuffer::Builder& VertexBuffer::Builder::vertexCount(uint32_t vertexCount) 
 
 VertexBuffer::Builder& VertexBuffer::Builder::enableBufferObjects(bool enabled) noexcept {
     mImpl->mBufferObjectsEnabled = enabled;
-    return *this;
-}
-
-VertexBuffer::Builder& VertexBuffer::Builder::enableExternalBuffer(bool enabled) noexcept {
-    mImpl->mExternalBuffersEnabled = enabled;
     return *this;
 }
 
@@ -152,8 +146,7 @@ VertexBuffer* VertexBuffer::Builder::build(Engine& engine) {
 
 FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& builder)
         : mVertexCount(builder->mVertexCount), mBufferCount(builder->mBufferCount),
-          mBufferObjectsEnabled(builder->mBufferObjectsEnabled),
-          mExternalBuffersEnabled(builder->mExternalBuffersEnabled) {
+          mBufferObjectsEnabled(builder->mBufferObjectsEnabled) {
     std::copy(std::begin(builder->mAttributes), std::end(builder->mAttributes), mAttributes.begin());
 
     mDeclaredAttributes = builder->mDeclaredAttributes;
@@ -205,8 +198,7 @@ FVertexBuffer::FVertexBuffer(FEngine& engine, const VertexBuffer::Builder& build
         for (size_t i = 0; i < MAX_VERTEX_BUFFER_COUNT; ++i) {
             if (bufferSizes[i] > 0) {
                 BufferObjectHandle bo = driver.createBufferObject(bufferSizes[i],
-                        backend::BufferObjectBinding::VERTEX, backend::BufferUsage::STATIC,
-                        mExternalBuffersEnabled);
+                        backend::BufferObjectBinding::VERTEX, backend::BufferUsage::STATIC);
                 driver.setVertexBufferObject(mHandle, i, bo);
                 mBufferObjects[i] = bo;
             }
@@ -231,7 +223,6 @@ size_t FVertexBuffer::getVertexCount() const noexcept {
 void FVertexBuffer::setBufferAt(FEngine& engine, uint8_t bufferIndex,
         backend::BufferDescriptor&& buffer, uint32_t byteOffset) {
     ASSERT_PRECONDITION(!mBufferObjectsEnabled, "Please use setBufferObjectAt()");
-    ASSERT_PRECONDITION(!mExternalBuffersEnabled, "Please use setExternalBufferAt()");
     if (bufferIndex < mBufferCount) {
         assert_invariant(mBufferObjects[bufferIndex]);
         engine.getDriverApi().updateBufferObject(mBufferObjects[bufferIndex],
@@ -243,26 +234,12 @@ void FVertexBuffer::setBufferAt(FEngine& engine, uint8_t bufferIndex,
 
 void FVertexBuffer::setBufferObjectAt(FEngine& engine, uint8_t bufferIndex,
         FBufferObject const * bufferObject) {
-    ASSERT_PRECONDITION(!mExternalBuffersEnabled, "Please use setExternalBufferAt()");
     ASSERT_PRECONDITION(mBufferObjectsEnabled, "Please use setBufferAt()");
     ASSERT_PRECONDITION(bufferObject->getBindingType() == BufferObject::BindingType::VERTEX,
             "Binding type must be VERTEX.");
     if (bufferIndex < mBufferCount) {
         auto hwBufferObject = bufferObject->getHwHandle();
         engine.getDriverApi().setVertexBufferObject(mHandle, bufferIndex, hwBufferObject);
-    } else {
-        ASSERT_PRECONDITION(bufferIndex < mBufferCount, "bufferIndex must be < bufferCount");
-    }
-}
-
-void FVertexBuffer::setExternalBufferAt(FEngine& engine, uint8_t bufferIndex,
-         intptr_t externalBuffer) {
-    ASSERT_PRECONDITION(!mBufferObjectsEnabled, "Please use setBufferObjectAt()");
-    ASSERT_PRECONDITION(mExternalBuffersEnabled, "Please use setBufferAt()");
-    if (bufferIndex < mBufferCount) {
-        assert_invariant(mBufferObjects[bufferIndex]);
-        engine.getDriverApi().setupExternalResource(externalBuffer);
-        engine.getDriverApi().setExternalBuffer(mBufferObjects[bufferIndex], externalBuffer);
     } else {
         ASSERT_PRECONDITION(bufferIndex < mBufferCount, "bufferIndex must be < bufferCount");
     }
@@ -284,10 +261,6 @@ void VertexBuffer::setBufferAt(Engine& engine, uint8_t bufferIndex,
 void VertexBuffer::setBufferObjectAt(Engine& engine, uint8_t bufferIndex,
         BufferObject const* bufferObject) {
     upcast(this)->setBufferObjectAt(upcast(engine), bufferIndex, upcast(bufferObject));
-}
-
-void VertexBuffer::setExternalBufferAt(Engine& engine, uint8_t bufferIndex, intptr_t externalBuffer) {
-    upcast(this)->setExternalBufferAt(upcast(engine), bufferIndex, externalBuffer);
 }
 
 } // namespace filament

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -65,10 +65,10 @@ FView::FView(FEngine& engine)
 
     // allocate ubos
     mLightUbh = driver.createBufferObject(CONFIG_MAX_LIGHT_COUNT * sizeof(LightsUib),
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     mShadowUbh = driver.createBufferObject(mShadowUb.getSize(),
-            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC, false);
+            BufferObjectBinding::UNIFORM, BufferUsage::DYNAMIC);
 
     mIsDynamicResolutionSupported = driver.isFrameTimeSupported();
 
@@ -470,7 +470,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
                 mRenderableUBOSize = uint32_t(count * sizeof(PerRenderableUib));
                 driver.destroyBufferObject(mRenderableUbh);
                 mRenderableUbh = driver.createBufferObject(mRenderableUBOSize,
-                        BufferObjectBinding::UNIFORM, BufferUsage::STREAM, false);
+                        BufferObjectBinding::UNIFORM, BufferUsage::STREAM);
             } else {
                 // TODO: should we shrink the underlying UBO at some point?
             }

--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -350,8 +350,7 @@ void FRenderableManager::create(
                         .handle = driver.createBufferObject(
                                 CONFIG_MAX_BONE_COUNT * sizeof(PerRenderableUibBone),
                                 BufferObjectBinding::UNIFORM,
-                                backend::BufferUsage::DYNAMIC,
-                                false),
+                                backend::BufferUsage::DYNAMIC),
                         .count = (uint16_t)count,
                         .offset = 0,
                         .skinningBufferMode = false };

--- a/filament/src/details/BufferObject.h
+++ b/filament/src/details/BufferObject.h
@@ -47,6 +47,7 @@ public:
 private:
     friend class BufferObject;
     backend::Handle<backend::HwBufferObject> mHandle;
+    intptr_t mImportedId;
     uint32_t mByteCount;
     BindingType mBindingType;
 };

--- a/filament/src/details/IndexBuffer.h
+++ b/filament/src/details/IndexBuffer.h
@@ -27,28 +27,32 @@
 
 namespace filament {
 
+class FBufferObject;
 class FEngine;
 
 class FIndexBuffer : public IndexBuffer {
 public:
+    using IndexBufferHandle = backend::IndexBufferHandle;
+    using BufferObjectHandle = backend::BufferObjectHandle;
+
     FIndexBuffer(FEngine& engine, const Builder& builder);
 
     // frees driver resources, object becomes invalid
     void terminate(FEngine& engine);
 
-    backend::Handle<backend::HwIndexBuffer> getHwHandle() const noexcept { return mHandle; }
+    IndexBufferHandle getHwHandle() const noexcept { return mHandle; }
 
     size_t getIndexCount() const noexcept { return mIndexCount; }
 
     void setBuffer(FEngine& engine, BufferDescriptor&& buffer, uint32_t byteOffset = 0);
-
-    void setExternalBuffer(FEngine& engine, intptr_t externalBuffer);
+    void setBufferObject(FEngine& engine, FBufferObject const* bufferObject);
 
 private:
     friend class IndexBuffer;
-    backend::Handle<backend::HwIndexBuffer> mHandle;
+    IndexBufferHandle mHandle;
+    BufferObjectHandle mObjectHandle;
     uint32_t mIndexCount;
-    bool mExternalBuffersEnabled = false;
+    bool mBufferObjectEnabled = false;
 };
 
 FILAMENT_UPCAST(IndexBuffer)

--- a/filament/src/details/VertexBuffer.h
+++ b/filament/src/details/VertexBuffer.h
@@ -60,9 +60,6 @@ public:
     void setBufferObjectAt(FEngine& engine, uint8_t bufferIndex,
             FBufferObject const * bufferObject);
 
-    void setExternalBufferAt(FEngine& engine, uint8_t bufferIndex,
-            intptr_t externalBuffer);
-
 private:
     friend class VertexBuffer;
 
@@ -77,7 +74,6 @@ private:
     uint32_t mVertexCount = 0;
     uint8_t mBufferCount = 0;
     bool mBufferObjectsEnabled = false;
-    bool mExternalBuffersEnabled = false;
 };
 
 FILAMENT_UPCAST(VertexBuffer)


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-594](https://shapr3d.atlassian.net/browse/GFX-594)

## Short description (What? How?) 📖
This PR reintroduces the changes of https://github.com/shapr3d/filament/pull/89, which were reverted in https://github.com/shapr3d/filament/pull/91. In addition it contains a change, that removes some leftover code, which could result in double destroying EBO handles (this might lead to errors based on the opengl driver).

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Driver backend

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
See https://github.com/shapr3d/filament/pull/89

Automated 💻
n/a