### PR TITLE
[GFX-2295] Transparent screenshot fixed

### DIFF
--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -162,6 +162,10 @@ void PerViewUniforms::prepareSSAO(Handle<HwTexture> ssao, AmbientOcclusionOption
     s.aoBentNormals = options.enabled && options.bentNormals ? 1.0f : 0.0f;
 }
 
+void PerViewUniforms::prepareBlending(bool needsAlphaChannel) noexcept {
+    mPerViewUb.edit().needsAlphaChannel = needsAlphaChannel ? 1.0f : 0.0f;
+}
+
 void PerViewUniforms::prepareSSR(Handle<HwTexture> ssr, float refractionLodOffset) noexcept {
     mPerViewSb.setSampler(PerViewSib::SSR, ssr, {
         .filterMag = SamplerMagFilter::LINEAR,

--- a/filament/src/PerViewUniforms.h
+++ b/filament/src/PerViewUniforms.h
@@ -62,6 +62,8 @@ public:
     void prepareFog(const CameraInfo& camera, FogOptions const& options) noexcept;
     void prepareStructure(TextureHandle structure) noexcept;
     void prepareSSAO(TextureHandle ssao, AmbientOcclusionOptions const& options) noexcept;
+    void prepareBlending(bool needsAlphaChannel) noexcept;
+
     void prepareSSR(TextureHandle ssr, float refractionLodOffset) noexcept;
     void prepareShadowMapping(ShadowMappingUniforms const& shadowMappingUniforms,
             VsmShadowOptions const& options) noexcept;

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -332,7 +332,7 @@ void FView::prepareLighting(FEngine& engine, FEngine::DriverApi& driver, ArenaSc
 }
 
 void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
-        filament::Viewport const& viewport, float4 const& userTime) noexcept {
+        filament::Viewport const& viewport, float4 const& userTime, bool needsAlphaChannel) noexcept {
     JobSystem& js = engine.getJobSystem();
 
     /*
@@ -493,6 +493,7 @@ void FView::prepare(FEngine& engine, DriverApi& driver, ArenaScope& arena,
 
     mPerViewUniforms.prepareTime(engine, userTime);
     mPerViewUniforms.prepareFog(mViewingCameraInfo, mFogOptions);
+    mPerViewUniforms.prepareBlending(needsAlphaChannel);
 
     // set uniforms and samplers
     bindPerViewUniformsAndSamplers(driver);

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -116,7 +116,7 @@ public:
     void terminate(FEngine& engine);
 
     void prepare(FEngine& engine, backend::DriverApi& driver, ArenaScope& arena,
-            Viewport const& viewport, math::float4 const& userTime) noexcept;
+            Viewport const& viewport, math::float4 const& userTime, bool needsAlphaChannel) noexcept;
 
     void setScene(FScene* scene) { mScene = scene; }
     FScene const* getScene() const noexcept { return mScene; }

--- a/filament/src/materials/colorGrading/colorGrading.mat
+++ b/filament/src/materials/colorGrading/colorGrading.mat
@@ -161,10 +161,7 @@ vec4 resolve() {
     }
 #else
     vec4 color = resolveAlphaFragment(ivec2(getUV()));
-    if (color.a == 0.0) {
-        color.a = max(FLT_EPS, max3(color.rgb));
-    }
-    color.rgb /= color.a;
+    color.rgb /= max(color.a, FLT_EPS);
     if (materialParams.bloom.x > 0.0) {
         color.rgb = bloom(color.rgb);
     }
@@ -173,7 +170,7 @@ vec4 resolve() {
         color.rgb = vignette(color.rgb, uv, materialParams.vignette, materialParams.vignetteColor);
     }
     color.rgb  = colorGrade(materialParams_lut, color.rgb);
-    color.rgb *= color.a;
+    color.rgb *= max(color.a, FLT_EPS);
 #endif
     return color;
 }

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -84,6 +84,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float iblLuminance;
     float exposure;
     float ev100;
+    float needsAlphaChannel;
 
     alignas(16) math::float4 iblSH[9]; // actually float3 entries (std140 requires float4 alignment)
 
@@ -141,7 +142,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::mat4f iblRotation; // contains the IBL's rotation
 
     // bring PerViewUib to 2 KiB
-    math::float4 arrayPadding[51];
+    math::float4 arrayPadding[50];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -71,6 +71,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // camera
             .add("exposure",                1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH) // high precision to work around #3602 (qualcomm)
             .add("ev100",                   1, UniformInterfaceBlock::Type::FLOAT)
+            .add("needsAlphaChannel",       1, UniformInterfaceBlock::Type::FLOAT)
             // ibl
             .add("iblSH",                   9, UniformInterfaceBlock::Type::FLOAT3)
             // user time
@@ -123,7 +124,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("iblRotation",             1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
 
             // bring PerViewUib to 2 KiB
-            .add("arrayPadding", 51, UniformInterfaceBlock::Type::FLOAT4)
+            .add("arrayPadding", 50, UniformInterfaceBlock::Type::FLOAT4)
             .build();
     return uib;
 }

--- a/shaders/src/shading_lit.fs
+++ b/shaders/src/shading_lit.fs
@@ -4,7 +4,7 @@
 
 float computeDiffuseAlpha(float a) {
 #if defined(BLEND_MODE_TRANSPARENT) || defined(BLEND_MODE_FADE) || defined(BLEND_MODE_MASKED)
-    return a;
+    return (frameUniforms.needsAlphaChannel == 1.0) ? min(1.0, a + 0.125) : a;
 #else
     return 1.0;
 #endif


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2295](https://shapr3d.atlassian.net/browse/GFX-2295)

## Short description (What? How?) 📖
Transparent screenshots were hacked poorly. Upstreaming efforts reached this modification as well, so it was a nice occasion to do a second pass on it, and try the [following formula](https://twitter.com/garrettkjohnson/status/1526645084493557760) - referred as magic formula in the followings.

### Trying the magic formula

The formula did work well (see: New), and eliminated most of the artifacts that were caused by the previous solution (see: Original)

<img alt="diff" style="width: 60%;margin: auto;display: block;" src="https://user-images.githubusercontent.com/6261494/204782881-b19b6e58-395e-408e-9161-c68ba46e1d10.png">

### Handling separate path for translucent views

The magic formula required a separate path for translucent `View`-s which we use for transparent screenshots. We used the solution from upstream for it, which adds field `needsAlphaChannel` to `PerViewUniforms`. This handles automatically setting `needsAlphaChannel` to _'true'_ (`1.f`) when we set `View`-s blend mode to `TRANSLUCENT`.

A nice extra that we're getting for free with this change, is that now we can show in the app what the users are actually going to get when they press the Capture button.

### Zero alpha handling in `colorGrading.mat`

In `colorGrading.mat`, the following solution of handling `color.a == 0.0` needed to be modified:
```
if (color.a == 0.0) {
    color.a = max(FLT_EPS, max3(color.rgb));
}
```

Clamping alpha to `max3(color.rgb)` did produce artifacts combined with the magic formula. We opted not to modify alpha here, instead we used the following to handle singularities:
```
color.rgb /= max(color.a, FLT_EPS); // unpremultiply...
// ...
color.rgb *= max(color.a, FLT_EPS); // un-unpremultipy
```

### Hacking simple transparent
Removing `max3(color.rgb)` breaks simple transparent material. In `computeDiffuseAlpha`, the following hack provides plausable results for this situation:
```
return (frameUniforms.needsAlphaChannel == 1.0) ? min(1.0, a + 0.125) : a; 
```

## Upstreaming scope
This modification is going to be upstreamed together with #34. From this PR, zero alpha handling in `colorGrading.mat` is upstreamable, and we can check what they think about our usage of this magic formula. Hacking simple transparent is a simple solution for us, but IMO not upstreamable.

## Testing

### Design review 🎨
<!--- List the design team members who approved the implementation -->

### Affected areas 🧭
<!--- List all areas that can be affected by the changes introduced -->

### Special use-cases to test 🧷
<!--- List special use-cases that could have changed -->

### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
Manual 💁‍♂️

Automated 💻
