### PR TITLE
[GFX-2308] Fixing metal no return warnings

### DIFF
--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -111,4 +111,7 @@ vec3 uintToColorDebug(uint v) {
     } else if (v == 5u) {
         return vec3(0.0, 1.0, 1.0);     // cyan
     }
+
+    // fallback to handle no all code-paths return warnings
+    return vec3(0.0, 0.0, 0.0);
 }

--- a/shaders/src/common_graphics.fs
+++ b/shaders/src/common_graphics.fs
@@ -112,6 +112,6 @@ vec3 uintToColorDebug(uint v) {
         return vec3(0.0, 1.0, 1.0);     // cyan
     }
 
-    // fallback to handle no all code-paths return warnings
+    // fallback to handle "not all code-paths return" warnings
     return vec3(0.0, 0.0, 0.0);
 }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2308](https://shapr3d.atlassian.net/browse/GFX-2308)

## Short description (What? How?) 📖

Since we disabled the optimisations in SPIR-V, we are receiving this kind of warnings in Shapr when the backend tries to compile our ground plane shaders:
`program_source:2110:1: warning: control may reach end of non-void function`

Luckily after checking the generated shader sources, turned out it was only caused by a debug visualisation code path for cascaded shadows, what we don't use anyway.

Because it is not a priority (only developer experience is affected: output spamming) therefore it could be bumped together with a later PR, but we should not forget to recompile the materials.

## Upstreaming scope
https://shapr3d.atlassian.net/browse/GFX-2351

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Filament shaders (cascaded shadows)
Visualization: Ground plane shaders

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Can be tested the same way as https://github.com/shapr3d/shapr3d/pull/12622. 

Automated 💻
n/a