### PR TITLE
[Added] Note about updating material stats

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,12 @@ Let's focus on the what? and how?.
 Don't duplicate what's in the Jira ticket. If it's outdated, let's update that.
 -->
 
+## Material shader statistics implications
+<!---
+If you are altering the material shaders directly or indirectly, make sure to update the statistics as per
+https://shapr3d.atlassian.net/wiki/spaces/RT/pages/3323134029/Benchmark+material+attribute+performance .
+-->
+
 ## Upstreaming scope
 <!---
 Should we propagate these changes to upstream? If so, reference the upstream PR


### PR DESCRIPTION
## Jira ticket URL (Why?)
n/a

## Short description (What? How?) 📖
Since we have RGA-based shader statistics, we want a reminder to update them if we alter the material shaders. If we do that explicitly, it is easy to remember, however, if we do it indirectly (e.g. by altering the shader skeleton or codegen), the new bulletin should remind us to consider that possibility.

Updates should be done to the 5 material type sheets linked from https://shapr3d.atlassian.net/wiki/spaces/RT/pages/3323134029/Benchmark+material+attribute+performance with a new sheet using the master-based git hash. 

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
n/a

Automated 💻
n/a