### PR TITLE
[GFX-1045] Fix skybox in ortho mode

### DIFF
--- a/filament/src/materials/skybox.mat
+++ b/filament/src/materials/skybox.mat
@@ -184,8 +184,6 @@ fragment {
 
 vertex {
     void materialVertex(inout MaterialVertexInputs material) {
-        float3 p = getPosition().xyz;
-        float3 unprojected = mulMat4x4Float3(getViewFromClipMatrix(), p).xyz;
-        material.eyeDirection.xyz = mulMat3x3Float3(getWorldFromViewMatrix(), unprojected);
+        material.eyeDirection.xyz = material.worldPosition.xyz;
     }
 }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1045](https://shapr3d.atlassian.net/browse/GFX-1045)

## Short description (What? How?) 📖
In the skybox shader, there was a varying that was calculated incorrectly when the projection was ortho. With the modified calculation the skybox seems to be fixed in gltfw_viewer and in Shapr3D as well:

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/12460850/212196542-582f0c89-4291-4074-a8c3-c37f00b40cd8.png">

I will open a bump PR in Shapr3D once this is approved.

## Upstreaming scope
[Upstream PR](https://github.com/google/filament/pull/6459) is already open. Keeping this as a draft until that's merged.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Skyboxes in ortho.

### Special use-cases to test 🧷
Apply [this patch](https://github.com/shapr3d/filament/files/10410022/gltf_viewer_ortho_cam.patch) and check in gltf_viewer or bump Filament and test Gradient environment in Shapr3D (in ortho mode).

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-1045]: https://shapr3d.atlassian.net/browse/GFX-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ