### PR TITLE
[GFX-734] Always use LDR ASTC formats in Metal backend

### DIFF
--- a/filament/backend/src/metal/MetalEnums.mm
+++ b/filament/backend/src/metal/MetalEnums.mm
@@ -127,30 +127,6 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
 #if !defined(FILAMENT_IOS_SIMULATOR)
     if (context->highestSupportedGpuFamily.apple >= 2) {
         if (@available(macOS 11.0, macCatalyst 14.0, *)) {
-            if (@available(iOS 13.0, *)) {
-                // Only iOS 13.0 + Apple GPU family 6 and above supports the ASTC HDR profile.
-                // Older versions of iOS fallback to LDR. The HDR profile is a superset of the LDR profile.
-                if (context->highestSupportedGpuFamily.apple >= 6) {
-                    switch (format) {
-                        case TextureFormat::RGBA_ASTC_4x4: return MTLPixelFormatASTC_4x4_HDR;
-                        case TextureFormat::RGBA_ASTC_5x4: return MTLPixelFormatASTC_5x4_HDR;
-                        case TextureFormat::RGBA_ASTC_5x5: return MTLPixelFormatASTC_5x5_HDR;
-                        case TextureFormat::RGBA_ASTC_6x5: return MTLPixelFormatASTC_6x5_HDR;
-                        case TextureFormat::RGBA_ASTC_6x6: return MTLPixelFormatASTC_6x6_HDR;
-                        case TextureFormat::RGBA_ASTC_8x5: return MTLPixelFormatASTC_8x5_HDR;
-                        case TextureFormat::RGBA_ASTC_8x6: return MTLPixelFormatASTC_8x6_HDR;
-                        case TextureFormat::RGBA_ASTC_8x8: return MTLPixelFormatASTC_8x8_HDR;
-                        case TextureFormat::RGBA_ASTC_10x5: return MTLPixelFormatASTC_10x5_HDR;
-                        case TextureFormat::RGBA_ASTC_10x6: return MTLPixelFormatASTC_10x6_HDR;
-                        case TextureFormat::RGBA_ASTC_10x8: return MTLPixelFormatASTC_10x8_HDR;
-                        case TextureFormat::RGBA_ASTC_10x10: return MTLPixelFormatASTC_10x10_HDR;
-                        case TextureFormat::RGBA_ASTC_12x10: return MTLPixelFormatASTC_12x10_HDR;
-                        case TextureFormat::RGBA_ASTC_12x12: return MTLPixelFormatASTC_12x12_HDR;
-                        default: break;
-                    }
-                }
-            }
-
             switch (format) {
                 case TextureFormat::SRGB8_ALPHA8_ASTC_4x4: return MTLPixelFormatASTC_4x4_sRGB;
                 case TextureFormat::SRGB8_ALPHA8_ASTC_5x4: return MTLPixelFormatASTC_5x4_sRGB;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-734](https://shapr3d.atlassian.net/browse/GFX-734)

## Short description (What? How?) 📖
There is a thorough explanation in the ticket. In short: I chose to mimic the Vulkan backend and other graphics libraries I checked (MetalANGLE, BGFX) and always use LDR pixel formats. HDR pixel format is not needed now.

## Upstreaming scope
This depends on what the Filament devs want. If they want to stick to OpenGL ES frontend then there is no good solution, and we shouldn't upstream anything. If they are willing to extend filament::backend::TextureFormat with LDR and HDR values, then I think we can do it for them.
- [ ] TODO: discuss this on SU, should I even bother asking them?

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
ASTC compressed textures are uploaded as LDR compressed textures

### Special use-cases to test 🧷
Test ASTC textures on Apple6+ GPUs and on older ones too.

### How did you test it? 🤔
Manual 💁‍♂️
TODO
Automated 💻
