### PR TITLE
[GFX-2302] Merge back .mat files from shapr3d repo

### DIFF
--- a/filament/src/materials/Cloth.mat
+++ b/filament/src/materials/Cloth.mat
@@ -162,6 +162,14 @@ material {
         {
             type : float4,
             name : ambientColor
+        },
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Our ASTC compressor lays out the coordinates as XXXY but our BC5 compressor lays them out as XY.
+        // This flag indicates if data is stored as XY or XXXY (so we can sample the normal map accordingly)
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        {
+            type : int,
+            name : useSwizzledNormalMaps
         }
     ],
     variables: [

--- a/filament/src/materials/Opaque.mat
+++ b/filament/src/materials/Opaque.mat
@@ -175,6 +175,14 @@ material {
         {
             type : float4,
             name : ambientColor
+        },
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Our ASTC compressor lays out the coordinates as XXXY but our BC5 compressor lays them out as XY.
+        // This flag indicates if data is stored as XY or XXXY (so we can sample the normal map accordingly)
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        {
+            type : int,
+            name : useSwizzledNormalMaps
         }
     ],
     variables: [

--- a/filament/src/materials/Refractive.mat
+++ b/filament/src/materials/Refractive.mat
@@ -217,6 +217,14 @@ material {
         {
             type : float4,
             name : ambientColor
+        },
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Our ASTC compressor lays out the coordinates as XXXY but our BC5 compressor lays them out as XY.
+        // This flag indicates if data is stored as XY or XXXY (so we can sample the normal map accordingly)
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        {
+            type : int,
+            name : useSwizzledNormalMaps
         }
     ],
     variables: [

--- a/filament/src/materials/Subsurface.mat
+++ b/filament/src/materials/Subsurface.mat
@@ -184,6 +184,14 @@ material {
         {
             type : float4,
             name : ambientColor
+        },
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Our ASTC compressor lays out the coordinates as XXXY but our BC5 compressor lays them out as XY.
+        // This flag indicates if data is stored as XY or XXXY (so we can sample the normal map accordingly)
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        {
+            type : int,
+            name : useSwizzledNormalMaps
         }
     ],
     variables: [

--- a/filament/src/materials/Transparent.mat
+++ b/filament/src/materials/Transparent.mat
@@ -128,6 +128,14 @@ material {
         {
             type : float4,
             name : ambientColor
+        },
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Our ASTC compressor lays out the coordinates as XXXY but our BC5 compressor lays them out as XY.
+        // This flag indicates if data is stored as XY or XXXY (so we can sample the normal map accordingly)
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        {
+            type : int,
+            name : useSwizzledNormalMaps
         }
     ],
     variables: [


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2302](https://shapr3d.atlassian.net/browse/GFX-2302)

## Short description (What? How?) 📖
After https://github.com/shapr3d/shapr3d/pull/13170 is merged, we have to sync the .mat files with this repo so that our technical artists use the same files as Shapr3D app does.

This PR also includes changes from https://github.com/shapr3d/shapr3d/pull/12880

Note that `IN_SHAPR_SHADER` is not defined when compiling the .mat files in this repo, but it is when compiling for Shapr3D app!

## Upstreaming scope
God, no! 🙅 

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
glTF Viewer (but nothing should change)

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
- Checked on macOS (after I finally found out how to set 'art root path' and 'load a material' in glTF Viewer)

Automated 💻
n/a