### PR TITLE
[GFX-2955] Fix swizzle support on iOS simulator

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -81,12 +81,14 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
     // In order to support texture swizzling, the GPU needs to support it and the system be running
     // iOS 13+.
     mContext->supportsTextureSwizzling = false;
+    #if !TARGET_OS_SIMULATOR
     if (@available(iOS 13, *)) {
         mContext->supportsTextureSwizzling =
             mContext->highestSupportedGpuFamily.apple >= 1 ||       // all Apple GPUs
             mContext->highestSupportedGpuFamily.mac   >= 2 ||       // newer macOS GPUs
             mContext->highestSupportedGpuFamily.macCatalyst >= 2;   // newer Mac Catalyst GPUs
     }
+    #endif
 
     mContext->supportsDepthResolve =
         mContext->highestSupportedGpuFamily.apple >= 3 ||


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-2955](https://shapr3d.atlassian.net/browse/GFX-2955)

## Short description (What? How?) 📖
iOS simulator cannot `supportsTextureSwizzling`, so we turn it off to enable rendering tests for DoF: https://github.com/shapr3d/shapr3d/pull/15427

## Material shader statistics implications
n/a

## Upstreaming scope
?

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
It does work.
Automated 💻
See https://github.com/shapr3d/shapr3d/pull/15427

[GFX-2955]: https://shapr3d.atlassian.net/browse/GFX-2955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ