### PR TITLE
[GFX-1632] Downstream changes approved by Google

### DIFF
--- a/docs/Materials.html
+++ b/docs/Materials.html
@@ -2587,6 +2587,7 @@ type aliases:
 
 </p><div class="table"><table class="table"><tbody><tr><th style="text-align:left"> Name </th><th style="text-align:center"> Type </th><th style="text-align:left"> Description </th></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getResolution()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Resolution of the view in pixels: <code>width</code>, <code>height</code>, <code>1 / width</code>, <code>1 / height</code> </td></tr>
+<tr><td style="text-align:left"> <strong class="asterisk">getWorldCameraPosition()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Position of the camera/eye in world space </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldOffset()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> The shift required to obtain API-level world space </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getTime()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Current time as a remainder of 1 second. Yields a value between 0 and 1 </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getUserTime()</strong> </td><td style="text-align:center"> float4 </td><td style="text-align:left"> Current time in seconds: <code>time</code>, <code>(double)time - time</code>, <code>0</code>, <code>0</code> </td></tr>
@@ -2594,6 +2595,16 @@ type aliases:
 <tr><td style="text-align:left"> <strong class="asterisk">getExposure()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> Photometric exposure of the camera </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getEV100()</strong> </td><td style="text-align:center"> float </td><td style="text-align:left"> <a href="https://en.wikipedia.org/wiki/Exposure_value">Exposure value at ISO 100</a> of the camera </td></tr>
 </tbody></table></div>
+
+<p></p><p>
+
+</p><div class="admonition tip"><div class="admonition-title"> world space</div>
+
+<p></p><p>
+
+    To achieve good precision, the “world space” in Filament's shading system does not necessarily
+    match the API-level world space. To obtain the position of the API-level camera, custom
+    materials can add <code>getWorldOffset()</code> to <code>getWorldCameraPosition()</code>.</p></div>
 
 <p></p>
 <a class="target" name="vertexonly">&nbsp;</a><a class="target" name="materialdefinitions/shaderpublicapis/vertexonly">&nbsp;</a><a class="target" name="toc4.5.5">&nbsp;</a><h3>Vertex only</h3>
@@ -2619,7 +2630,6 @@ The following APIs are only available from the fragment block:
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldTangentFrame()</strong> </td><td style="text-align:center"> float3×3 </td><td style="text-align:left"> Matrix containing in each column the <code>tangent</code> (<code>frame[0]</code>), <code>bi-tangent</code> (<code>frame[1]</code>) and <code>normal</code> (<code>frame[2]</code>) of the vertex in world space. If the material does not compute a tangent space normal for bump mapping or if the shading is not anisotropic, only the <code>normal</code> is valid in this matrix. </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldPosition()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Position of the fragment in world space (see note below about world-space) </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldViewVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized vector in world space from the fragment position to the eye </td></tr>
-<tr><td style="text-align:left"> <strong class="asterisk">getWorldViewVectorWithMagnitude()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Vector in world space from the fragment position to the eye </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldNormalVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized normal in world space, after bump mapping (must be used after <code>prepareMaterial()</code>) </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldGeometricNormalVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Normalized normal in world space, before bump mapping (can be used before <code>prepareMaterial()</code>) </td></tr>
 <tr><td style="text-align:left"> <strong class="asterisk">getWorldReflectedVector()</strong> </td><td style="text-align:center"> float3 </td><td style="text-align:left"> Reflection of the view vector about the normal (must be used after <code>prepareMaterial()</code>) </td></tr>
@@ -2642,9 +2652,8 @@ The following APIs are only available from the fragment block:
 
 <p></p><p>
 
-    To achieve good precision, the “world space” in Filament's shading system does not necessarily
-    match the API-level world space. To obtain API-level world space coordinates, custom materials
-    should add <code>getWorldOffset()</code> to <code>getWorldPosition()</code> (et al).</p></div>
+    To obtain API-level world space coordinates, custom materials should add <code>getWorldOffset()</code> to
+    <code>getWorldPosition()</code> (et al).</p></div>
 
 <p></p><p>
 

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2134,12 +2134,18 @@ type aliases:
                  Name               |   Type   |            Description
 :-----------------------------------|:--------:|:------------------------------------
 **getResolution()**                 | float4   |  Resolution of the view in pixels: `width`, `height`, `1 / width`, `1 / height`
+**getWorldCameraPosition()**        | float3   |  Position of the camera/eye in world space
 **getWorldOffset()**                | float3   |  The shift required to obtain API-level world space
 **getTime()**                       | float    |  Current time as a remainder of 1 second. Yields a value between 0 and 1
 **getUserTime()**                   | float4   |  Current time in seconds: `time`, `(double)time - time`, `0`, `0`
 **getUserTimeMode(float m)**        | float    |  Current time modulo m in seconds
 **getExposure()**                   | float    |  Photometric exposure of the camera
 **getEV100()**                      | float    |  [Exposure value at ISO 100](https://en.wikipedia.org/wiki/Exposure_value) of the camera
+
+!!! TIP: world space
+    To achieve good precision, the "world space" in Filament's shading system does not necessarily
+    match the API-level world space. To obtain the position of the API-level camera, custom
+    materials can add `getWorldOffset()` to `getWorldCameraPosition()`.
 
 ### Vertex only
 
@@ -2162,7 +2168,6 @@ The following APIs are only available from the fragment block:
 **getWorldTangentFrame()**              | float3x3 |  Matrix containing in each column the `tangent` (`frame[0]`), `bi-tangent` (`frame[1]`) and `normal` (`frame[2]`) of the vertex in world space. If the material does not compute a tangent space normal for bump mapping or if the shading is not anisotropic, only the `normal` is valid in this matrix.
 **getWorldPosition()**                  | float3   |  Position of the fragment in world space (see note below about world-space)
 **getWorldViewVector()**                | float3   |  Normalized vector in world space from the fragment position to the eye
-**getWorldViewVectorWithMagnitude()**   | float3   |  Vector in world space from the fragment position to the eye
 **getWorldNormalVector()**              | float3   |  Normalized normal in world space, after bump mapping (must be used after `prepareMaterial()`)
 **getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
 **getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
@@ -2179,9 +2184,8 @@ The following APIs are only available from the fragment block:
 **uvToRenderTargetUV(float2)**          | float2   |  Transforms a UV coordinate to allow sampling from a `RenderTarget` attachment
 
 !!! TIP: world space
-    To achieve good precision, the "world space" in Filament's shading system does not necessarily
-    match the API-level world space. To obtain API-level world space coordinates, custom materials
-    should add `getWorldOffset()` to `getWorldPosition()` (et al).
+    To obtain API-level world space coordinates, custom materials should add `getWorldOffset()` to
+    `getWorldPosition()` (et al).
 
 !!! TIP: sampling from render targets
     When sampling from a `filament::Texture` that is attached to a `filament::RenderTarget` for

--- a/filament/src/PerViewUniforms.cpp
+++ b/filament/src/PerViewUniforms.cpp
@@ -82,7 +82,6 @@ void PerViewUniforms::prepareCamera(const CameraInfo& camera) noexcept {
     s.clipFromWorldMatrix = clipFromWorld;    // projection * view
     s.worldFromClipMatrix = worldFromClip;    // 1/(projection * view)
     s.cameraPosition = float3{ camera.getPosition() };
-    s.cameraForward = float3{ camera.getForwardVector() };
     s.worldOffset = camera.worldOffset;
     s.cameraFar = camera.zf;
     s.clipControl = mClipControl;

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -54,19 +54,17 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
 
     math::float4 resolution; // viewport width, height, 1/width, 1/height
 
-    math::float3 cameraForward;
-    float padding0;
-
     // camera position in view space (when camera_at_origin is enabled), i.e. it's (0,0,0).
     // Always add worldOffset in the shader to get the true world-space position of the camera.
     math::float3 cameraPosition;
+
     float time; // time in seconds, with a 1 second period
 
     math::float4 lightColorIntensity; // directional light
 
     math::float4 sun; // cos(sunAngle), sin(sunAngle), 1/(sunAngle*HALO_SIZE-sunAngle), HALO_EXP
 
-    math::float3 padding1;
+    math::float3 padding0;
     uint32_t lightChannels;
 
     math::float3 lightDirection;
@@ -123,7 +121,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     float aoReserved3;
 
     math::float2 clipControl;
-    math::float2 padding2;
+    math::float2 padding1;
 
     float vsmExponent;
     float vsmDepthScale;
@@ -141,7 +139,7 @@ struct PerViewUib { // NOLINT(cppcoreguidelines-pro-type-member-init)
     math::mat4f iblRotation; // contains the IBL's rotation
 
     // bring PerViewUib to 2 KiB
-    math::float4 arrayPadding[51];
+    math::float4 padding2[52];
 };
 
 // 2 KiB == 128 float4s

--- a/libs/filamat/src/UibGenerator.cpp
+++ b/libs/filamat/src/UibGenerator.cpp
@@ -45,15 +45,13 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             // view
             .add("resolution",              1, UniformInterfaceBlock::Type::FLOAT4, Precision::HIGH)
             // camera
-            .add("cameraForward",           1, UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH)
-            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT)
             .add("cameraPosition",          1, UniformInterfaceBlock::Type::FLOAT3, Precision::HIGH)
             // time
             .add("time",                    1, UniformInterfaceBlock::Type::FLOAT, Precision::HIGH)
             // directional light
             .add("lightColorIntensity",     1, UniformInterfaceBlock::Type::FLOAT4)
             .add("sun",                     1, UniformInterfaceBlock::Type::FLOAT4)
-            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT3)
+            .add("padding0",                1, UniformInterfaceBlock::Type::FLOAT3)
             .add("lightChannels",           1, UniformInterfaceBlock::Type::UINT)
             .add("lightDirection",          1, UniformInterfaceBlock::Type::FLOAT3)
             .add("fParamsX",                1, UniformInterfaceBlock::Type::UINT)
@@ -104,7 +102,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("aoReserved3",             1, UniformInterfaceBlock::Type::FLOAT)
 
             .add("clipControl",             1, UniformInterfaceBlock::Type::FLOAT2)
-            .add("padding2",                1, UniformInterfaceBlock::Type::FLOAT2)
+            .add("padding1",                1, UniformInterfaceBlock::Type::FLOAT2)
 
             .add("vsmExponent",             1, UniformInterfaceBlock::Type::FLOAT)
             .add("vsmDepthScale",           1, UniformInterfaceBlock::Type::FLOAT)
@@ -123,7 +121,7 @@ UniformInterfaceBlock const& UibGenerator::getPerViewUib() noexcept  {
             .add("iblRotation",             1, UniformInterfaceBlock::Type::MAT4, Precision::HIGH)
 
             // bring PerViewUib to 2 KiB
-            .add("arrayPadding", 51, UniformInterfaceBlock::Type::FLOAT4)
+            .add("padding2", 52, UniformInterfaceBlock::Type::FLOAT4)
             .build();
     return uib;
 }

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -281,9 +281,7 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             vec2 uvDy = dFdy(uv0);
 
             mat3 tangentFromWorld = transpose(getWorldTangentFrame());
-            vec3 tangentCameraPosition = tangentFromWorld * getWorldCameraPosition();
-            vec3 tangentFragPosition = tangentFromWorld * getWorldPosition();
-            vec3 v = normalize(tangentCameraPosition - tangentFragPosition);
+            vec3 v = tangentFromWorld * getWorldViewVector();
 
             float minLayers = 8.0;
             float maxLayers = 48.0;

--- a/samples/sample_full_pbr.cpp
+++ b/samples/sample_full_pbr.cpp
@@ -281,7 +281,9 @@ static void setup(Engine* engine, View* view, Scene* scene) {
             vec2 uvDy = dFdy(uv0);
 
             mat3 tangentFromWorld = transpose(getWorldTangentFrame());
-            vec3 v = tangentFromWorld * getWorldViewVector();
+            vec3 tangentCameraPosition = tangentFromWorld * getWorldCameraPosition();
+            vec3 tangentFragPosition = tangentFromWorld * getWorldPosition();
+            vec3 v = normalize(tangentCameraPosition - tangentFragPosition);
 
             float minLayers = 8.0;
             float maxLayers = 48.0;

--- a/shaders/src/common_getters.fs
+++ b/shaders/src/common_getters.fs
@@ -42,6 +42,11 @@ highp vec4 getResolution() {
 }
 
 /** @public-api */
+highp vec3 getWorldCameraPosition() {
+    return frameUniforms.cameraPosition;
+}
+
+/** @public-api */
 highp vec3 getWorldOffset() {
     return frameUniforms.worldOffset;
 }

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -42,19 +42,6 @@ vec3 getWorldViewVector() {
 }
 
 /** @public-api */
-vec3 getWorldViewVectorWithMagnitude() {
-    vec3 worldPosToEye = frameUniforms.cameraPosition - shading_position;
-    if (frameUniforms.clipFromViewMatrix[2].w != 0.0) {
-        // Perspective camera
-        return worldPosToEye;
-    } else {
-        // 'Magnitude' is the signed distance from plane: (orthoEyePos, -orthoViewDir)
-        float magnitude = dot(shading_view, worldPosToEye);
-        return magnitude * shading_view;
-    }
-}
-
-/** @public-api */
 vec3 getWorldNormalVector() {
     return shading_normal;
 }

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -41,6 +41,10 @@ vec3 getWorldViewVector() {
     return shading_view;
 }
 
+bool isPerspectiveProjection() {
+    return frameUniforms.clipFromViewMatrix[2].w != 0.0;
+}
+
 /** @public-api */
 vec3 getWorldNormalVector() {
     return shading_normal;

--- a/shaders/src/main.fs
+++ b/shaders/src/main.fs
@@ -40,7 +40,7 @@ void main() {
 #endif
 
 #if defined(HAS_FOG)
-    vec3 view = -getWorldViewVectorWithMagnitude();
+    vec3 view = getWorldPosition() - getWorldCameraPosition();
     fragColor = fog(fragColor, view);
 #endif
 

--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -33,7 +33,13 @@ void computeShadingParams() {
 #endif
 
     shading_position = vertex_worldPosition;
-    shading_view = normalize(frameUniforms.cameraPosition - shading_position);
+
+    // With perspective camera, the view vector is cast from the fragment pos to the eye position,
+    // With ortho camera, however, the view vector is the same for all fragments:
+    shading_view = isPerspectiveProjection() ?
+        (frameUniforms.cameraPosition - shading_position) :
+        frameUniforms.worldFromViewMatrix[2].xyz; // ortho camera backward dir
+    shading_view = normalize(shading_view);
 
     // we do this so we avoid doing (matrix multiply), but we burn 4 varyings:
     //    p = clipFromWorldMatrix * shading_position;

--- a/shaders/src/shading_parameters.fs
+++ b/shaders/src/shading_parameters.fs
@@ -33,10 +33,7 @@ void computeShadingParams() {
 #endif
 
     shading_position = vertex_worldPosition;
-    
-    // Perspective or orthographic:
-    shading_view = (frameUniforms.clipFromViewMatrix[2].w != 0.0) ? frameUniforms.cameraPosition - shading_position : -frameUniforms.cameraForward;
-    shading_view = normalize(shading_view);
+    shading_view = normalize(frameUniforms.cameraPosition - shading_position);
 
     // we do this so we avoid doing (matrix multiply), but we burn 4 varyings:
     //    p = clipFromWorldMatrix * shading_position;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1632](https://shapr3d.atlassian.net/browse/GFX-1632)

## Short description (What? How?) 📖
Downstream https://github.com/google/filament/pull/6453. This PR reverts some changes made in #21, namely:
 - Changes to the public API in shaders lib (and the related HTML documentation changes)
 - Correct _view dir_ calculation of fog in ortho mode
 - Changes to the Uib (ortho camera view dir is extracted from a matrix in _shading_parameters.fs_ instead of passing it in a uniform variable)

None of these reverts affect Shapr3D, we don't use fog.

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-1632]: https://shapr3d.atlassian.net/browse/GFX-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ