### PR TITLE
[GFX-1630] Optimize spherical IBL lookup

### DIFF
--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -359,7 +359,7 @@ struct VsmShadowOptions {
 
 struct IblOptions {    
     enum class IblTechnique : uint32_t {
-        IBL_INFINITE, IBL_FINITE_SPHERE, IBL_FINITE_BOX
+        IBL_INFINITE, IBL_FINITE_SPHERE, IBL_FINITE_BOX, IBL_FINITE_SPHERE_NEW
     };
 
     IblTechnique iblTechnique = IblTechnique::IBL_INFINITE;

--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -359,7 +359,7 @@ struct VsmShadowOptions {
 
 struct IblOptions {    
     enum class IblTechnique : uint32_t {
-        IBL_INFINITE, IBL_FINITE_SPHERE, IBL_FINITE_BOX, IBL_FINITE_SPHERE_NEW
+        IBL_INFINITE, IBL_FINITE_SPHERE, IBL_FINITE_BOX
     };
 
     IblTechnique iblTechnique = IblTechnique::IBL_INFINITE;

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -1463,6 +1463,10 @@ void SimpleViewer::updateUserInterface() {
                 iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_SPHERE;
             }
             ImGui::SameLine();
+            if (ImGui::RadioButton("New sphere", iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_SPHERE_NEW)) {
+                iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_SPHERE_NEW;
+            }
+            ImGui::SameLine();
             if (ImGui::RadioButton("Box", iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_BOX)) {
                 iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_BOX;
             }
@@ -1482,6 +1486,15 @@ void SimpleViewer::updateUserInterface() {
                 ImGui::SliderFloat3("Box half extents", iblHalfExtents.v, -100.0f, 100.0f);
 
                 iblOptions.iblHalfExtents = iblHalfExtents;
+            }
+            else if (iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_SPHERE_NEW) {
+                static float radius = std::sqrt(iblOptions.iblHalfExtents.x);
+
+                ImGui::SliderFloat3("Sphere center", iblOptions.iblCenter.v, -10.0f, 10.0f);
+                ImGui::SliderFloat("Sphere radius", &radius, 0.0f, 256.0f);
+
+                iblOptions.iblHalfExtents.x = radius;
+                iblOptions.iblHalfExtents.y = (radius != 0.0f) ? 1.0f / radius : 1.0f;
             }
         }
         if (ImGui::CollapsingHeader("Sunlight")) {

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -1463,10 +1463,6 @@ void SimpleViewer::updateUserInterface() {
                 iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_SPHERE;
             }
             ImGui::SameLine();
-            if (ImGui::RadioButton("New sphere", iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_SPHERE_NEW)) {
-                iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_SPHERE_NEW;
-            }
-            ImGui::SameLine();
             if (ImGui::RadioButton("Box", iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_BOX)) {
                 iblOptions.iblTechnique = IblOptions::IblTechnique::IBL_FINITE_BOX;
             }
@@ -1477,7 +1473,8 @@ void SimpleViewer::updateUserInterface() {
                 ImGui::SliderFloat3("Sphere center", iblOptions.iblCenter.v, -10.0f, 10.0f);
                 ImGui::SliderFloat("Sphere radius", &radius, 0.0f, 256.0f);
 
-                iblOptions.iblHalfExtents.x = radius * radius;
+                iblOptions.iblHalfExtents.x = radius;
+                iblOptions.iblHalfExtents.y = (radius != 0.0f) ? 1.0f / radius : 1.0f;
             }
             else if (iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_BOX) {
                 static filament::math::float3 iblHalfExtents = iblOptions.iblHalfExtents;
@@ -1486,15 +1483,6 @@ void SimpleViewer::updateUserInterface() {
                 ImGui::SliderFloat3("Box half extents", iblHalfExtents.v, -100.0f, 100.0f);
 
                 iblOptions.iblHalfExtents = iblHalfExtents;
-            }
-            else if (iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_SPHERE_NEW) {
-                static float radius = std::sqrt(iblOptions.iblHalfExtents.x);
-
-                ImGui::SliderFloat3("Sphere center", iblOptions.iblCenter.v, -10.0f, 10.0f);
-                ImGui::SliderFloat("Sphere radius", &radius, 0.0f, 256.0f);
-
-                iblOptions.iblHalfExtents.x = radius;
-                iblOptions.iblHalfExtents.y = (radius != 0.0f) ? 1.0f / radius : 1.0f;
             }
         }
         if (ImGui::CollapsingHeader("Sunlight")) {

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -614,6 +614,7 @@ void SimpleViewer::updateIndirectLight() {
     if (mIndirectLight) {
         mIndirectLight->setIntensity(mSettings.lighting.iblIntensity);
         mIndirectLight->setRotation(mat3f::rotation(mSettings.lighting.iblRotation, float3{ 0, 1, 0 }));
+        mIndirectLight->setIblOptions(mSettings.lighting.iblOptions);
     }
     if (mScene->getSkybox()) {
         mScene->getSkybox()->setIntensity(mSettings.lighting.skyIntensity);

--- a/libs/viewer/src/SimpleViewer.cpp
+++ b/libs/viewer/src/SimpleViewer.cpp
@@ -1478,8 +1478,8 @@ void SimpleViewer::updateUserInterface() {
             else if (iblOptions.iblTechnique == IblOptions::IblTechnique::IBL_FINITE_BOX) {
                 static filament::math::float3 iblHalfExtents = iblOptions.iblHalfExtents;
 
-                ImGui::SliderFloat3("Box center", iblOptions.iblCenter.v, -10.0f, 10.0f);
-                ImGui::SliderFloat3("Box half extents", iblHalfExtents.v, -10.0f, 10.0f);
+                ImGui::SliderFloat3("Box center", iblOptions.iblCenter.v, -100.0f, 100.0f);
+                ImGui::SliderFloat3("Box half extents", iblHalfExtents.v, -100.0f, 100.0f);
 
                 iblOptions.iblHalfExtents = iblHalfExtents;
             }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1630](https://shapr3d.atlassian.net/browse/GFX-1630)

## Short description (What? How?) 📖
While making the Filament upstream PR, a spherical IBL lookup optimization was added. If we assume that the lookup position is within the sphere, we can simplify the ray-sphere intersection computations. If the lit fragment is outside of the sphere however, we'll have different shading. This should not be a problem for Shapr, since we guarantee there that the sphere is large enough to contain the workspace. 

Previously, this is what happened when your IBL sphere did not include the entirety of the scene:
![image](https://user-images.githubusercontent.com/90197216/201696438-56c624c4-49a5-42c9-8164-0be3376ded17.png)

With the ray-sphere intersection code introduced in this PR, the out-of-sphere lookups will be changed such as this:
![image](https://user-images.githubusercontent.com/90197216/201696581-4c827b23-d99f-4aa5-a05d-2628d5c8e203.png)

The previous implementation (that computed both roots in a numerically stable way) required 42 full rate and 3 quarter rate instructions on AMD, while the new version computes the intersection in 34 full rate and 2 quarter rate ops (so it's 12 cycles shorter, sans register data stalls). 

To avoid numerical issues, the ray is semi-normalized in the sense that intersection is being tested in the normalized space of the sphere (origin = sphere center, radius = 1 => every point is scaled down by the IBL radius) but the ray direction itself remains a direction vector. We pass the reciprocal of the IBL sphere radius as the .y coordinate of the IBL half extent UB member.

## Upstreaming scope
Upstream PR is opened under

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Should be invisible to users in Shapr3D as we set the sphere radius such that it envelopes the entirety of the workspace AABB. 

### Special use-cases to test 🧷
No IBL reflection should change.

### How did you test it? 🤔
Manual 💁‍♂️
Use 6a04a94fa34d9d5d7561226d32660fd29751b7f4 to switch between the old and the new spherical IBL computations. The subsequent commit only replaces the old code by the new method. 

Automated 💻
n/a