### PR TITLE
[Fixed] Material orientation shader usage in wrap axis UV flipping

### DIFF
--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -244,10 +244,11 @@ BiplanarData GenerateBiplanarData(BiplanarAxes axes, float scaler, highp vec3 po
     // Store the query data
     BiplanarData result = DEFAULT_BIPLANAR_DATA;
 
-    // Position needs some fixed flipping-fu so that textures are oriented as intended    
-    vec2 uvQueries[3] = vec2[3](queryPos.yz * vec2(SIGN_NO_ZERO(normal.x), -1.0), 
-                                queryPos.xz * vec2(SIGN_NO_ZERO(normal.y), -1.0), 
-                                queryPos.xy * vec2(1.0, SIGN_NO_ZERO(normal.z)));
+    // Position needs some fixed flipping-fu so that textures are oriented as intended
+    vec3 materialOrientedNormal = normal * getMaterialOrientationMatrix();
+    vec2 uvQueries[3] = vec2[3](queryPos.yz * vec2(SIGN_NO_ZERO(materialOrientedNormal.x), -1.0), 
+                                queryPos.xz * vec2(SIGN_NO_ZERO(materialOrientedNormal.y), -1.0), 
+                                queryPos.xy * vec2(1.0, SIGN_NO_ZERO(materialOrientedNormal.z)));
 
     result.maxPos = uvQueries[axes.maximum.x];
     result.medPos = uvQueries[axes.median.x];


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2931](https://shapr3d.atlassian.net/browse/GFX-2931)

## Short description (What? How?) 📖
Filament counterpart of https://github.com/shapr3d/shapr3d/pull/15054 . 

## Material shader statistics implications
From now on, Bence is making these stats roughly every 2nd sprint. 

## Upstreaming scope
None

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Visualization with non-unit matrix material orientations

### Special use-cases to test 🧷
GltfViewer should work as before

### How did you test it? 🤔
Manual 💁‍♂️
There should be no difference in GltfViewer.

Automated 💻
n/a

[GFX-2931]: https://shapr3d.atlassian.net/browse/GFX-2931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ