### PR TITLE
[GFX-3322] Reduce command buffer queue size to 11 MiB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "49" CACHE STRING
     "Size of the high-level draw commands buffer. Rule of thumb, 1 MB less than FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB, default 1."
 )
 
-set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "49" CACHE STRING
+set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "9" CACHE STRING
     "Size of the command-stream buffer. As a rule of thumb use the same value as FILAMENT_PER_FRRAME_COMMANDS_SIZE_IN_MB, default 1."
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "49" CACHE STRING
     "Size of the high-level draw commands buffer. Rule of thumb, 1 MB less than FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB, default 1."
 )
 
-set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "9" CACHE STRING
+set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "11" CACHE STRING
     "Size of the command-stream buffer. As a rule of thumb use the same value as FILAMENT_PER_FRRAME_COMMANDS_SIZE_IN_MB, default 1."
 )
 

--- a/filament/backend/src/CircularBuffer.cpp
+++ b/filament/backend/src/CircularBuffer.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include <stdio.h>
+#include <algorithm>
 
 #include <utils/ashmem.h>
 #include <utils/Log.h>
@@ -123,7 +124,8 @@ void* CircularBuffer::alloc(size_t size) noexcept {
     }
     return data;
 #else
-    return ::malloc(2 * size);
+    // Use 20% or 3 MiB overflow guard, whichever is bigger
+    return ::malloc(std::max(6 * size / 5, size + 3 * 1024 * 1024));
 #endif
 }
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3322](https://shapr3d.atlassian.net/browse/GFX-3322)

## Short description (What? How?) 📖
The current 49 MiB is wasteful, the original 1 MiB is not enough. I chose 11 MiB. This means that `CirculaBuffer::mSize` will be 33 MiB instead of 147 MiB. If a workspace used too many commands (more than 33 MiB) we'd get an exception and a crash. But we need more than 30 BigEngines with inefficient (fragmented) shape part batching to achieve this (Visualization cannot handle 10 BigEngines now either).

Note that the actual memory allocation for the command buffer would be doubled because of overflow protection inside `CircularBuffer`. I reduced the 100% overflow protection to 20%, because that should be enough. See detailed explanation [here](https://shapr3d.atlassian.net/wiki/spaces/DD/pages/3467444546/Filament+constants+in+root+CMakeLists.txt#Command-buffer).

So in overall the memory allocated at app startup was reduced from 294 MB (2 * 3 * 49) to 39.6 MB (1.2 * 3 * 11).

## Material shader statistics implications
n/a

## Upstreaming scope
n/a. These constants are chosen specifically for the workload of Shapr3D (via profiling), not applicable to other apps.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
The workspaces in [GFX-1388](https://shapr3d.atlassian.net/browse/GFX-1388) can be checked (no crash means 👍)

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-3322]: https://shapr3d.atlassian.net/browse/GFX-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GFX-1388]: https://shapr3d.atlassian.net/browse/GFX-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ