### PR TITLE
Revert "[GFX-2063] Don't flush on renderable creation (#101)"

### DIFF
--- a/filament/src/components/RenderableManager.cpp
+++ b/filament/src/components/RenderableManager.cpp
@@ -373,6 +373,7 @@ void FRenderableManager::create(
             }
         }
     }
+    engine.flushIfNeeded();
 }
 
 // this destroys a single component from an entity


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2274](https://shapr3d.atlassian.net/browse/GFX-2274)

## Short description (What? How?) 📖

Since we changing the threading mode with https://github.com/shapr3d/filament/pull/104, we don't need the https://github.com/shapr3d/filament/pull/101 quick fix anymore.

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Visualization
RenderableManager

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
n/a

Automated 💻
n/a