### PR TITLE
[GFX-3038] Fix EGL_ANDROID_recordable warnings on Windows

### DIFF
--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -174,9 +174,9 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
     }
 
     if (recordable == 1 && configsCount == 0) {
-      // warn and retry without EGL_RECORDABLE_ANDROID
+        // warn and retry without EGL_RECORDABLE_ANDROID
         logEglError("eglChooseConfig(..., EGL_RECORDABLE_ANDROID) failed. Continuing without it.");
-      // this is not fatal
+        // this is not fatal
         configAttribs[12] = EGL_RECORDABLE_ANDROID;
         configAttribs[13] = EGL_DONT_CARE;
         if (!eglChooseConfig(mEGLDisplay, configAttribs, &mEGLTransparentConfig, 1, &configsCount) ||

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -185,7 +185,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
             goto error;
         }
     }
-    
+
     if (!extensions.has("EGL_KHR_no_config_context")) {
         // if we have the EGL_KHR_no_config_context, we don't need to worry about the config
         // when creating the context, otherwise, we must always pick a transparent config.

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -104,6 +104,12 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
     eglCreateImageKHR = (PFNEGLCREATEIMAGEKHRPROC) eglGetProcAddress("eglCreateImageKHR");
     eglDestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC) eglGetProcAddress("eglDestroyImageKHR");
 
+#ifndef FILAMENT_USE_ANGLE
+    constexpr EGLint recordable = 1;
+#else
+    constexpr EGLint recordable = EGL_DONT_CARE;
+#endif
+
     EGLint configsCount;
     EGLint configAttribs[] = {
             EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT_KHR,        //  0
@@ -112,7 +118,7 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
             EGL_BLUE_SIZE,   8,                                 //  6
             EGL_ALPHA_SIZE,  0,                                 //  8 : reserved to set ALPHA_SIZE below
             EGL_DEPTH_SIZE, 24,                                 // 10
-            EGL_RECORDABLE_ANDROID, 1,                          // 12
+            EGL_RECORDABLE_ANDROID, recordable,                 // 12
             EGL_NONE                                            // 14
     };
 
@@ -140,21 +146,22 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
     EGLConfig eglConfig = nullptr;
 
     // find an opaque config
-    if (!eglChooseConfig(mEGLDisplay, configAttribs, &mEGLConfig, 1, &configsCount)) {
+    if (!eglChooseConfig(mEGLDisplay, configAttribs, &mEGLConfig, 1, &configsCount) ||
+            (configAttribs[13] == EGL_DONT_CARE && configsCount == 0)) {
         logEglError("eglChooseConfig");
         goto error;
     }
 
-    if (configsCount == 0) {
-      // warn and retry without EGL_RECORDABLE_ANDROID
-      logEglError("eglChooseConfig(..., EGL_RECORDABLE_ANDROID) failed. Continuing without it.");
-      configAttribs[12] = EGL_RECORDABLE_ANDROID;
-      configAttribs[13] = EGL_DONT_CARE;
-      if (!eglChooseConfig(mEGLDisplay, configAttribs, &mEGLConfig, 1, &configsCount) ||
-              configsCount == 0) {
-          logEglError("eglChooseConfig");
-          goto error;
-      }
+    if (recordable == 1 && configsCount == 0) {
+        // warn and retry without EGL_RECORDABLE_ANDROID
+        logEglError("eglChooseConfig(..., EGL_RECORDABLE_ANDROID) failed. Continuing without it.");
+        configAttribs[12] = EGL_RECORDABLE_ANDROID;
+        configAttribs[13] = EGL_DONT_CARE;
+        if (!eglChooseConfig(mEGLDisplay, configAttribs, &mEGLConfig, 1, &configsCount) ||
+                configsCount == 0) {
+            logEglError("eglChooseConfig");
+            goto error;
+        }
     }
 
     // find a transparent config
@@ -166,19 +173,19 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
         goto error;
     }
 
-    if (configsCount == 0) {
+    if (recordable == 1 && configsCount == 0) {
       // warn and retry without EGL_RECORDABLE_ANDROID
         logEglError("eglChooseConfig(..., EGL_RECORDABLE_ANDROID) failed. Continuing without it.");
       // this is not fatal
-      configAttribs[12] = EGL_RECORDABLE_ANDROID;
-      configAttribs[13] = EGL_DONT_CARE;
-      if (!eglChooseConfig(mEGLDisplay, configAttribs, &mEGLTransparentConfig, 1, &configsCount) ||
-              configsCount == 0) {
-          logEglError("eglChooseConfig");
-          goto error;
-      }
+        configAttribs[12] = EGL_RECORDABLE_ANDROID;
+        configAttribs[13] = EGL_DONT_CARE;
+        if (!eglChooseConfig(mEGLDisplay, configAttribs, &mEGLTransparentConfig, 1, &configsCount) ||
+                configsCount == 0) {
+            logEglError("eglChooseConfig");
+            goto error;
+        }
     }
-
+    
     if (!extensions.has("EGL_KHR_no_config_context")) {
         // if we have the EGL_KHR_no_config_context, we don't need to worry about the config
         // when creating the context, otherwise, we must always pick a transparent config.

--- a/filament/backend/src/opengl/PlatformEGL.cpp
+++ b/filament/backend/src/opengl/PlatformEGL.cpp
@@ -104,10 +104,10 @@ Driver* PlatformEGL::createDriver(void* sharedContext) noexcept {
     eglCreateImageKHR = (PFNEGLCREATEIMAGEKHRPROC) eglGetProcAddress("eglCreateImageKHR");
     eglDestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC) eglGetProcAddress("eglDestroyImageKHR");
 
-#ifndef FILAMENT_USE_ANGLE
-    constexpr EGLint recordable = 1;
-#else
+#ifdef FILAMENT_USE_ANGLE
     constexpr EGLint recordable = EGL_DONT_CARE;
+#else
+    constexpr EGLint recordable = 1;
 #endif
 
     EGLint configsCount;


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3038](https://shapr3d.atlassian.net/browse/GFX-3038)

## Short description (What? How?) 📖
ANGLE doesn't support any `EGL_ANDROID_recordable` EGL config (checked both on our fork and upstream), so we received warnings when Filament tried to request such configs. The easiest fix for this is avoid requesting such configs when ANGLE present.

## Material shader statistics implications
It's only setup code.

## Upstreaming scope
I don't think they would merge an ANGLE related PR.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
- Filament logging

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
Set breakpoints in the LoggerScope callbacks, and checked that the warnings are no longer sent. 

Automated 💻
n/a

[GFX-3038]: https://shapr3d.atlassian.net/browse/GFX-3038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ