### PR TITLE
[GFX-2499] Upgrade prerequisites for Xcode 14.0 and macOS 12.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ if (MSVC)
     set(CXX_STANDARD "/std:c++latest")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} /W0 /Zc:__cplusplus /sdl-")
 else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} -fstrict-aliasing -Wno-unknown-pragmas -Wno-unused-function")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_STANDARD} -fstrict-aliasing -Wno-unknown-pragmas -Wno-unused-function -Wno-deprecated-declarations")
 endif()
 
 if (FILAMENT_USE_EXTERNAL_GLES3)

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -795,7 +795,7 @@ void OpenGLDriver::framebufferTexture(backend::TargetBufferInfo const& binfo,
     // depth/stencil attachment must match the rendertarget sample count
     // this is because EXT_multisampled_render_to_texture doesn't guarantee depth/stencil
     // is resolved.
-    bool attachmentTypeNotSupportedByMSRTT = false;
+    UTILS_UNUSED bool attachmentTypeNotSupportedByMSRTT = false;
     switch (attachment) {
         case GL_DEPTH_ATTACHMENT:
         case GL_STENCIL_ATTACHMENT:

--- a/libs/utils/include/utils/FixedCapacityVector.h
+++ b/libs/utils/include/utils/FixedCapacityVector.h
@@ -396,7 +396,8 @@ private:
         SizeTypeWrapper() noexcept = default;
         SizeTypeWrapper(SizeTypeWrapper const& rhs) noexcept = default;
         explicit  SizeTypeWrapper(TYPE value) noexcept : value(value) { }
-        SizeTypeWrapper operator=(TYPE rhs) noexcept { value = rhs; return *this; }
+        SizeTypeWrapper& operator=(TYPE rhs) noexcept { value = rhs; return *this; }
+        SizeTypeWrapper& operator=(SizeTypeWrapper& rhs) noexcept = delete;
         operator TYPE() const noexcept { return value; }
     };
 

--- a/third_party/libassimp/tnt/CMakeLists.txt
+++ b/third_party/libassimp/tnt/CMakeLists.txt
@@ -263,20 +263,21 @@ add_library(${TARGET} STATIC ${PRIVATE_HDRS} ${PUBLIC_HDRS} ${SRCS})
 
 if(NOT MSVC)
     target_compile_options(${TARGET}
-        PRIVATE -Wno-strict-aliasing
+        PRIVATE -Wno-deprecated-declarations
+        PRIVATE -Wno-deprecated-register
+        PRIVATE -Wno-incompatible-pointer-types
+        PRIVATE -Wno-ordered-compare-function-pointers
+        PRIVATE -Wno-parentheses
         PRIVATE -Wno-sign-compare
+        PRIVATE -Wno-strict-aliasing
+        PRIVATE -Wno-strict-overflow
+        PRIVATE -Wno-tautological-compare
+        PRIVATE -Wno-tautological-undefined-compare
+        PRIVATE -Wno-undefined-var-template
+        PRIVATE -Wno-uninitialized
         PRIVATE -Wno-unused-const-variable
         PRIVATE -Wno-unused-private-field
         PRIVATE -Wno-unused-variable
-        PRIVATE -Wno-deprecated-declarations
-        PRIVATE -Wno-parentheses
-        PRIVATE -Wno-uninitialized
-        PRIVATE -Wno-strict-overflow
-        PRIVATE -Wno-deprecated-register
-        PRIVATE -Wno-tautological-undefined-compare
-        PRIVATE -Wno-incompatible-pointer-types
-        PRIVATE -Wno-tautological-compare
-        PRIVATE -Wno-undefined-var-template
     )
 else()
     target_compile_options(${TARGET} PRIVATE /bigobj)

--- a/third_party/spirv-tools/CMakeLists.txt
+++ b/third_party/spirv-tools/CMakeLists.txt
@@ -252,6 +252,7 @@ if(CMAKE_VERSION VERSION_LESS "3.12" OR ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   find_host_package(PythonInterp 3 REQUIRED)
 else()
   find_package(Python3 COMPONENTS Interpreter)
+  set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
 endif()
 
 # Check for symbol exports on Linux.

--- a/third_party/spirv-tools/filament-specific-changes.patch
+++ b/third_party/spirv-tools/filament-specific-changes.patch
@@ -67,6 +67,7 @@ index 55f84e6d8..41ae7897c 100755
 +  find_host_package(PythonInterp 3 REQUIRED)
 +else()
 +  find_package(Python3 COMPONENTS Interpreter)
++  set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
 +endif()
  
  # Check for symbol exports on Linux.


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2499](https://shapr3d.atlassian.net/browse/GFX-2499)

## Short description (What? How?) 📖
Cherry-picking https://github.com/google/filament/pull/5330 from upstream.

It fixes:
-  Python 3 detection in `spirv-tools`, which became important with the removal of Python 2 in macOS 12.3,
-  Compile errors related to deprecation of `sprintf()` in Xcode 14.0.

There were a few conficts, each of them were resolved to empty changes in our fork, (as most of them just reverted some previous change which hasn't reached our fork yet).

## Upstreaming scope
N/A

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Building the library.

### Special use-cases to test 🧷
Use Xcode 14.0+ and macOS 12.3+.

### How did you test it? 🤔
Manual 💁‍♂️
Using Xcode 14.2 on macOS 13.1, I've built `shadowtest` sample app, and the library used in Shapr3D.

Automated 💻
n/a

[GFX-2499]: https://shapr3d.atlassian.net/browse/GFX-2499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ