### PR TITLE
[GFX-2856] Fix material translation in case of material rotation

### DIFF
--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -238,7 +238,7 @@ BiplanarAxes ComputeBiplanarPlanes(vec3 weights) {
 
 BiplanarData GenerateBiplanarData(BiplanarAxes axes, float scaler, highp vec3 pos, lowp vec3 weights) {
     // Depending on the resolution of the texture, we may want to multiply the texture coordinates
-    vec3 queryPos = scaler * (pos - getMaterialOrientationCenter() - (objectUniforms.worldFromModelMatrix[3].xyz + getWorldOffset()));
+    vec3 queryPos = scaler * (pos - getMaterialOrientationCenter());
     if (IsAutoOrientationEnabled()) {
         queryPos *= getMaterialOrientationMatrix();
     }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2856](https://shapr3d.atlassian.net/browse/GFX-2856)

Previously: [GFX-2791](https://shapr3d.atlassian.net/browse/GFX-2791)

## Short description (What? How?) 📖
This is the Filament side of GFX-2856. Removing this translation is required, because `getMaterialOrientationCenter()` is already in world-space.

## Material shader statistics implications
This should not affect performance, as a few operations are removed.

## Upstreaming scope
This is part of our triplanar material mapping, which afaik we do not intend to upstream.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Material translation invariance, rotation

### Special use-cases to test 🧷
You cannot test this in `gltf_viewer`

### How did you test it? 🤔
Built `gltf_viewer` and ran it. This can't be tested in Filament right now.

[GFX-2791]: https://shapr3d.atlassian.net/browse/GFX-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GFX-2856]: https://shapr3d.atlassian.net/browse/GFX-2856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ