### PR TITLE
[GFX-2225] Handle Metal shader unused variable warnings

### DIFF
--- a/filament/src/materials/ssao/ssct.fs
+++ b/filament/src/materials/ssao/ssct.fs
@@ -24,8 +24,6 @@
 
 #include "ssaoUtils.fs"
 
-const float kSSCTLog2LodRate = 3.0;
-
 struct ConeTraceSetup {
     // fragment info
     highp vec2 ssStartPos;
@@ -109,8 +107,6 @@ float coneTraceOcclusion(in ConeTraceSetup setup, const highp sampler2D depthTex
         float ssTracedDistance = ssConeLength * t;
         float ssSliceRadius = setup.jitterOffset.x * (setup.coneAngleTangeant * ssTracedDistance);
         highp vec2 ssSamplePos = perpConeDir * ssSliceRadius + ssConeVector * t + ssStartPos;
-
-        float level = clamp(floor(log2(ssSliceRadius)) - kSSCTLog2LodRate, 0.0, float(setup.maxLevel));
         float vsSampleDepthLinear = -sampleDepthLinear(depthTexture, ssSamplePos * setup.resolution.zw, 0.0);
 
         // calculate depth range of cone slice

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -54,7 +54,6 @@ namespace {
             "float2 shading_normalizedViewportCoord;",
             "float3 shading_clearCoatNormal;",
             "float filament_lodBias = frameUniforms.lodBias;",
-            "float level0 = fast::clamp(floor(log2(ssSliceRadius)) - 3.0, 0.0, setup.maxLevel);",
             "float3 bentNormal = param_8;"
         };
 

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -18,6 +18,8 @@
 
 #include <sstream>
 #include <vector>
+#include <string>
+#include <string_view>
 
 #include <GlslangToSpv.h>
 #include <SPVRemapper.h>
@@ -37,6 +39,42 @@ using namespace spirv_cross;
 using namespace spvtools;
 
 namespace filamat {
+
+namespace {
+
+    std::string addMaybeUnusedToVariables(const std::string& mslShader) {
+        constexpr std::string_view unusedVariables[] = {
+            "float3x3 shading_tangentToWorld;",
+            "float3 shading_position;",
+            "float3 shading_view;",
+            "float3 shading_normal;",
+            "float3 shading_geometricNormal;",
+            "float3 shading_reflected;",
+            "float shading_NoV;",
+            "float2 shading_normalizedViewportCoord;",
+            "float3 shading_clearCoatNormal;",
+            "float filament_lodBias = frameUniforms.lodBias;",
+            "float level0 = fast::clamp(floor(log2(ssSliceRadius)) - 3.0, 0.0, setup.maxLevel);",
+            "float3 bentNormal = param_8;"
+        };
+
+        constexpr std::string_view maybeUnused = "[[maybe_unused]] ";
+
+        std::string patchedMslShader;
+        patchedMslShader.reserve(std::size(maybeUnused) * std::size(unusedVariables) + std::size(mslShader));
+        patchedMslShader = mslShader;
+        for (const auto& variable : unusedVariables) {
+
+            auto it = std::search(std::begin(patchedMslShader), std::end(patchedMslShader), std::begin(variable), std::end(variable));
+            if (it != std::end(patchedMslShader)) {
+                patchedMslShader.insert(it, std::begin(maybeUnused), std::end(maybeUnused));
+            }
+
+        }
+        return patchedMslShader;
+    }
+
+}
 
 GLSLPostProcessor::GLSLPostProcessor(MaterialBuilder::Optimization optimization, uint32_t flags)
         : mOptimization(optimization),
@@ -153,6 +191,7 @@ void GLSLPostProcessor::spirvToToMsl(const SpirvBlob *spirv, std::string *outMsl
     }
 
     *outMsl = mslCompiler.compile();
+    *outMsl = addMaybeUnusedToVariables(*outMsl);
     *outMsl = minifier.removeWhitespace(*outMsl);
 }
 

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -63,12 +63,10 @@ namespace {
         patchedMslShader.reserve(std::size(maybeUnused) * std::size(unusedVariables) + std::size(mslShader));
         patchedMslShader = mslShader;
         for (const auto& variable : unusedVariables) {
-
-            auto it = std::search(std::begin(patchedMslShader), std::end(patchedMslShader), std::begin(variable), std::end(variable));
-            if (it != std::end(patchedMslShader)) {
-                patchedMslShader.insert(it, std::begin(maybeUnused), std::end(maybeUnused));
+            auto pos = patchedMslShader.find(variable);
+            if (pos != std::string::npos) {
+                patchedMslShader.insert(pos, maybeUnused);
             }
-
         }
         return patchedMslShader;
     }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2225](https://shapr3d.atlassian.net/browse/)

## Short description (What? How?) 📖

When we disabled the shader optimisations in Filament a lot of unused variable warning appeared and bloated the output. After multiple prototypes (filter it with defines, spirv-cross reflection), we decided to run with a simple find and replace (insert) solution for the warnings. The following code lines (after metal transcompilation) introduce the majority of the unused variable warnings:
```
float3x3 shading_tangentToWorld;
float3 shading_position;
float3 shading_view
float3 shading_normal;
float3 shading_geometricNormal;
float3 shading_reflected;
float shading_NoV;
float2 shading_normalizedViewportCoord;
float3 shading_clearCoatNormal;
float filament_lodBias = frameUniforms.lodBias;
float level0 = fast::clamp(floor(log2(ssSliceRadius)) - 3.0, 0.0, setup.maxLevel);
float3 bentNormal = param_8;
```

To handle these we add `[[maybe_unused]]` attribute to every aforementioned line. 

Note: `[[maybe_unused]]` is not part of the Metal Shading Language Specification, but because the MSL compiler is based on clang, which supports it, therefore we could use it relative safely.

## Upstreaming scope
n/a

We consider this just a "quick fix", and not a proper solution to upstream.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Filamat, Material Compiler

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Checked with gltf_viewer and in Shapr3D too. Almost all unused variable warning disappeared in Shapr, but there are one or two left that probably comes from our material shader codes. 

Automated 💻
n/a