### PR TITLE
[GFX-2240] Support ASTC on iOS Simulator if building for Apple Silicon

### DIFF
--- a/filament/backend/src/metal/MetalEnums.mm
+++ b/filament/backend/src/metal/MetalEnums.mm
@@ -124,7 +124,7 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
     }
 #endif
 
-#if !defined(FILAMENT_IOS_SIMULATOR)
+#if !defined(FILAMENT_IOS_SIMULATOR) || TARGET_CPU_ARM64
     if (context->highestSupportedGpuFamily.apple >= 2) {
         if (@available(macOS 11.0, macCatalyst 14.0, *)) {
             if (@available(iOS 13.0, *)) {


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2240](https://shapr3d.atlassian.net/browse/GFX-2240)

## Short description (What? How?) 📖
There was a bug in MetalEnums.mm which prevented us from using ASTC textures on the iOS simulator when run on a Silicon Mac. The device itself supports ASTC (Apple7 GPU) and iOS Simulator claims to support it too (Apple2) so Filament should too.

The bug was actually introduced by me. Here's what happened:
 - [We tweaked](https://github.com/shapr3d/filament/pull/3/files#diff-fdf9708779ec3da8bc8b253dc75d1e71cd3f811fa32222b6f4dff6305e4b6551) `getMetalFormat()` in MetalEnums.h on our fork.
 - The Filament guys [refactored it](https://github.com/google/filament/commit/37d8f96927c1e08ed84f11cc6d419c0c19c34230#diff-558cc2eb1252bc4e8ad6ae6b774bfdef10bee36b73bd55e14daa1a1402f3315eR129) into MetalEnums.mm
 - We merged the upstream changes in #4. Obviously there was a conflict which we resolved. We also concluded that ASTC shouldn't be supported on the iOS simulator because we saw that our Intel Macs crash. But we failed to test it on Silicon Macs. Until now!

## Upstreaming scope
We can upstream the `#ifdef` because iOS simulator should still be disabled on Intel Macs (which is missing in the upstream code). [Ticket](https://shapr3d.atlassian.net/browse/GFX-2246).

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
iOS Simulator

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
I tested the rendering test on both Intel and ARM64 Macs (with iOS Simulator)

Automated 💻
