### PR TITLE
[GFX-1975] Depth variants of 1x1 dummy textures

### DIFF
--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -183,6 +183,8 @@ inline MTLPixelFormat getMetalFormat(PixelDataFormat format, PixelDataType type)
     CONVERT(RGBA_INTEGER, UINT, RGBA32Uint);
     CONVERT(RGBA_INTEGER, INT, RGBA32Sint);
     CONVERT(RGBA, FLOAT, RGBA32Float);
+    CONVERT(DEPTH_COMPONENT, USHORT, Depth16Unorm);
+    CONVERT(DEPTH_COMPONENT, FLOAT, Depth32Float);
     #undef CONVERT
 
     return MTLPixelFormatInvalid;

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -255,8 +255,14 @@ void PostProcessManager::init() noexcept {
     mDummyOneTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
+    mDummyOneDepthTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
+            TextureFormat::DEPTH16, 1, 1, 1, 1, TextureUsage::DEFAULT);
+
     mDummyOneTextureArray = driver.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
+
+    mDummyOneDepthTextureArray = driver.createTexture(SamplerType::SAMPLER_2D_ARRAY, 1,
+            TextureFormat::DEPTH16, 1, 1, 1, 1, TextureUsage::DEFAULT);
 
     mDummyZeroTexture = driver.createTexture(SamplerType::SAMPLER_2D, 1,
             TextureFormat::RGBA8, 1, 1, 1, 1, TextureUsage::DEFAULT);
@@ -265,11 +271,15 @@ void PostProcessManager::init() noexcept {
             TextureFormat::R8, 1, 256, 1, 1, TextureUsage::DEFAULT);
 
     PixelBufferDescriptor dataOne(driver.allocate(4), 4, PixelDataFormat::RGBA, PixelDataType::UBYTE);
+    PixelBufferDescriptor dataOneDepth(driver.allocate(2), 2, PixelDataFormat::DEPTH_COMPONENT, PixelDataType::USHORT);
     PixelBufferDescriptor dataOneArray(driver.allocate(4), 4, PixelDataFormat::RGBA, PixelDataType::UBYTE);
+    PixelBufferDescriptor dataOneDepthArray(driver.allocate(2), 2, PixelDataFormat::DEPTH_COMPONENT, PixelDataType::USHORT);
     PixelBufferDescriptor dataZero(driver.allocate(4), 4, PixelDataFormat::RGBA, PixelDataType::UBYTE);
     PixelBufferDescriptor dataStarburst(driver.allocate(256), 256, PixelDataFormat::R, PixelDataType::UBYTE);
     *static_cast<uint32_t *>(dataOne.buffer) = 0xFFFFFFFF;
+    *static_cast<uint16_t *>(dataOneDepth.buffer) = 0xFFFF;
     *static_cast<uint32_t *>(dataOneArray.buffer) = 0xFFFFFFFF;
+    *static_cast<uint16_t *>(dataOneDepthArray.buffer) = 0xFFFF;
     *static_cast<uint32_t *>(dataZero.buffer) = 0;
     std::generate_n((uint8_t*)dataStarburst.buffer, 256,
             [&dist = mUniformDistribution, &gen = mEngine.getRandomEngine()]() {
@@ -277,7 +287,9 @@ void PostProcessManager::init() noexcept {
         return uint8_t(r * 255.0f);
     });
     driver.update2DImage(mDummyOneTexture, 0, 0, 0, 1, 1, std::move(dataOne));
+    driver.update2DImage(mDummyOneDepthTexture, 0, 0, 0, 1, 1, std::move(dataOneDepth));
     driver.update3DImage(mDummyOneTextureArray, 0, 0, 0, 0, 1, 1, 1, std::move(dataOneArray));
+    driver.update3DImage(mDummyOneDepthTextureArray, 0, 0, 0, 0, 1, 1, 1, std::move(dataOneDepthArray));
     driver.update2DImage(mDummyZeroTexture, 0, 0, 0, 1, 1, std::move(dataZero));
     driver.update2DImage(mStarburstTexture, 0, 0, 0, 256, 1, std::move(dataStarburst));
 }
@@ -285,7 +297,9 @@ void PostProcessManager::init() noexcept {
 void PostProcessManager::terminate(DriverApi& driver) noexcept {
     FEngine& engine = mEngine;
     driver.destroyTexture(mDummyOneTexture);
+    driver.destroyTexture(mDummyOneDepthTexture);
     driver.destroyTexture(mDummyOneTextureArray);
+    driver.destroyTexture(mDummyOneDepthTextureArray);
     driver.destroyTexture(mDummyZeroTexture);
     driver.destroyTexture(mStarburstTexture);
     auto first = mMaterialRegistry.begin();

--- a/filament/src/PostProcessManager.h
+++ b/filament/src/PostProcessManager.h
@@ -145,8 +145,10 @@ public:
             bool reinhard, size_t kernelWidth, float sigma = 6.0f) noexcept;
 
     backend::Handle<backend::HwTexture> getOneTexture() const { return mDummyOneTexture; }
+    backend::Handle<backend::HwTexture> getOneDepthTexture() const { return mDummyOneDepthTexture; }
     backend::Handle<backend::HwTexture> getZeroTexture() const { return mDummyZeroTexture; }
     backend::Handle<backend::HwTexture> getOneTextureArray() const { return mDummyOneTextureArray; }
+    backend::Handle<backend::HwTexture> getOneDepthTextureArray() const { return mDummyOneDepthTextureArray; }
 
     math::float2 halton(size_t index) const noexcept {
         return mHaltonSamples[index & 0xFu];
@@ -223,7 +225,9 @@ private:
     PostProcessMaterial& getPostProcessMaterial(utils::StaticString name) noexcept;
 
     backend::Handle<backend::HwTexture> mDummyOneTexture;
+    backend::Handle<backend::HwTexture> mDummyOneDepthTexture;
     backend::Handle<backend::HwTexture> mDummyOneTextureArray;
+    backend::Handle<backend::HwTexture> mDummyOneDepthTextureArray;
     backend::Handle<backend::HwTexture> mDummyZeroTexture;
     backend::Handle<backend::HwTexture> mStarburstTexture;
 

--- a/filament/src/Renderer.cpp
+++ b/filament/src/Renderer.cpp
@@ -939,11 +939,11 @@ FrameGraphId<FrameGraphTexture> FRenderer::colorPass(FrameGraph& fg, const char*
 
                 // set shadow sampler
                 view.prepareShadow(data.shadows ?
-                        resources.getTexture(data.shadows) : ppm.getOneTextureArray());
+                        resources.getTexture(data.shadows) : ppm.getOneDepthTextureArray());
 
                 // set structure sampler
                 view.prepareStructure(data.structure ?
-                        resources.getTexture(data.structure) : ppm.getOneTexture());
+                        resources.getTexture(data.structure) : ppm.getOneDepthTexture());
 
                 if (data.ssr) {
                     view.prepareSSR(resources.getTexture(data.ssr), config.refractionLodOffset);


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-1975](https://shapr3d.atlassian.net/browse/GFX-1975)

## Short description (What? How?) 📖
`PostProcessManager` has a set of dummy textures that are used as fallback when a certain pass/feature is disabled. Problem is, shaders may do comparison sampling on bound textures, which is only supported for depth textures.

This PR adds depth variants of dummy textures, and uses them for shadow and structure pass fallbacks to avoid undefined behavior at runtime and error messages from validation layers. In practice, OpenGL error reporting and Metal validation (incl. shader validation) were unable to catch this, but D3D11 via ANGLE did report it.

Also the Metal backend lacked support for uploading data to depth textures, added support for `.depth16Unorm` and `.depth32Float` formats. (Note: type and format in `PixelBufferDescriptor` follows conventions of [`glTexImage2D()`](https://docs.gl/es3/glTexImage2D)).

## Material shader statistics implications
n/a

## Upstreaming scope
[GFX-2792](https://shapr3d.atlassian.net/browse/GFX-2792) created.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
I'm not aware of visible outcomes of the undefined behavior, nor if shaders actually executed depth sampling on dummy textures or if they were in inactive branches only.

### Special use-cases to test 🧷
Repro in the ticket shouldn't spam the logs on Windows anymore.

### How did you test it? 🤔
Manual 💁‍♂️
Tested the repro in ticket, checked frame captures and verified the pixel format of bound textures.

Automated 💻
:x:

[GFX-1975]: https://shapr3d.atlassian.net/browse/GFX-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GFX-2792]: https://shapr3d.atlassian.net/browse/GFX-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ