### PR TITLE
[GFX 3191] Revert handle arena size and adjust pool ratios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,11 @@ set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "49" CACHE STRING
     "Size of the command-stream buffer. As a rule of thumb use the same value as FILAMENT_PER_FRRAME_COMMANDS_SIZE_IN_MB, default 1."
 )
 
-set(FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB "100" CACHE STRING
+set(FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB "4" CACHE STRING
     "Size of the OpenGL handle arena, default 4."
 )
 
-set(FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB "96" CACHE STRING
+set(FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB "8" CACHE STRING
     "Size of the Metal handle arena, default 8."
 )
 

--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -44,9 +44,9 @@ template <size_t P0, size_t P1, size_t P2>
 class HandleAllocator {
 public:
     struct PoolRatios {
+        size_t pool0;
         size_t pool1;
         size_t pool2;
-        size_t pool3;
     };
 
     HandleAllocator(const char* name, size_t size, const PoolRatios& poolRatios) noexcept;

--- a/filament/backend/include/private/backend/HandleAllocator.h
+++ b/filament/backend/include/private/backend/HandleAllocator.h
@@ -43,8 +43,13 @@ namespace filament::backend {
 template <size_t P0, size_t P1, size_t P2>
 class HandleAllocator {
 public:
+    struct PoolRatios {
+        size_t pool1;
+        size_t pool2;
+        size_t pool3;
+    };
 
-    HandleAllocator(const char* name, size_t size) noexcept;
+    HandleAllocator(const char* name, size_t size, const PoolRatios& poolRatios) noexcept;
     HandleAllocator(HandleAllocator const& rhs) = delete;
     HandleAllocator& operator=(HandleAllocator const& rhs) = delete;
     ~HandleAllocator();
@@ -219,7 +224,7 @@ private:
         UTILS_UNUSED_IN_RELEASE const utils::AreaPolicy::HeapArea& mArea;
     public:
         static constexpr size_t MIN_ALIGNMENT_SHIFT = 4;
-        explicit Allocator(const utils::AreaPolicy::HeapArea& area);
+        Allocator(const utils::AreaPolicy::HeapArea& area, const PoolRatios& poolRatios);
 
         // this is in fact always called with a constexpr size argument
         [[nodiscard]] inline void* alloc(size_t size, size_t alignment, size_t extra) noexcept {

--- a/filament/backend/src/HandleAllocator.cpp
+++ b/filament/backend/src/HandleAllocator.cpp
@@ -29,9 +29,22 @@ UTILS_NOINLINE
 HandleAllocator<P0, P1, P2>::Allocator::Allocator(AreaPolicy::HeapArea const& area)
         : mArea(area) {
     // TODO: we probably need a better way to set the size of these pools
+#if defined(WIN32)
+    // OpenGL backend uses pool2 the most
+    const size_t unit = area.size() / 100;
+    const size_t offsetPool1 = unit;
+    const size_t offsetPool2 = 85 * unit;
+#elif defined(IOS)
+    // Metal backend uses pool3 99% of the time (and barely ever uses pool2)
     const size_t unit = area.size() / 256;
     const size_t offsetPool1 = unit;
     const size_t offsetPool2 = 2 * unit;
+#else
+    // Upstream Filament uses 1:15:16 ratio on all platforms
+    const size_t unit = area.size() / 32;
+    const size_t offsetPool1 =      unit;
+    const size_t offsetPool2 = 16 * unit;
+#endif
     char* const p = (char*)area.begin();
     mPool0 = PoolAllocator< P0, 16>(p, p + offsetPool1);
     mPool1 = PoolAllocator< P1, 16>(p + offsetPool1, p + offsetPool2);

--- a/filament/backend/src/HandleAllocator.cpp
+++ b/filament/backend/src/HandleAllocator.cpp
@@ -28,9 +28,9 @@ template <size_t P0, size_t P1, size_t P2>
 UTILS_NOINLINE
 HandleAllocator<P0, P1, P2>::Allocator::Allocator(AreaPolicy::HeapArea const& area, const PoolRatios& poolRatios)
         : mArea(area) {
-    const size_t unit = area.size() / (poolRatios.pool1 + poolRatios.pool2 + poolRatios.pool3);
-    const size_t offsetPool1 = poolRatios.pool1 * unit;
-    const size_t offsetPool2 = (poolRatios.pool1 + poolRatios.pool2) * unit;
+    const size_t unit = area.size() / (poolRatios.pool0 + poolRatios.pool1 + poolRatios.pool2);
+    const size_t offsetPool1 = poolRatios.pool0 * unit;
+    const size_t offsetPool2 = (poolRatios.pool0 + poolRatios.pool1) * unit;
     char* const p = (char*)area.begin();
     mPool0 = PoolAllocator< P0, 16>(p, p + offsetPool1);
     mPool1 = PoolAllocator< P1, 16>(p + offsetPool1, p + offsetPool2);

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -56,7 +56,7 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
         : DriverBase(new ConcreteDispatcher<MetalDriver>()),
         mPlatform(*platform),
         mContext(new MetalContext),
-mHandleAllocator("Handles", FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,1,254}) {
+        mHandleAllocator("Handles", FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,1,254}) {
     mContext->driver = this;
 
     mContext->device = mPlatform.createDevice();

--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -56,7 +56,7 @@ MetalDriver::MetalDriver(backend::MetalPlatform* platform) noexcept
         : DriverBase(new ConcreteDispatcher<MetalDriver>()),
         mPlatform(*platform),
         mContext(new MetalContext),
-        mHandleAllocator("Handles", FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U) {
+mHandleAllocator("Handles", FILAMENT_METAL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,1,254}) {
     mContext->driver = this;
 
     mContext->device = mPlatform.createDevice();

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -164,7 +164,7 @@ OpenGLDriver::DebugMarker::~DebugMarker() noexcept {
 
 OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
         : DriverBase(new ConcreteDispatcher<OpenGLDriver>()),
-          mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U), // TODO: set the amount in configuration
+mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,84,15}), // TODO: set the amount in configuration
           mSamplerMap(32),
           mPlatform(*platform) {
   

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -164,7 +164,7 @@ OpenGLDriver::DebugMarker::~DebugMarker() noexcept {
 
 OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform) noexcept
         : DriverBase(new ConcreteDispatcher<OpenGLDriver>()),
-mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,84,15}), // TODO: set the amount in configuration
+          mHandleAllocator("Handles", FILAMENT_OPENGL_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,84,15}), // TODO: set the amount in configuration
           mSamplerMap(32),
           mPlatform(*platform) {
   

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -94,7 +94,7 @@ Driver* VulkanDriverFactory::create(VulkanPlatform* const platform,
 VulkanDriver::VulkanDriver(VulkanPlatform* platform,
         const char* const* ppRequiredExtensions, uint32_t requiredExtensionCount) noexcept :
         DriverBase(new ConcreteDispatcher<VulkanDriver>()),
-mHandleAllocator("Handles", FILAMENT_VULKAN_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,15,16}),
+        mHandleAllocator("Handles", FILAMENT_VULKAN_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,15,16}),
         mContextManager(*platform),
         mStagePool(mContext),
         mFramebufferCache(mContext),

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -94,7 +94,7 @@ Driver* VulkanDriverFactory::create(VulkanPlatform* const platform,
 VulkanDriver::VulkanDriver(VulkanPlatform* platform,
         const char* const* ppRequiredExtensions, uint32_t requiredExtensionCount) noexcept :
         DriverBase(new ConcreteDispatcher<VulkanDriver>()),
-        mHandleAllocator("Handles", FILAMENT_VULKAN_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U),
+mHandleAllocator("Handles", FILAMENT_VULKAN_HANDLE_ARENA_SIZE_IN_MB * 1024U * 1024U, {1,15,16}),
         mContextManager(*platform),
         mStagePool(mContext),
         mFramebufferCache(mContext),


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3191](https://shapr3d.atlassian.net/browse/GFX-3191)

## Short description (What? How?) 📖
The huge allocations for handle arena size sometimes cause out-of-memory errors and since we reuse shape part batching in Filament, we use significantly less handles. This PR reverts the handle arena size to the same values as it was on upsteam. The pool ratios however needed adjustments to obtain the best performance. See details in Jira comments...

## Material shader statistics implications
n/a

## Upstreaming scope
[GFX-3321](https://shapr3d.atlassian.net/browse/GFX-3321). But I don't think our ratios could be upstream, as it's highly optimized for complex meshes with few textures (CAD models in general).

## Testing

### Design review 🎨

### Affected areas 🧭
Less memory is used on each platform, without any performance degradation.

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
See Jira ticket to see how I measured and tested it

Automated 💻


[GFX-3191]: https://shapr3d.atlassian.net/browse/GFX-3191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GFX-3321]: https://shapr3d.atlassian.net/browse/GFX-3321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ