### PR TITLE
[GFX-1488] Fix operations for material rotation

### DIFF
--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -464,7 +464,7 @@ void FTransformManager::computeMaterialWorldOrientation(
         math::float3 const& parentOrientationCenter,
         math::float3 const& localOrientationCenter) {
 
-    outOrientation = parentOrientation * localOrientation;
+    outOrientation = localOrientation * parentOrientation;
     outOrientationCenter = parentOrientationCenter + localOrientationCenter;
 }
 
@@ -477,12 +477,13 @@ math::mat3f FTransformManager::getMaterialCompoundOrientation(Instance ci) const
     worldRotation[0] = normalize(worldRotation[0]);
     worldRotation[1] = normalize(worldRotation[1]);
     worldRotation[2] = normalize(worldRotation[2]);
-    // we need to invert the rotation, because we undo it to keep texture direction
-    // orthonormal matrix -> transpose = inverse
-    worldRotation = transpose(worldRotation);
 
-    // we apply the orientation transformation first, then our world rotation
-    return orientation * worldRotation;
+    // We need to apply the inverse of the world transformation's rotation component
+    // then apply our own orientation. Multiplying with worldRotation on the right is
+    // equivalent to multiplying on the left with the transpose of it, which in this
+    // case is equal to the inverse (orthonormal matrix). This allows us to compute only
+    // one matrix multiplication, instead of two (one on the left, one on the right).
+    return worldRotation * orientation;
 }
 
 

--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -233,7 +233,7 @@ BiplanarAxes ComputeBiplanarPlanes(vec3 weights) {
 
 BiplanarData GenerateBiplanarData(BiplanarAxes axes, float scaler, highp vec3 pos, lowp vec3 weights) {
     // Depending on the resolution of the texture, we may want to multiply the texture coordinates
-    vec3 queryPos = scaler * (getMaterialOrientationMatrix() * (pos - getMaterialOrientationCenter()));
+    vec3 queryPos = (scaler * (pos - getMaterialOrientationCenter() - (objectUniforms.worldFromModelMatrix[3].xyz + getWorldOffset()))) * getMaterialOrientationMatrix();
 
     // Store the query data
     BiplanarData result = DEFAULT_BIPLANAR_DATA;
@@ -264,7 +264,7 @@ BiplanarData GenerateBiplanarData(BiplanarAxes axes, float scaler, highp vec3 po
 // A simple linear blend with normalization
 vec3 ComputeWeights(vec3 normal) {
     // We transform the normal only here for material rotation
-    normal = getMaterialOrientationMatrix() * normal;
+    normal = normal * getMaterialOrientationMatrix();
 
     // This one has a region where there is no blend, creating more defined interpolations
     const float blendBias = 0.2;


### PR DESCRIPTION
## Jira ticket URL (Why?)

[GFX-1488](https://shapr3d.atlassian.net/browse/GFX-1488)

## Short description (What? How?) 📖
After reviewing all matrices involved in our transformations the conclusion is:
- Rotation matrices from our material rotation calculator should be multiplied on the right for our bi/triplanar mapping
- The rotation component of transformations of bodies done in MS must be undone for correct material orientation, thus the inverse rotation matrix must be multiplied on the left. As this is a rotation-only matrix, multiplying by the inverse on the left is equivalent to multiplying on the right with the original matrix.

The transformation chain to use is this:
- Composing a body's orientation with its parts' orientation, for multiplying on the right in the shader is `outOrientation = localOrientation * parentOrientation`
- To undo the world orientation, it must be multiplied on the right in the shader, thus the input to the shader becomes `worldRotation * renderableOrientation`

This means the final transformation of a renderable becomes:
`finalRotation = worldRotation * (localOrientation * parentOrientation * ...)` (where the `* ...` denotes multiplying up the transform hierarchy to the root).

## Upstreaming scope
We do not intend to upstream material rotation, as it depends on bi/triplanar mapping, which we don't intend to upstream either.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Rotation of texture mapping

### Special use-cases to test 🧷
Try bodies with different rotations with and without world transforms

### How did you test it? 🤔
Manual 💁‍♂️
Tried different bodies in different configurations
Automated 💻
Only Shapr-side automatic testing

[GFX-1488]: https://shapr3d.atlassian.net/browse/GFX-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ