### PR TITLE
[GFX-2365] Custom logging

### DIFF
--- a/libs/utils/include/utils/Log.h
+++ b/libs/utils/include/utils/Log.h
@@ -38,6 +38,12 @@ struct UTILS_PUBLIC Loggers {
 
 extern UTILS_PUBLIC Loggers const slog;
 
+using LoggerCallback = void(*)(const char*);
+extern UTILS_PUBLIC LoggerCallback slogdcb;
+extern UTILS_PUBLIC LoggerCallback slogecb;
+extern UTILS_PUBLIC LoggerCallback slogwcb;
+extern UTILS_PUBLIC LoggerCallback slogicb;
+
 } // namespace utils
 
 #endif // TNT_UTILS_LOG_H

--- a/libs/utils/src/Log.cpp
+++ b/libs/utils/src/Log.cpp
@@ -63,17 +63,36 @@ ostream& LogStream::flush() noexcept {
             break;
     }
 #else
+
+    LoggerCallback callback = nullptr;
+    FILE* stream = nullptr;
+
     switch (mPriority) {
-        case LOG_DEBUG:
-        case LOG_WARNING:
-        case LOG_INFO:
-            fprintf(stdout, "%s", buf.get());
-            break;
-        case LOG_ERROR:
-            fprintf(stderr, "%s", buf.get());
-            break;
+    case LOG_DEBUG:
+        callback = slogdcb;
+        stream = stdout;
+        break;
+    case LOG_WARNING:
+        callback = slogwcb;
+        stream = stdout;
+        break;
+    case LOG_INFO:
+        callback = slogicb;
+        stream = stdout;
+        break;
+    case LOG_ERROR:
+        callback = slogecb;
+        stream = stderr;
+        break;
     }
 #endif
+
+    if (callback) {
+        callback(buf.get());
+    } else {
+        fprintf(stream, "%s", buf.get());
+    }
+
     buf.reset();
     return *this;
 }
@@ -92,5 +111,10 @@ Loggers const slog = {
         io::cwarn,  // warning
         io::cinfo   // info
 };
+
+LoggerCallback slogdcb = nullptr;
+LoggerCallback slogecb = nullptr;
+LoggerCallback slogwcb = nullptr;
+LoggerCallback slogicb = nullptr;
 
 } // namespace utils

--- a/libs/utils/src/Log.cpp
+++ b/libs/utils/src/Log.cpp
@@ -68,22 +68,22 @@ ostream& LogStream::flush() noexcept {
     FILE* stream = nullptr;
 
     switch (mPriority) {
-    case LOG_DEBUG:
-        callback = slogdcb;
-        stream = stdout;
-        break;
-    case LOG_WARNING:
-        callback = slogwcb;
-        stream = stdout;
-        break;
-    case LOG_INFO:
-        callback = slogicb;
-        stream = stdout;
-        break;
-    case LOG_ERROR:
-        callback = slogecb;
-        stream = stderr;
-        break;
+        case LOG_DEBUG:
+            callback = slogdcb;
+            stream = stdout;
+            break;
+        case LOG_WARNING:
+            callback = slogwcb;
+            stream = stdout;
+            break;
+        case LOG_INFO:
+            callback = slogicb;
+            stream = stdout;
+            break;
+        case LOG_ERROR:
+            callback = slogecb;
+            stream = stderr;
+            break;
     }
 #endif
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2365](https://shapr3d.atlassian.net/browse/GFX-2365)

## Short description (What? How?) 📖
Filament logs via the `slog.d/e/w/i` globals. On Android these are connected to the usual system log, in other platforms it prints to standard output/error streams.

This PR adds the option to register custom loggers via callbacks, available in similar globals.

Pre-condition and post-condition assertions also log their messages and callstacks before aborting/throwing, which makes this solution suitable for providing helpful info for crashes.

## Material shader statistics implications
n/a

## Upstreaming scope
[GFX-3007](https://shapr3d.atlassian.net/browse/GFX-3007). Already requested upstream in https://github.com/google/filament/discussions/5750.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Logging: assertions, error reporting.

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
See app-side PR.


[GFX-2365]: https://shapr3d.atlassian.net/browse/GFX-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GFX-3007]: https://shapr3d.atlassian.net/browse/GFX-3007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ