### PR TITLE
[GFX-2246] Enable ASTC on Simulator

### DIFF
--- a/filament/backend/src/metal/MetalEnums.mm
+++ b/filament/backend/src/metal/MetalEnums.mm
@@ -124,7 +124,6 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
     }
 #endif
 
-#if !defined(FILAMENT_IOS_SIMULATOR) || TARGET_CPU_ARM64
     if (context->highestSupportedGpuFamily.apple >= 2) {
         if (@available(macOS 11.0, macCatalyst 14.0, *)) {
             if (@available(iOS 13.0, *)) {
@@ -204,7 +203,6 @@ MTLPixelFormat getMetalFormat(MetalContext* context, TextureFormat format) noexc
             }
         }
     }
-#endif
 
     // DXT (BC) formats are only available on macOS desktop and Mac Catalyst.
     // See https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2246](https://shapr3d.atlassian.net/browse/GFX-2246)

## Short description (What? How?) 📖
I must have missed sth in https://github.com/shapr3d/filament/pull/3/commits/8d6ef7682b1806c1f56761c7fa8fb9f4b1972786 because the iPad 10.5" Simulator seems to support ASTC. I found this out while testing my code before opening an upstream PR. Turned out I could run rendering tests with ASTC textures after removing the check from Filament.
(My guess is that I mistook a Filament error message to a Metal API Validation error message)

I briefly tested ETC2 too and I verified that I can indeed create such a texture on iOS Simulator and update its content (with valid ETC2 compressed data). I didn't do further testing (such as can it be bound to a fragment shader, can a shader actually sample it etc...).

## Upstreaming scope
Nothing. In fact, the upstream version of the code made my realize that our fork was buggy

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
iOS Simulator when using ASTC textures (e.g. in Shapr3D rendering tests)

### Special use-cases to test 🧷
Run Visu rendering tests in Shapr

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻
I ran the rendering tests with this version of Filament and ASTC textures (on an Intel Mac)