### PR TITLE
[GFX-2610] Fix Filament bump builds with ccache on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,29 +61,34 @@ endif()
 # ==================================================================================================
 # Support for ccache
 # ==================================================================================================
-#find_program(CCACHE_PROGRAM ccache)
-#if (CCACHE_PROGRAM)
-#    set(C_LAUNCHER   "${CCACHE_PROGRAM}")
-#    set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
-#
-#    configure_file(build/launch-c.in   launch-c)
-#    configure_file(build/launch-cxx.in launch-cxx)
-#
-#    execute_process(COMMAND chmod a+rx
-#        "${CMAKE_BINARY_DIR}/launch-c"
-#        "${CMAKE_BINARY_DIR}/launch-cxx"
-#    )
-#
-#    if (CMAKE_GENERATOR STREQUAL "Xcode")
-#        set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
-#        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
-#        set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
-#        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
-#    else()
-#        set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
-#        set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
-#    endif()
-#endif()
+find_program(CCACHE_PROGRAM ccache)
+if (CCACHE_PROGRAM)
+	if(WIN32)
+		set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
+		set(CMAKE_CXX_COMPILER_LAUNCHER	"${CCACHE_PROGRAM}")
+	else()
+		set(C_LAUNCHER   "${CCACHE_PROGRAM}")
+		set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+	
+		configure_file(build/launch-c.in   launch-c)
+		configure_file(build/launch-cxx.in launch-cxx)
+
+		execute_process(COMMAND chmod a+rx
+			"${CMAKE_BINARY_DIR}/launch-c"
+			"${CMAKE_BINARY_DIR}/launch-cxx"
+		)
+
+		if (CMAKE_GENERATOR STREQUAL "Xcode")
+			set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
+			set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
+			set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
+			set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+		else()
+			set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
+			set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
+		endif()
+	endif()
+endif()
 
 # ==================================================================================================
 # Support Vim and Visual Studio Code by generating compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,31 +63,31 @@ endif()
 # ==================================================================================================
 find_program(CCACHE_PROGRAM ccache)
 if (CCACHE_PROGRAM)
-	if(WIN32)
-		set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
-		set(CMAKE_CXX_COMPILER_LAUNCHER	"${CCACHE_PROGRAM}")
-	else()
-		set(C_LAUNCHER   "${CCACHE_PROGRAM}")
-		set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
-	
-		configure_file(build/launch-c.in   launch-c)
-		configure_file(build/launch-cxx.in launch-cxx)
+    if(WIN32)
+        set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    else()
+        set(C_LAUNCHER   "${CCACHE_PROGRAM}")
+        set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+    
+        configure_file(build/launch-c.in   launch-c)
+        configure_file(build/launch-cxx.in launch-cxx)
 
-		execute_process(COMMAND chmod a+rx
-			"${CMAKE_BINARY_DIR}/launch-c"
-			"${CMAKE_BINARY_DIR}/launch-cxx"
-		)
+        execute_process(COMMAND chmod a+rx
+            "${CMAKE_BINARY_DIR}/launch-c"
+            "${CMAKE_BINARY_DIR}/launch-cxx"
+        )
 
-		if (CMAKE_GENERATOR STREQUAL "Xcode")
-			set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
-			set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
-			set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
-			set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
-		else()
-			set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
-			set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
-		endif()
-	endif()
+        if (CMAKE_GENERATOR STREQUAL "Xcode")
+            set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
+            set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
+            set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
+            set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+        else()
+            set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
+            set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
+        endif()
+    endif()
 endif()
 
 # ==================================================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,29 +61,29 @@ endif()
 # ==================================================================================================
 # Support for ccache
 # ==================================================================================================
-find_program(CCACHE_PROGRAM ccache)
-if (CCACHE_PROGRAM)
-    set(C_LAUNCHER   "${CCACHE_PROGRAM}")
-    set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
-
-    configure_file(build/launch-c.in   launch-c)
-    configure_file(build/launch-cxx.in launch-cxx)
-
-    execute_process(COMMAND chmod a+rx
-        "${CMAKE_BINARY_DIR}/launch-c"
-        "${CMAKE_BINARY_DIR}/launch-cxx"
-    )
-
-    if (CMAKE_GENERATOR STREQUAL "Xcode")
-        set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
-        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
-        set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
-        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
-    else()
-        set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
-        set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
-    endif()
-endif()
+#find_program(CCACHE_PROGRAM ccache)
+#if (CCACHE_PROGRAM)
+#    set(C_LAUNCHER   "${CCACHE_PROGRAM}")
+#    set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+#
+#    configure_file(build/launch-c.in   launch-c)
+#    configure_file(build/launch-cxx.in launch-cxx)
+#
+#    execute_process(COMMAND chmod a+rx
+#        "${CMAKE_BINARY_DIR}/launch-c"
+#        "${CMAKE_BINARY_DIR}/launch-cxx"
+#    )
+#
+#    if (CMAKE_GENERATOR STREQUAL "Xcode")
+#        set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
+#        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
+#        set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
+#        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+#    else()
+#        set(CMAKE_C_COMPILER_LAUNCHER        "${CMAKE_BINARY_DIR}/launch-c")
+#        set(CMAKE_CXX_COMPILER_LAUNCHER      "${CMAKE_BINARY_DIR}/launch-cxx")
+#    endif()
+#endif()
 
 # ==================================================================================================
 # Support Vim and Visual Studio Code by generating compile_commands.json


### PR DESCRIPTION
## Jira ticket URL (Why?)

[GFX-2610](https://shapr3d.atlassian.net/browse/GFX-2610)

## Short description (What? How?) 📖

Our build script `create_package.ps1` for integrating Filament into our repository started failing some time ago on Windows. This PR aims to fix this.

### Reasons for failure

Our build script only builds the strictly necessary parts of the Filament project, by using Filament's `cmake` build scripts to generate `ninja` build files, in order to generate the output. Filament's root `CMakeLists.txt` script includes support for using `ccache`, if found installed on the system, but is unprepared to use it on Windows (only Unix-like systems and Xcode are supported). Thus our script broke, when we installed `ccache` on our Windows machines.

### Why didn't it fail before?

`cmake`'s only generators that support the `CMAKE_<LANGUAGE>_COMPILER_LAUNCHER` parameters are the `ninja` and `Makefile` ones. This is used to tell `cmake` to use `ccache` to launch the selected compiler. Thus compiling Filament using `Visual Studio`/`MSBuild` does not break with ccache installed. Filament's build script also has special handling for the Xcode generator, which has no support for compiler launchers.

### Fixing it

I decided to implement the bare minimum `ccache` support in Filament's root `CMakeLists.txt`, by simply adding a special case for the `WIN32` platform. In this case, it will use `ccache` as the compiler launcher.

The build script passes extra parameters to `ccache` on Unix and Xcode systems, using a bash script. I decided not to mirror this functionality for two reasons:

1. Using `ccache` as-is still speeds up the build
2. It would take an unreasonable amount of effort to pass those parameters properly

#### Why is the proper solution complicated

`ccache` expects parameters as environment variables. `cmake` has no facility to pass a modified environment to its compiler launchers ([set(ENV{BAR} blah)](https://cmake.org/cmake/help/v3.7/command/set.html#set-environment-variable) does not work), thus on Unix-like systems, Filament employs a `bash` script to `export` the desired variables.

This can be mirrored on Windows either with Batch files or Powershell scripts. Filament's Windows scripts use Batch files, thus would be preferred for upstreaming. Unfortunately, going this route spawns new Command Prompt windows for each invocation, thus making the build considerably slower, and making the compiler output harder to see, as these windows close on compiler instance termination. The Powershell route has two issues: it's different from the current Filament Windows scripts, and the default setting on Windows is to disallow running of Powershell scripts that aren't digitally signed.

#### What do we lose by omitting the parameters

Two parameters are passed to `ccache`. One of them matches the default value, thus nothing is lost. The other parameter (`CCACHE_SLOPPINESS`) relaxes some cache invalidation checks in order to increase cache hit rate. I have not tested whether this speeds up the build or not.

## Upstreaming scope

This is a bug in Filament's root `CMakeLists.txt`, thus we should upstream. The only risk is requiring to implement `ccache` parameters too.

## Testing

### Design review 🎨

N/A

### Affected areas 🧭

Filament version bump in shapr repo

### Special use-cases to test 🧷

N/A

### How did you test it? 🤔
Manual 💁‍♂️
The script now works on Windows
Automated 💻
We have no facility for this, and don't intend to have yet

[GFX-2610]: https://shapr3d.atlassian.net/browse/GFX-2610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ