### PR TITLE
[GFX-2310] Fix Apple debug build

### DIFF
--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -756,7 +756,7 @@ FrameGraphId<FrameGraphTexture> FRenderer::refractionPass(FrameGraph& fg,
         // In the end we get: lod = 2 * log2(perceptualRoughness) - log2(sigma0 * s * sqrt2)
         const float refractionLodOffset = -std::log2(sigma0 * s * f::SQRT2);
         const float maxPerceptualRoughness = 0.5f;
-        const uint8_t maxLod = std::ceil(2.0f * std::log2(maxPerceptualRoughness) + refractionLodOffset);
+        const uint8_t maxLod = std::max(1.0f, std::ceil(2.0f * std::log2(maxPerceptualRoughness) + refractionLodOffset));
 
         // Number of roughness levels we want.
         // TODO: If we want to limit the number of mip levels, we must reduce the initial


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2310](https://shapr3d.atlassian.net/browse/GFX-2310)

## Short description (What? How?) 📖
Apple debug build of Filament ran into the following run-time error:

```
-[MTLTextureDescriptorInternal validateWithDevice:]:1325: failed assertion `Texture Descriptor Validation
MTLTextureDescriptor requests 0 mipmap levels, but the dimensions (5, 5, 1) can only support a maxiumum of 3 levels
```

Clamping `maxLod` in `refractionPass` to not go below `1.f` solves this issue.

## Upstreaming scope
`roughnessLodCount` comes directly from `FTexture::maxLevelCount` on upstream, which already clamps the values to be over `1.f`. 

Moreover, putting in some refractive samples from the `glTF-Sample-Models` repo - e.g. `IridescentDishWithOlives` - results in no run-time crash in debug builds.

Thus, no action needed.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Does not crash now.
Automated 💻
Not applicable.