### PR TITLE
[GFX-2686] Draw triplanar blending weights option in viz/DevTools

### DIFF
--- a/filament/src/materials/Cloth.mat
+++ b/filament/src/materials/Cloth.mat
@@ -129,6 +129,10 @@ material {
         {
             type : uint,
             name : usageFlags
+        },
+        {
+            type : uint,
+            name : debugUsageFlags
         }
     ],
     variables: [

--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -443,6 +443,13 @@ void ApplyBaseColor(inout MaterialInputs material, inout FragmentData fragmentDa
 
     // Naive multiplicative tinting seems to be fine enough for now
     material.baseColor.rgb *= materialParams.tintColor.rgb;
+
+#if defined(DRAW_WEIGHTS)
+if((materialParams.debugUsageFlags & 1u ) != 0u) {
+    material.baseColor.rgb = ComputeWeights(fragmentData.normal);
+}
+
+#endif
 #if defined(BLENDING_ENABLED)
     material.baseColor.rgb *= material.baseColor.a;
     material.baseColor.a = 0.0;

--- a/filament/src/materials/Opaque.mat
+++ b/filament/src/materials/Opaque.mat
@@ -137,6 +137,10 @@ material {
         {
             type : uint,
             name : usageFlags
+        },
+        {
+            type : uint,
+            name : debugUsageFlags
         }
     ],
     variables: [

--- a/filament/src/materials/Refractive.mat
+++ b/filament/src/materials/Refractive.mat
@@ -171,6 +171,10 @@ material {
         {
             type : uint,
             name : usageFlags
+        },
+        {
+            type : uint,
+            name : debugUsageFlags
         }
     ],
     variables: [

--- a/filament/src/materials/Subsurface.mat
+++ b/filament/src/materials/Subsurface.mat
@@ -146,6 +146,10 @@ material {
         {
             type : uint,
             name : usageFlags
+        },
+        {
+            type : uint,
+            name : debugUsageFlags
         }
     ],
     variables: [

--- a/filament/src/materials/Transparent.mat
+++ b/filament/src/materials/Transparent.mat
@@ -103,6 +103,10 @@ material {
         {
             type : uint,
             name : usageFlags
+        },
+        {
+            type : uint,
+            name : debugUsageFlags
         }
     ],
     variables: [


### PR DESCRIPTION
<!---
If a section is not applicable for your PR,
please just mark it with "n/a" rather than deleting it.
Also these comment sections should be deleted from the final PR.
-->

## Jira ticket URL (Why?)
<!---
Use the Jira ticket id as text in PROJ-XXX format and append it to the end of the link.
If there are multiple tickets, list all.
-->
[GFX-2686](https://shapr3d.atlassian.net/browse/GFX-2686/)

## Short description (What? How?) 📖
<!---
Short description of the change, can include screenshot, gif, etc.
Let's focus on the what? and how?.
Don't duplicate what's in the Jira ticket. If it's outdated, let's update that.
-->
In this PR, a new `DRAW_WEIGHTS` define was introduced in `MaterialHelpersShading.fxh` to control the visualization of triplanar weights. 

For each material type a new `debugUsageFlags` parameter was introduced to store flags that are only essential for debugging purposes. The first debugUsageFlag is responsible for applying the weight coloring in the shader. The color is calculated using the `ComputeWeights(normal)` function. 

## Testing

### Design review 🎨
<!--- List the design team members who approved the implementation -->

### Affected areas 🧭
<!--- List all areas that can be affected by the changes introduced -->
Filament material shaders
### Special use-cases to test 🧷
<!--- List special use-cases that could have changed -->

### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
The modified shaders were tested in gltf viewer.



[GFX-2686]: https://shapr3d.atlassian.net/browse/GFX-2686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ