### PR TITLE
[GFX-2660] Add API for applying world transform to material orientation or not

### DIFF
--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -303,6 +303,23 @@ public:
     const math::mat3f& getMaterialOrientation(Instance ci) const noexcept;
 
     /**
+     * Sets whether the world transformation's rotation component should be applied to the material
+     * orientation of a transform component.
+     * @param ci    The instance of the transform component to set this property to.
+     * @param apply Whether to apply the world transform or not.
+     * @see isWorldTransformAppliedToMaterialOrientation()
+    */
+    void applyWorldTransformToMaterialOrientation(Instance ci, bool apply) noexcept;
+
+    /**
+     * Returns whether the world transformation's rotation component is applied to the material
+     * orientation of a transform component.
+     * @param ci The instance of the transform component to query this property from.
+     * @return True, if the world transform is applied to the material orientation, false otherwise.
+    */
+    bool isWorldTransformAppliedToMaterialOrientation(Instance ci) const noexcept;
+
+    /**
      * Returns the world material orientation of a transform component.
      * @param ci The instance of the transform component to query the world material orientation from.
      * @return The world orientation of the component's material (i.e. relative to the root). This is the

--- a/filament/src/Scene.cpp
+++ b/filament/src/Scene.cpp
@@ -114,7 +114,8 @@ void FScene::prepare(const mat4& worldOriginTransform, bool shadowReceiversAreCa
         const mat4f worldTransform{ worldOriginTransform * tcm.getWorldTransformAccurate(ti) };
         const bool reversedWindingOrder = det(worldTransform.upperLeft()) < 0;
 
-        const mat3f materialOrientation = tcm.getMaterialCompoundOrientation(ti);
+        const bool applyWorldToMaterialOrientation = tcm.isWorldTransformAppliedToMaterialOrientation(ti);
+        const mat3f materialOrientation = applyWorldToMaterialOrientation ? tcm.getMaterialCompoundOrientation(ti) : tcm.getMaterialOrientation(ti);
         const float3 materialOrientationCenter = tcm.getMaterialWorldOrientationCenter(ti);
 
         // don't even draw this object if it doesn't have a transform (which shouldn't happen

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -60,6 +60,8 @@ void FTransformManager::create(Entity entity, Instance parent, const mat4f& loca
     assert_invariant(i);
     assert_invariant(i != parent);
 
+    manager[i].applyWorldToMaterialOrientation = true;
+
     if (i && i != parent) {
         manager[i].parent = 0;
         manager[i].next = 0;
@@ -81,6 +83,8 @@ void FTransformManager::create(Entity entity, Instance parent, const mat4& local
     Instance i = manager.addComponent(entity);
     assert_invariant(i);
     assert_invariant(i != parent);
+
+    manager[i].applyWorldToMaterialOrientation = true;
 
     if (i && i != parent) {
         manager[i].parent = 0;
@@ -196,6 +200,14 @@ void FTransformManager::setMaterialOrientation(Instance ci, const math::mat3f& r
         // store our local transform
         manager[ci].materialLocalOrientation = rotation;
         updateNodeTransform(ci);
+    }
+}
+
+void FTransformManager::applyWorldTransformToMaterialOrientation(Instance ci, bool apply) noexcept {
+    validateNode(ci);
+    if (ci) {
+        auto& manager = mManager;
+        manager[ci].applyWorldToMaterialOrientation = apply;
     }
 }
 
@@ -619,7 +631,11 @@ const mat3f& TransformManager::getMaterialOrientation(Instance ci) const noexcep
     return upcast(this)->getMaterialOrientation(ci);
 }
 
-const mat3f& TransformManager::getMaterialWorldOrientation(Instance ci) const noexcept {
+void TransformManager::applyWorldTransformToMaterialOrientation(Instance ci, bool apply) noexcept {
+    upcast(this)->applyWorldTransformToMaterialOrientation(ci, apply);
+}
+
+const mat3f &TransformManager::getMaterialWorldOrientation(Instance ci) const noexcept {
     return upcast(this)->getMaterialWorldOrientation(ci);
 }
 

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -119,6 +119,11 @@ public:
 
     void setMaterialOrientation(Instance ci, const math::mat3f& rotation) noexcept;
 
+    void applyWorldTransformToMaterialOrientation(Instance ci, bool apply) noexcept;
+    bool isWorldTransformAppliedToMaterialOrientation(Instance ci) const noexcept {
+        return mManager[ci].applyWorldToMaterialOrientation;
+    }
+
     const math::mat3f& getMaterialOrientation(Instance ci) const noexcept {
         return mManager[ci].materialLocalOrientation;
     }
@@ -172,6 +177,7 @@ private:
         MATERIAL_ORIENTATION,               // bi/triplanar mapping rotation matrix, composed with parent transforms
         MATERIAL_LOCAL_ORIENTATION_CENTER,  // local center of bi/triplanar mapping
         MATERIAL_ORIENTATION_CENTER,        // bi/triplanar mapping center, composed with parent center
+        APPLY_WORLD_TO_MATERIAL_ORIENTATION,// whether to concatenate the world transform to material orientation
         PARENT,         // instance to the parent
         FIRST_CHILD,    // instance to our first child
         NEXT,           // instance to our next sibling
@@ -187,6 +193,7 @@ private:
             math::mat3f,    // orientation
             math::float3,   // local orientation center
             math::float3,   // orientation center
+            bool,           // apply world to material orientation
             Instance,       // parent
             Instance,       // firstChild
             Instance,       // next
@@ -215,6 +222,7 @@ private:
                 Field<MATERIAL_ORIENTATION>                 materialOrientation;
                 Field<MATERIAL_LOCAL_ORIENTATION_CENTER>    materialLocalOrientationCenter;
                 Field<MATERIAL_ORIENTATION_CENTER>          materialOrientationCenter;
+                Field<APPLY_WORLD_TO_MATERIAL_ORIENTATION>  applyWorldToMaterialOrientation;
                 Field<PARENT>       parent;
                 Field<FIRST_CHILD>  firstChild;
                 Field<NEXT>         next;

--- a/filament/src/materials/MaterialHelpersShading.fxh
+++ b/filament/src/materials/MaterialHelpersShading.fxh
@@ -36,7 +36,6 @@
 // 12    doDeriveAbsorption             materialParams.usageFlags & 4096
 // 13    doDeriveSheenColor             materialParams.usageFlags & 8192
 // 14    doDeriveSubsurfaceColor        materialParams.usageFlags & 16384
-// 15    isAutoOrientationEnabled       materialParams.usageFlags & 32768
 //
 // Our ASTC compressor lays out the coordinates as XXXY but our BC5 compressor lays them out as XY.
 // The useSwizzledNormalMaps flag indicates if data is stored as XY or XXXY (so we can sample the 
@@ -102,10 +101,6 @@ bool DoDeriveSheenColor() {
 
 bool DoDeriveSubsurfaceColor() {
     return ( materialParams.usageFlags & 16384u ) != 0u;
-}
-
-bool IsAutoOrientationEnabled() {
-    return ( materialParams.usageFlags & 32768u ) != 0u;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -238,9 +233,8 @@ BiplanarAxes ComputeBiplanarPlanes(vec3 weights) {
 BiplanarData GenerateBiplanarData(BiplanarAxes axes, float scaler, highp vec3 pos, lowp vec3 normal, lowp vec3 weights) {
     // Depending on the resolution of the texture, we may want to multiply the texture coordinates
     vec3 queryPos = scaler * (pos - getMaterialOrientationCenter());
-    if (IsAutoOrientationEnabled()) {
-        queryPos *= getMaterialOrientationMatrix();
-    }
+    queryPos *= getMaterialOrientationMatrix();
+
     // Store the query data
     BiplanarData result = DEFAULT_BIPLANAR_DATA;
 
@@ -273,9 +267,7 @@ BiplanarData GenerateBiplanarData(BiplanarAxes axes, float scaler, highp vec3 po
 // A simple linear blend with normalization
 vec3 ComputeWeights(vec3 normal) {
     // We transform the normal only here for material rotation
-    if (IsAutoOrientationEnabled()) {
-        normal = normal * getMaterialOrientationMatrix();
-    }
+    normal = normal * getMaterialOrientationMatrix();
 
     // This one has a region where there is no blend, creating more defined interpolations
     const float blendBias = 0.2;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2660](https://shapr3d.atlassian.net/browse/GFX-2660)

## Short description (What? How?) 📖
With the introduction of manual material orientations, we always need to apply a rotation matrix to our texture projection. This PR removes the conditional flag from the material shaders.

We also need a way of disabling applying the world transform to the material orientation. This is currently always applied. When the user disables automatic orientation, we should not apply the world transform either, but should apply the manual one. `applyWorldTransformToMaterialOrientation(Instance, bool)` allows enabling or disabling world transform application for each entity.

## Material shader statistics implications
There should be no noticeable impact. Removing a branch on a uniform should give an immeasurably small performance improvement. 

## Upstreaming scope
None. This only affects our material texture mapping, which we do not intend to upstream.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
All material types' texture mapping.

### Special use-cases to test 🧷
This should have no visible impact in gltf_viewer, until some UI controls are made available.

### How did you test it? 🤔
Manual 💁‍♂️
Recompiled gltf_viewer and tried some materials

[GFX-2660]: https://shapr3d.atlassian.net/browse/GFX-2660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ