### PR TITLE
[GFX-2789] Fix DoF transparency

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -1143,7 +1143,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                       dofOptions.maxBackgroundCOC ? dofOptions.maxBackgroundCOC : DOF_DEFAULT_MAX_COC});
                 mi->setParameter("uvscale", float4{ width, height,
                         1.0f / colorDesc.width, 1.0f / colorDesc.height });
-                commitAndRender(out, material, driver);
+                commitAndRender(out, material, variant, driver);
             });
 
     /*
@@ -1389,7 +1389,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                     0.0 // unused for now
                 });
                 mi->setParameter("bokehAngle",  bokehAngle);
-                commitAndRender(out, material, driver);
+                commitAndRender(out, material, variant, driver);
             });
 
     /*
@@ -1495,7 +1495,7 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::dof(FrameGraph& fg,
                     colorDesc.width  / (tilesDesc.width  * float(tileSize)),
                     colorDesc.height / (tilesDesc.height * float(tileSize))
                 });
-                commitAndRender(out, material, driver);
+                commitAndRender(out, material, variant, driver);
             });
 
     return ppDoFCombine->output;

--- a/filament/src/materials/dof/dofMedian.mat
+++ b/filament/src/materials/dof/dofMedian.mat
@@ -49,64 +49,96 @@ layout(location = 1) out float outAlpha;
  * [https://casual-effects.com/research/McGuire2008Median/index.html]
  */
 
-void sort2(inout vec4 a, inout vec4 b) {
-    vec4 t = a;
-    a = min(a, b);
-    b = max(t, b);
+#define MINLEFTMAXRIGHT_TEMPLATE(type)                                                                      \
+void sort2(inout type a, inout type b) {                                                                    \
+    type t = a;                                                                                             \
+    a = min(a, b);                                                                                          \
+    b = max(t, b);                                                                                          \
+}                                                                                                           \
+                                                                                                            \
+void minLeft(inout type a, inout type b, inout type c) {                                                    \
+    sort2(a, b);                                                                                            \
+    sort2(a, c);                                                                                            \
+}                                                                                                           \
+                                                                                                            \
+void maxRight(inout type a, inout type b, inout type c) {                                                   \
+    sort2(b, c);                                                                                            \
+    sort2(a, c);                                                                                            \
+}                                                                                                           \
+                                                                                                            \
+void minLeftMaxRight(inout type a, inout type b, inout type c) {                                            \
+    maxRight(a, b, c);                                                                                      \
+    sort2(a, b);                                                                                            \
+}                                                                                                           \
+                                                                                                            \
+void minLeftMaxRight(inout type a, inout type b, inout type c, inout type d) {                              \
+    sort2(a, b);                                                                                            \
+    sort2(c, d);                                                                                            \
+    sort2(a, c);                                                                                            \
+    sort2(b, d);                                                                                            \
+}                                                                                                           \
+                                                                                                            \
+void minLeftMaxRight(inout type a, inout type b, inout type c, inout type d, inout type e) {                \
+    sort2(a, b);                                                                                            \
+    sort2(c, d);                                                                                            \
+    minLeft(a, c, e);                                                                                       \
+    maxRight(b, d, e);                                                                                      \
+}                                                                                                           \
+                                                                                                            \
+void minLeftMaxRight(inout type a, inout type b, inout type c, inout type d, inout type e, inout type f) {  \
+    sort2(a, d);                                                                                            \
+    sort2(b, e);                                                                                            \
+    sort2(c, f);                                                                                            \
+    minLeft(a, b, c);                                                                                       \
+    maxRight(d, e, f);                                                                                      \
 }
 
-void minLeft(inout vec4 a, inout vec4 b, inout vec4 c) {
-    sort2(a, b);
-    sort2(a, c);
-}
+MINLEFTMAXRIGHT_TEMPLATE(vec4)
+MINLEFTMAXRIGHT_TEMPLATE(float)
 
-void maxRight(inout vec4 a, inout vec4 b, inout vec4 c) {
-    sort2(b, c);
-    sort2(a, c);
-}
 
-void minLeftMaxRight(inout vec4 a, inout vec4 b, inout vec4 c) {
-    maxRight(a, b, c);
-    sort2(a, b);
-}
-
-void minLeftMaxRight(inout vec4 a, inout vec4 b, inout vec4 c, inout vec4 d) {
-    sort2(a, b);
-    sort2(c, d);
-    sort2(a, c);
-    sort2(b, d);
-}
-
-void minLeftMaxRight(inout vec4 a, inout vec4 b, inout vec4 c, inout vec4 d, inout vec4 e) {
-    sort2(a, b);
-    sort2(c, d);
-    minLeft(a, c, e);
-    maxRight(b, d, e);
-}
-
-void minLeftMaxRight(inout vec4 a, inout vec4 b, inout vec4 c, inout vec4 d, inout vec4 e, inout vec4 f) {
-    sort2(a, d);
-    sort2(b, e);
-    sort2(c, f);
-    minLeft(a, b, c);
-    maxRight(d, e, f);
-}
 
 // - we can't use a function because offset must be a constant expression
 // - we can't use line continuation because that's not supported on desktop
-#define makeSample(ij, o) vec4(texelFetchOffset(materialParams_dof, ij, 0, o).rgb, texelFetchOffset(materialParams_alpha, ij, 0, o).r)
+#define makeSampleColor(ij, o) texelFetchOffset(materialParams_dof, ij, 0, o)
+#define makeSampleAlpha(ij, o) texelFetchOffset(materialParams_alpha, ij, 0, o).r
 
-vec4 median(ivec2 ij) {
+vec4 medianColor(ivec2 ij) {
     vec4 v[9];
-    v[0] = makeSample(ij, ivec2(-1, -1));
-    v[1] = makeSample(ij, ivec2( 0, -1));
-    v[2] = makeSample(ij, ivec2( 1, -1));
-    v[3] = makeSample(ij, ivec2(-1,  0));
-    v[4] = makeSample(ij, ivec2( 0,  0));
-    v[5] = makeSample(ij, ivec2( 1,  0));
-    v[6] = makeSample(ij, ivec2(-1,  1));
-    v[7] = makeSample(ij, ivec2( 0,  1));
-    v[8] = makeSample(ij, ivec2( 1,  1));
+    v[0] = makeSampleColor(ij, ivec2(-1, -1));
+    v[1] = makeSampleColor(ij, ivec2( 0, -1));
+    v[2] = makeSampleColor(ij, ivec2( 1, -1));
+    v[3] = makeSampleColor(ij, ivec2(-1,  0));
+    v[4] = makeSampleColor(ij, ivec2( 0,  0));
+    v[5] = makeSampleColor(ij, ivec2( 1,  0));
+    v[6] = makeSampleColor(ij, ivec2(-1,  1));
+    v[7] = makeSampleColor(ij, ivec2( 0,  1));
+    v[8] = makeSampleColor(ij, ivec2( 1,  1));
+
+    // max() is a faster alternative to the median filter, but it looks pretty bad imho
+    //return max(v[0], max(v[1], max(v[2], max(v[3], max(v[4], max(v[5], max(v[6], max(v[7], v[8]))))))));
+    // it looks better (than max()) to skip this filter and keep the noise
+    //return v[4];
+
+    minLeftMaxRight(v[0], v[1], v[2], v[3], v[4], v[5]);
+    minLeftMaxRight(v[1], v[2], v[3], v[4], v[6]);
+    minLeftMaxRight(v[2], v[3], v[4], v[7]);
+    minLeftMaxRight(v[3], v[4], v[8]);
+    return v[4];
+}
+
+
+float medianAlpha(ivec2 ij) {
+    float v[9];
+    v[0] = makeSampleAlpha(ij, ivec2(-1, -1));
+    v[1] = makeSampleAlpha(ij, ivec2( 0, -1));
+    v[2] = makeSampleAlpha(ij, ivec2( 1, -1));
+    v[3] = makeSampleAlpha(ij, ivec2(-1,  0));
+    v[4] = makeSampleAlpha(ij, ivec2( 0,  0));
+    v[5] = makeSampleAlpha(ij, ivec2( 1,  0));
+    v[6] = makeSampleAlpha(ij, ivec2(-1,  1));
+    v[7] = makeSampleAlpha(ij, ivec2( 0,  1));
+    v[8] = makeSampleAlpha(ij, ivec2( 1,  1));
 
     // max() is a faster alternative to the median filter, but it looks pretty bad imho
     //return max(v[0], max(v[1], max(v[2], max(v[3], max(v[4], max(v[5], max(v[6], max(v[7], v[8]))))))));
@@ -123,15 +155,17 @@ vec4 median(ivec2 ij) {
 void postProcess(inout PostProcessInputs postProcess) {
     vec2 tiles = textureLod(materialParams_tiles, variable_vertex.zw, 0.0).rg;
     vec4 dof = vec4(0.0);
+    float alpha = 0.0;
 
     if (!isTrivialTile(tiles)) {
         vec2 size = vec2(textureSize(materialParams_dof, 0));
         ivec2 ij = ivec2(variable_vertex.xy * size);
-        dof = median(ij);
+        dof = medianColor(ij);
+        alpha = medianAlpha(ij);
     }
 
     postProcess.color  = dof;
-    outAlpha           = dof.a;
+    outAlpha           = alpha;
 }
 
 }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2789](https://shapr3d.atlassian.net/browse/GFX-2789)

## Short description (What? How?) 📖
The missing transparency with enabled DoF was cause by the following inconsistencies:
- Filament used the wrong shader variants for transparent DoF because the pipeline selector flag was missing in the code.
- DoF median shader discarded the alpha channel of the "original" color texture.

## Material shader statistics implications
DoF shaders were changed and Filament used different shader variants for transparent DoF, so I'm certain that this change has an impact on performance.
@benceboros2 


## Upstreaming scope
https://shapr3d.atlassian.net/browse/GFX-3000

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
- Visualisation: Depth of Field

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
I modified the Filament renderer to behave by default like when a screenshot is taken, then I was able to capture the frames in XCode. This was done to iterate on the problem faster, but to check it capturing a screenshot is sufficient.

https://github.com/shapr3d/filament/assets/100697016/9038cc5a-5c11-462f-886b-80de9039579d

Automated 💻
n/a

[GFX-2789]: https://shapr3d.atlassian.net/browse/GFX-2789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ