### PR TITLE
[GFX-3322] Reduce per-render pass arena size to 7 MiB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,11 @@ set(FILAMENT_NDK_VERSION "" CACHE STRING
     "Android NDK version or version prefix to be used when building for Android."
 )
 
-set(FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB "50" CACHE STRING
+set(FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB "7" CACHE STRING
     "Per render pass arena size. Must be roughly 1 MB larger than FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB, default 2."
 )
 
-set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "49" CACHE STRING
+set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "6" CACHE STRING
     "Size of the high-level draw commands buffer. Rule of thumb, 1 MB less than FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB, default 1."
 )
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3322](https://shapr3d.atlassian.net/browse/GFX-3322)

## Short description (What? How?) 📖
See detailed explanation [here](https://shapr3d.atlassian.net/wiki/spaces/DD/pages/3467444546/Filament+constants+in+root+CMakeLists.txt#Per-render-pass-arena).

I never saw the command arena size exceed 2 MiB, so I chose 6 MiB to be super safe.

Even though we don't currently use dynamic lights, I kept the 1 MiB extra memory in per-render pass arena used by upstream Filament, because we might use them later. Created [a reminder ticket](https://shapr3d.atlassian.net/browse/GFX-3343) about it.

So in overall the memory allocated at app startup was reduced from 50 MB to 7 MB.

## Material shader statistics implications
n/a

## Upstreaming scope
n/a. These constants are chosen specifically for the workload of Shapr3D (via profiling), not applicable to other apps.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
The workspaces in [GFX-1388](https://shapr3d.atlassian.net/browse/GFX-1388) can be checked (no crash means 👍)

### How did you test it? 🤔
Manual 💁‍♂️
I checked the workspaces in the Confluence doc and in GFX-1388 on an M1 MacBook Pro.

Automated 💻


[GFX-3322]: https://shapr3d.atlassian.net/browse/GFX-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GFX-1388]: https://shapr3d.atlassian.net/browse/GFX-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ