### PR TITLE
[GFX-3486] Revert our unused depth-stencil changes

### DIFF
--- a/filament/backend/include/backend/DriverEnums.h
+++ b/filament/backend/include/backend/DriverEnums.h
@@ -29,7 +29,6 @@
 #include <math/vec4.h>
 
 #include <array>    // FIXME: STL headers are not allowed in public headers
-#include <cstring>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -302,15 +301,6 @@ enum class CullingMode : uint8_t {
     FRONT,              //!< Front face culling, only back faces are visible
     BACK,               //!< Back face culling, only front faces are visible
     FRONT_AND_BACK      //!< Front and Back, geometry is not visible
-};
-
-//! Stencil depth fail and pass operation mode.
-enum class StencilOperation : uint8_t {
-    KEEP,
-    ZERO,
-    INVERT,
-    REPLACE,
-    DEFAULT = KEEP
 };
 
 //! Pixel Data Format
@@ -862,10 +852,9 @@ struct RasterState {
     using DepthFunc = backend::SamplerCompareFunc;
     using BlendEquation = backend::BlendEquation;
     using BlendFunction = backend::BlendFunction;
-    using StencilOperation = StencilOperation;
 
     RasterState() noexcept { // NOLINT
-        static_assert(sizeof(RasterState) == sizeof(uint8_t[5]),
+        static_assert(sizeof(RasterState) == sizeof(uint32_t),
                 "RasterState size not what was intended");
         culling = CullingMode::BACK;
         blendEquationRGB = BlendEquation::ADD;
@@ -876,13 +865,8 @@ struct RasterState {
         blendFunctionDstAlpha = BlendFunction::ZERO;
     }
 
-    bool operator == (RasterState rhs) const noexcept { 
-        return std::memcmp(u, rhs.u, sizeof(u)) == 0;
-    }
-
-    bool operator != (RasterState rhs) const noexcept { 
-        return !operator==(rhs);
-    }
+    bool operator == (RasterState rhs) const noexcept { return u == rhs.u; }
+    bool operator != (RasterState rhs) const noexcept { return u != rhs.u; }
 
     void disableBlending() noexcept {
         blendEquationRGB = BlendEquation::ADD;
@@ -937,19 +921,10 @@ struct RasterState {
             //! whether front face winding direction must be inverted
             bool inverseFrontFaces              : 1;        // 31
 
-            //! Whether stencil-buffer writes are enabled
-            bool stencilWrite                   : 1;        // 32
-
-            //! stencil operation for depth test failures
-            StencilOperation stencilDepthFail   : 2;        // 34
-
-            //! stencil operation for depth test passes
-            StencilOperation stencilDepthPass   : 2;        // 36
-
             //! padding, must be 0
-            uint8_t padding                     : 4;        // 40
+            uint8_t padding                     : 1;        // 32
         };
-        uint8_t u[5] = {0};
+        uint32_t u = 0;
     };
 };
 

--- a/filament/backend/include/private/backend/DriverAPI.inc
+++ b/filament/backend/include/private/backend/DriverAPI.inc
@@ -302,8 +302,6 @@ DECL_DRIVER_API_SYNCHRONOUS_N(backend::SyncStatus, getSyncStatus, backend::SyncH
 DECL_DRIVER_API_SYNCHRONOUS_N(bool, isWorkaroundNeeded, backend::Workaround, workaround)
 DECL_DRIVER_API_SYNCHRONOUS_N(void, setupExternalResource, intptr_t, externalResource)
 
-DECL_DRIVER_API_SYNCHRONOUS_0(bool, isDepthResolveSupported)
-
 /*
  * Updating driver objects
  * -----------------------

--- a/filament/backend/src/metal/MetalContext.h
+++ b/filament/backend/src/metal/MetalContext.h
@@ -62,7 +62,6 @@ struct MetalContext {
     std::atomic<bool> memorylessLimitsReached = false;
 
     // Supported features.
-    bool supportsDepthResolve = false;
     bool supportsTextureSwizzling = false;
     bool supportsMemorylessRenderTargets = false;
     uint8_t maxColorRenderTargets = 4;

--- a/filament/backend/src/metal/MetalEnums.h
+++ b/filament/backend/src/metal/MetalEnums.h
@@ -52,17 +52,6 @@ constexpr inline MTLCompareFunction getMetalCompareFunction(RasterState::DepthFu
     }
 }
 
-constexpr inline MTLStencilOperation getMetalStencilOperation(RasterState::StencilOperation operation)
-        noexcept {
-    using StencilOperation = RasterState::StencilOperation;
-    switch (operation) {
-        case StencilOperation::KEEP:    return MTLStencilOperationKeep;
-        case StencilOperation::ZERO:    return MTLStencilOperationZero;
-        case StencilOperation::REPLACE: return MTLStencilOperationReplace;
-        case StencilOperation::INVERT:  return MTLStencilOperationInvert;
-    }
-}
-
 constexpr inline MTLIndexType getIndexType(size_t elementSize) noexcept {
     if (elementSize == 2) {
         return MTLIndexTypeUInt16;
@@ -297,27 +286,6 @@ constexpr inline MTLTextureType getMetalType(SamplerType target) {
     }
 }
 
-inline MTLTextureType getMetalTypeMultisample(SamplerType target) {
-    switch (target) {
-        case SamplerType::SAMPLER_2D:
-        case SamplerType::SAMPLER_EXTERNAL:
-            return MTLTextureType2DMultisample;
-        case SamplerType::SAMPLER_2D_ARRAY: {
-            if (@available(iOS 14.0, macCatalyst 14.0, *)) {
-                return MTLTextureType2DMultisampleArray;
-            }
-            else {
-                ASSERT_POSTCONDITION(false, "MTLTextureType2DMultisampleArray not supported on this platform.");
-                return MTLTextureType2D;
-            }
-        }
-        default: {
-            ASSERT_POSTCONDITION(false, "There is no multisample variant of this Metal texture type.");
-            return MTLTextureType2D;
-        }
-    }
-}
-
 constexpr inline MTLBlendOperation getMetalBlendOperation(BlendEquation equation) noexcept {
     switch (equation) {
         case BlendEquation::ADD: return MTLBlendOperationAdd;
@@ -457,17 +425,6 @@ inline MTLTextureSwizzleChannels getSwizzleChannels(TextureSwizzle r, TextureSwi
         TextureSwizzle a) {
     return MTLTextureSwizzleChannelsMake(getSwizzle(r), getSwizzle(g), getSwizzle(b),
             getSwizzle(a));
-}
-
-constexpr inline bool formatHasStencil(MTLPixelFormat format) {
-    switch (format) {
-        case MTLPixelFormatStencil8: return true;
-        case MTLPixelFormatDepth32Float_Stencil8: return true;
-#if (TARGET_OS_OSX || TARGET_OS_MACCATALYST)
-        case MTLPixelFormatDepth24Unorm_Stencil8: return true;
-#endif
-        default: return false;
-    }
 }
 
 } // namespace backend

--- a/filament/backend/src/metal/MetalHandles.h
+++ b/filament/backend/src/metal/MetalHandles.h
@@ -291,7 +291,7 @@ public:
 
     Attachment getDrawColorAttachment(size_t index);
     Attachment getReadColorAttachment(size_t index);
-    Attachment getDepthStencilAttachment();
+    Attachment getDepthAttachment();
 
 private:
 
@@ -305,7 +305,7 @@ private:
     uint8_t samples = 1;
 
     Attachment color[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = {};
-    Attachment depthStencil = {};
+    Attachment depth = {};
 };
 
 // MetalFence is used to implement both Fences and Syncs.

--- a/filament/backend/src/metal/MetalState.h
+++ b/filament/backend/src/metal/MetalState.h
@@ -215,11 +215,10 @@ struct MetalPipelineState {
     VertexDescription vertexDescription;                                       // 528 bytes
     MTLPixelFormat colorAttachmentPixelFormat[MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT] = { MTLPixelFormatInvalid };  // 64 bytes
     MTLPixelFormat depthAttachmentPixelFormat = MTLPixelFormatInvalid;         // 8 bytes
-    MTLPixelFormat stencilAttachmentPixelFormat = MTLPixelFormatInvalid;       // 8 bytes
+    NSUInteger sampleCount = 1;                                                // 8 bytes
     BlendState blendState;                                                     // 56 bytes
-    uint8_t sampleCount = 1;                                                   // 1 bytes
     bool colorWrite = true;                                                    // 1 byte
-    char padding[6] = { 0 };                                                   // 6 bytes
+    char padding[7] = { 0 };                                                   // 7 bytes
 
     bool operator==(const MetalPipelineState& rhs) const noexcept {
         return (
@@ -229,7 +228,6 @@ struct MetalPipelineState {
                 std::equal(this->colorAttachmentPixelFormat, this->colorAttachmentPixelFormat + MRT::MAX_SUPPORTED_RENDER_TARGET_COUNT,
                         rhs.colorAttachmentPixelFormat) &&
                 this->depthAttachmentPixelFormat == rhs.depthAttachmentPixelFormat &&
-                this->stencilAttachmentPixelFormat == rhs.stencilAttachmentPixelFormat &&
                 this->sampleCount == rhs.sampleCount &&
                 this->blendState == rhs.blendState &&
                 this->colorWrite == rhs.colorWrite
@@ -259,18 +257,12 @@ using PipelineStateCache = StateCache<MetalPipelineState, id<MTLRenderPipelineSt
 
 struct DepthStencilState {
     MTLCompareFunction compareFunction = MTLCompareFunctionAlways;      // 8 bytes
-    MTLStencilOperation stencilDepthFail = MTLStencilOperationKeep;     // 8 bytes
-    MTLStencilOperation stencilDepthPass = MTLStencilOperationKeep;     // 8 bytes
     bool depthWriteEnabled = false;                                     // 1 byte
-    bool stencilWriteEnabled = false;                                   // 1 byte
-    char padding[6] = { 0 };                                            // 6 bytes
+    char padding[7] = { 0 };                                            // 7 bytes
 
     bool operator==(const DepthStencilState& rhs) const noexcept {
         return this->compareFunction == rhs.compareFunction &&
-               this->depthWriteEnabled == rhs.depthWriteEnabled &&
-               this->stencilWriteEnabled == rhs.stencilWriteEnabled &&
-               this->stencilDepthFail == rhs.stencilDepthFail &&
-               this->stencilDepthPass == rhs.stencilDepthPass;
+               this->depthWriteEnabled == rhs.depthWriteEnabled;
     }
 
     bool operator!=(const DepthStencilState& rhs) const noexcept {
@@ -280,7 +272,7 @@ struct DepthStencilState {
 
 // This assert checks that the struct is the size we expect without any "hidden" padding bytes
 // inserted by the compiler.
-static_assert(sizeof(DepthStencilState) == 32, "DepthStencilState unexpected size.");
+static_assert(sizeof(DepthStencilState) == 16, "DepthStencilState unexpected size.");
 
 struct DepthStateCreator {
     id<MTLDepthStencilState> operator()(id<MTLDevice> device, const DepthStencilState& state)

--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -78,7 +78,6 @@ id<MTLRenderPipelineState> PipelineStateCreator::operator()(id<MTLDevice> device
 
     // Depth attachment
     descriptor.depthAttachmentPixelFormat = state.depthAttachmentPixelFormat;
-    descriptor.stencilAttachmentPixelFormat = state.stencilAttachmentPixelFormat;
 
     // MSAA
     descriptor.rasterSampleCount = state.sampleCount;
@@ -100,20 +99,6 @@ id<MTLDepthStencilState> DepthStateCreator::operator()(id<MTLDevice> device,
     MTLDepthStencilDescriptor* depthStencilDescriptor = [MTLDepthStencilDescriptor new];
     depthStencilDescriptor.depthCompareFunction = state.compareFunction;
     depthStencilDescriptor.depthWriteEnabled = state.depthWriteEnabled;
-
-    if (state.stencilWriteEnabled) {
-        MTLStencilDescriptor* stencilDescriptor = [MTLStencilDescriptor new];
-        stencilDescriptor.readMask = 0xFF;
-        stencilDescriptor.writeMask = 0xFF;
-        stencilDescriptor.stencilCompareFunction = MTLCompareFunctionAlways;
-        stencilDescriptor.stencilFailureOperation = MTLStencilOperationKeep;
-        stencilDescriptor.depthFailureOperation = state.stencilDepthFail;
-        stencilDescriptor.depthStencilPassOperation = state.stencilDepthPass;
-
-        depthStencilDescriptor.backFaceStencil = stencilDescriptor;
-        depthStencilDescriptor.frontFaceStencil = stencilDescriptor;
-    }
-
     return [device newDepthStencilStateWithDescriptor:depthStencilDescriptor];
 }
 

--- a/filament/backend/src/noop/NoopDriver.cpp
+++ b/filament/backend/src/noop/NoopDriver.cpp
@@ -49,10 +49,6 @@ void NoopDriver::terminate() {
 void NoopDriver::tick(int) {
 }
 
-bool NoopDriver::isDepthResolveSupported() {
-    return true;
-}
-
 void NoopDriver::beginFrame(int64_t monotonic_clock_ns, uint32_t frameId) {
 }
 

--- a/filament/backend/src/opengl/GLUtils.h
+++ b/filament/backend/src/opengl/GLUtils.h
@@ -253,16 +253,6 @@ constexpr inline GLenum getTextureCompareFunc(SamplerCompareFunc func) noexcept 
     }
 }
 
-constexpr inline GLenum getStencilOperation(RasterState::StencilOperation operation) noexcept {
-    using StencilOperation = RasterState::StencilOperation;
-    switch (operation) {
-        case StencilOperation::KEEP:    return GL_KEEP;
-        case StencilOperation::ZERO:    return GL_ZERO;
-        case StencilOperation::INVERT:  return GL_INVERT;
-        case StencilOperation::REPLACE: return GL_REPLACE;
-    }
-}
-
 constexpr inline GLenum getDepthFunc(SamplerCompareFunc func) noexcept {
     return getTextureCompareFunc(func);
 }

--- a/filament/backend/src/opengl/OpenGLContext.h
+++ b/filament/backend/src/opengl/OpenGLContext.h
@@ -111,10 +111,6 @@ public:
     inline void endQuery(GLenum target) noexcept;
     inline GLuint getQuery(GLenum target) const noexcept;
 
-    inline void stencilMask(GLuint mask) noexcept;
-    inline void stencilFunc(GLenum func, GLuint ref, GLuint mask) noexcept;
-    inline void stencilOp(GLenum stencilFail, GLenum depthFail, GLenum depthPass) noexcept;
-
     inline void setScissor(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
     inline void viewport(GLint left, GLint bottom, GLsizei width, GLsizei height) noexcept;
     inline void depthRange(GLclampf near, GLclampf far) noexcept;
@@ -300,13 +296,6 @@ private:
             GLboolean colorMask         = GL_TRUE;
             GLboolean depthMask         = GL_TRUE;
             GLenum depthFunc            = GL_LESS;
-            GLenum stencilFunc          = GL_ALWAYS;
-            GLenum stencilFail          = GL_KEEP;
-            GLenum stencilDepthFail     = GL_KEEP;
-            GLenum stencilDepthPass     = GL_KEEP;
-            GLuint stencilRef           = 0;
-            GLuint stencilWriteMask     = 0xFF;
-            GLuint stencilReadMask     = 0xFF;
         } raster;
 
         struct PolygonOffset {
@@ -641,39 +630,6 @@ void OpenGLContext::depthFunc(GLenum func) noexcept {
     update_state(state.raster.depthFunc, func, [&]() {
         glDepthFunc(func);
     });
-}
-
-void OpenGLContext::stencilMask(GLuint mask) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    update_state(state.raster.stencilWriteMask, mask, [&]() {
-        glStencilMask(mask);
-    });
-}
-
-void OpenGLContext::stencilFunc(GLenum func, GLuint ref, GLuint mask) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    if (UTILS_UNLIKELY(
-            state.raster.stencilFunc != func ||
-            state.raster.stencilRef != ref ||
-            state.raster.stencilReadMask != mask)) {
-        state.raster.stencilFunc = func;
-        state.raster.stencilRef = ref;
-        state.raster.stencilReadMask = mask;
-        glStencilFunc(func, ref, mask);
-    }
-}
-
-void OpenGLContext::stencilOp(GLenum stencilFail, GLenum depthFail, GLenum depthPass) noexcept {
-    // WARNING: don't call this without updating mRasterState
-    if (UTILS_UNLIKELY(
-            state.raster.stencilFail != stencilFail ||
-            state.raster.stencilDepthFail != depthFail ||
-            state.raster.stencilDepthPass != depthPass)) {
-        state.raster.stencilFail = stencilFail;
-        state.raster.stencilDepthFail = depthFail;
-        state.raster.stencilDepthPass = depthPass;
-        glStencilOp(stencilFail, depthFail, depthPass);
-    }
 }
 
 void OpenGLContext::polygonOffset(GLfloat factor, GLfloat units) noexcept {

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -294,19 +294,6 @@ void OpenGLDriver::setRasterStateSlow(RasterState rs) noexcept {
         gl.depthMask(GLboolean(rs.depthWrite));
     }
 
-    if (!rs.stencilWrite) {
-        gl.disable(GL_STENCIL_TEST);
-    } else {
-        gl.enable(GL_STENCIL_TEST);
-        gl.stencilMask(0xFF);
-        gl.stencilFunc(GL_ALWAYS, 1, 0xFF);
-        gl.stencilOp(
-            GL_KEEP,
-            getStencilOperation(rs.stencilDepthFail),
-            getStencilOperation(rs.stencilDepthPass)
-        );
-    }
-
     // write masks
     gl.colorMask(GLboolean(rs.colorWrite));
 
@@ -3032,10 +3019,6 @@ void OpenGLDriver::draw(PipelineState state, Handle<HwRenderPrimitive> rph, uint
 #else
     CHECK_GL_ERROR(utils::slog.e)
 #endif
-}
-
-bool OpenGLDriver::isDepthResolveSupported() {
-    return true;
 }
 
 // explicit instantiation of the Dispatcher

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -1929,10 +1929,6 @@ void VulkanDriver::debugCommandBegin(CommandStream* cmds, bool synchronous, cons
 #endif
 }
 
-bool VulkanDriver::isDepthResolveSupported() {
-    return true;
-}
-
 // explicit instantiation of the Dispatcher
 template class ConcreteDispatcher<VulkanDriver>;
 

--- a/filament/include/filament/Material.h
+++ b/filament/include/filament/Material.h
@@ -54,7 +54,6 @@ public:
     using VertexDomain = VertexDomain;
     using TransparencyMode = TransparencyMode;
 
-    using StencilOperation = backend::StencilOperation;
     using ParameterType = backend::UniformType;
     using Precision = backend::Precision;
     using SamplerType = backend::SamplerType;
@@ -168,21 +167,6 @@ public:
 
     //! Indicates whether instances of this material will, by default, use depth testing.
     bool isDepthCullingEnabled() const noexcept;
-
-    //! Indicates whether instances of this material will write to the stencil buffer
-    bool isStencilWriteEnabled() const noexcept;
-
-    /** 
-     * Indicates whether instances of this material will keep/replace/zero/invert 
-     * the contents of the stencil buffer if the depth test fails.
-     */
-    StencilOperation getStencilDepthFail() const noexcept;
-
-    /** 
-     * Indicates whether instances of this material will keep/replace/zero/invert 
-     * the contents of the stencil buffer if the depth test passes.
-     */
-    StencilOperation getStencilDepthPass() const noexcept;
 
     //! Indicates whether this material is double-sided.
     bool isDoubleSided() const noexcept;

--- a/filament/include/filament/MaterialInstance.h
+++ b/filament/include/filament/MaterialInstance.h
@@ -40,7 +40,6 @@ class UTILS_PUBLIC MaterialInstance : public FilamentAPI {
 public:
     using CullingMode = filament::backend::CullingMode;
     using TransparencyMode = filament::TransparencyMode;
-    using StencilOperation = filament::backend::StencilOperation;
 
     template<typename T>
     using is_supported_parameter_t = typename std::enable_if<
@@ -228,22 +227,6 @@ public:
      * Overrides the default depth testing state that was set on the material.
      */
     void setDepthCulling(bool enable) noexcept;
-
-    /**
-     * Overrides the default stencil state that was set on the material.
-     */
-    void setStencilWrite(bool enable) noexcept;
-
-    /**
-     * Overrides the default depth fail stencil operation that was set on the material.
-     */
-    void setStencilDepthFail(StencilOperation operation) noexcept;
-
-    /**
-     * Overrides the default depth pass stencil operation that was set on the material.
-     */
-    void setStencilDepthPass(StencilOperation operation) noexcept;
-
 };
 
 } // namespace filament

--- a/filament/include/filament/Renderer.h
+++ b/filament/include/filament/Renderer.h
@@ -118,22 +118,15 @@ public:
      */
     struct ClearOptions {
         /** Color to use to clear the SwapChain */
-        math::float4 clearColorValue = {};
-        
+        math::float4 clearColor = {};
         /**
          * Whether the SwapChain should be cleared using the clearColor. Use this if translucent
          * View will be drawn, for instance.
          */
-        bool clearColor = false;
-        
+        bool clear = false;
         /**
-         * Whether the depth buffer should be cleared.
-         */
-        bool clearDepth = true;
-        
-        /**
-         * Whether the SwapChain content should be discarded. clearColor implies discard. Set this
-         * to false (along with clearColor to false as well) if the SwapChain already has content that
+         * Whether the SwapChain content should be discarded. clear implies discard. Set this
+         * to false (along with clear to false as well) if the SwapChain already has content that
          * needs to be preserved
          */
         bool discard = true;

--- a/filament/include/filament/Texture.h
+++ b/filament/include/filament/Texture.h
@@ -155,14 +155,6 @@ public:
         Builder& sampler(Sampler target) noexcept;
 
         /**
-         * Specifies the sample count of the texture
-         *
-         * @param sampleCount sample count (default: 1)
-         * @return This Builder, for chaining calls.
-         */
-        Builder& samples(uint8_t sampleCount) noexcept;
-
-        /**
          * Specifies the *internal* format of this texture.
          *
          * The internal format specifies how texels are stored (which may be different from how

--- a/filament/include/filament/View.h
+++ b/filament/include/filament/View.h
@@ -152,38 +152,6 @@ public:
      * @see setRenderTarget
      */
     RenderTarget* getRenderTarget() const noexcept;
-    
-    /**
-     * Specifies an offscreen render target's HDR color output texture to render into.
-     *
-     * @param texture HDR color texture
-     */
-    void setHdrColorTexture(Texture* texture) noexcept;
-    
-    /**
-     * Gets the offscreen render target's HDR color output texture.
-     *
-     * Returns nullptr if the render target is the swap chain (which is default).
-     *
-     * @see setHDRColorTexture
-     */
-    Texture* getHdrColorTexture() const noexcept;
-
-    /**
-     * Specifies an offscreen render target's depth-stencil texture to render into.
-     *
-     * @param texture depth-stencil texture
-     */
-    void setDepthStencilTexture(Texture* texture) noexcept;
-    
-    /**
-     * Gets the offscreen render target's depth-stencil texture.
-     *
-     * Returns nullptr if the render target is the swap chain (which is default).
-     *
-     * @see setDepthStencilTexture
-     */
-    Texture* getDepthStencilTexture() const noexcept;
 
     /**
      * Sets the rectangular region to render to.

--- a/filament/src/Material.cpp
+++ b/filament/src/Material.cpp
@@ -68,18 +68,6 @@ bool Material::isDepthCullingEnabled() const noexcept {
     return upcast(this)->isDepthCullingEnabled();
 }
 
-bool Material::isStencilWriteEnabled() const noexcept {
-    return upcast(this)->isStencilWriteEnabled();
-}
-
-StencilOperation Material::getStencilDepthFail() const noexcept {
-    return upcast(this)->getStencilDepthFail();
-}
-
-StencilOperation Material::getStencilDepthPass() const noexcept {
-    return upcast(this)->getStencilDepthPass();
-}
-
 bool Material::isDoubleSided() const noexcept {
     return upcast(this)->isDoubleSided();
 }

--- a/filament/src/MaterialInstance.cpp
+++ b/filament/src/MaterialInstance.cpp
@@ -251,18 +251,6 @@ void MaterialInstance::setDepthCulling(bool enable) noexcept {
     upcast(this)->setDepthCulling(enable);
 }
 
-void MaterialInstance::setStencilWrite(bool enable) noexcept {
-    upcast(this)->setStencilWrite(enable);
-}
-
-void MaterialInstance::setStencilDepthFail(StencilOperation operation) noexcept {
-    upcast(this)->setStencilDepthFail(operation);
-}
-
-void MaterialInstance::setStencilDepthPass(StencilOperation operation) noexcept {
-    upcast(this)->setStencilDepthPass(operation);
-}
-
 MaterialInstance* MaterialInstance::duplicate(MaterialInstance const* other, const char* name) noexcept {
     return FMaterialInstance::duplicate(upcast(other), name);
 }

--- a/filament/src/MaterialParser.cpp
+++ b/filament/src/MaterialParser.cpp
@@ -165,22 +165,6 @@ bool MaterialParser::getDepthWrite(bool* value) const noexcept {
     return mImpl.getFromSimpleChunk(ChunkType::MaterialDepthWrite, value);
 }
 
-bool MaterialParser::getStencilWrite(bool* value) const noexcept {
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialStencilWrite, value);
-}
-
-bool MaterialParser::getStencilDepthFail(backend::StencilOperation* value) const noexcept {
-    static_assert(sizeof(backend::StencilOperation) == sizeof(uint8_t),
-            "StencilOperation expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialStencilDepthFail, reinterpret_cast<uint8_t*>(value));
-}
-
-bool MaterialParser::getStencilDepthPass(backend::StencilOperation* value) const noexcept {
-    static_assert(sizeof(backend::StencilOperation) == sizeof(uint8_t),
-            "StencilOperation expected size is wrong");
-    return mImpl.getFromSimpleChunk(ChunkType::MaterialStencilDepthPass, reinterpret_cast<uint8_t*>(value));
-}
-
 bool MaterialParser::getDoubleSidedSet(bool* value) const noexcept {
     return mImpl.getFromSimpleChunk(ChunkType::MaterialDoubleSidedSet, value);
 }

--- a/filament/src/MaterialParser.h
+++ b/filament/src/MaterialParser.h
@@ -78,9 +78,6 @@ public:
     bool getInterpolation(Interpolation* value) const noexcept;
     bool getVertexDomain(VertexDomain* value) const noexcept;
     bool getMaterialDomain(MaterialDomain* domain) const noexcept;
-    bool getStencilWrite(bool* value) const noexcept;
-    bool getStencilDepthFail(backend::StencilOperation* value) const noexcept;
-    bool getStencilDepthPass(backend::StencilOperation* value) const noexcept;
 
     bool getShading(Shading*) const noexcept;
     bool getBlendingMode(BlendingMode*) const noexcept;

--- a/filament/src/RenderPass.cpp
+++ b/filament/src/RenderPass.cpp
@@ -225,9 +225,6 @@ void RenderPass::setupColorCommand(Command& cmdDraw, Variant variant,
     cmdDraw.primitive.rasterState.colorWrite = mi->getColorWrite();
     cmdDraw.primitive.rasterState.depthWrite = mi->getDepthWrite();
     cmdDraw.primitive.rasterState.depthFunc = mi->getDepthFunc();
-    cmdDraw.primitive.rasterState.stencilWrite = mi->getStencilWrite();
-    cmdDraw.primitive.rasterState.stencilDepthFail = mi->getStencilDepthFail();
-    cmdDraw.primitive.rasterState.stencilDepthPass = mi->getStencilDepthPass();
     cmdDraw.primitive.mi = mi;
     cmdDraw.primitive.materialVariant = variant;
     // we keep "RasterState::colorWrite" to the value set by material (could be disabled)

--- a/filament/src/RenderPass.h
+++ b/filament/src/RenderPass.h
@@ -218,11 +218,11 @@ public:
         backend::Handle<backend::HwRenderPrimitive> primitiveHandle;    // 4 bytes
         backend::Handle<backend::HwBufferObject> morphWeightBuffer;     // 4 bytes
         backend::Handle<backend::HwSamplerGroup> morphTargetBuffer;     // 4 bytes
-        backend::RasterState rasterState;                               // 5 bytes
-        Variant materialVariant;                                        // 1 byte
+        backend::RasterState rasterState;                               // 4 bytes
         uint16_t index = 0;                                             // 2 bytes
         uint16_t instanceCount;                                         // 2 bytes
-        uint8_t reserved[10 - sizeof(void*)] = {};                      // 2 bytes (6)
+        Variant materialVariant;                                        // 1 byte
+        uint8_t reserved[11 - sizeof(void*)] = {};                      // 3 bytes (7)
     };
     static_assert(sizeof(PrimitiveInfo) == 32);
 

--- a/filament/src/RendererUtils.h
+++ b/filament/src/RendererUtils.h
@@ -50,8 +50,6 @@ public:
         uint32_t yoffset;
         // dynamic resolution scale
         math::float2 scale;
-        // Depth format
-        backend::TextureFormat depthFormat;
         // HDR format
         backend::TextureFormat hdrFormat;
         // MSAA sample count

--- a/filament/src/View.cpp
+++ b/filament/src/View.cpp
@@ -16,8 +16,6 @@
 
 #include "details/View.h"
 
-#include "details/Texture.h"
-
 namespace filament {
 
 void View::setScene(Scene* scene) {
@@ -83,22 +81,6 @@ void View::setRenderTarget(RenderTarget* renderTarget) noexcept {
 
 RenderTarget* View::getRenderTarget() const noexcept {
     return upcast(this)->getRenderTarget();
-}
-
-void View::setHdrColorTexture(Texture* texture) noexcept {
-    return upcast(this)->setHdrColorTexture(upcast(texture));
-}
-
-Texture* View::getHdrColorTexture() const noexcept {
-    return upcast(this)->getHdrColorTexture();
-}
-
-void View::setDepthStencilTexture(Texture* texture) noexcept {
-    return upcast(this)->setDepthStencilTexture(upcast(texture));
-}
-
-Texture* View::getDepthStencilTexture() const noexcept {
-    return upcast(this)->getDepthStencilTexture();
 }
 
 void View::setSampleCount(uint8_t count) noexcept {

--- a/filament/src/details/Material.cpp
+++ b/filament/src/details/Material.cpp
@@ -276,18 +276,6 @@ FMaterial::FMaterial(FEngine& engine, const Material::Builder& builder)
         mRasterState.culling = mCullingMode;
     }
 
-    bool stencilWrite;
-    StencilOperation stencilDepthFail;
-    StencilOperation stencilDepthPass;
-
-    parser->getStencilWrite(&stencilWrite);
-    parser->getStencilDepthFail(&stencilDepthFail);
-    parser->getStencilDepthPass(&stencilDepthPass);
-
-    mRasterState.stencilWrite = stencilWrite;
-    mRasterState.stencilDepthFail = stencilDepthFail;
-    mRasterState.stencilDepthPass = stencilDepthPass;
-
     parser->getTransparencyMode(&mTransparencyMode);
     parser->hasCustomDepthShader(&mHasCustomDepthShader);
     mIsDefaultMaterial = builder->mDefaultMaterial;

--- a/filament/src/details/Material.h
+++ b/filament/src/details/Material.h
@@ -120,12 +120,6 @@ public:
     bool isDepthCullingEnabled() const noexcept {
         return mRasterState.depthFunc != backend::RasterState::DepthFunc::A;
     }
-
-    bool isStencilWriteEnabled() const noexcept { return mRasterState.stencilWrite; }
-
-    StencilOperation getStencilDepthFail() const noexcept { return mRasterState.stencilDepthFail; }
-    StencilOperation getStencilDepthPass() const noexcept { return mRasterState.stencilDepthPass; }
-
     bool isDoubleSided() const noexcept { return mDoubleSided; }
     bool hasDoubleSidedCapability() const noexcept { return mDoubleSidedCapability; }
     float getMaskThreshold() const noexcept { return mMaskThreshold; }

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -44,9 +44,6 @@ FMaterialInstance::FMaterialInstance(FEngine& engine,
           mCulling(other->mCulling),
           mColorWrite(other->mColorWrite),
           mDepthWrite(other->mDepthWrite),
-          mStencilWrite(other->mStencilWrite),
-          mStencilDepthFail(other->mStencilDepthFail),
-          mStencilDepthPass(other->mStencilDepthPass),
           mDepthFunc(other->mDepthFunc),
           mScissorRect(other->mScissorRect),
           mName(name ? CString(name) : other->mName) {
@@ -101,9 +98,6 @@ void FMaterialInstance::initDefaultInstance(FEngine& engine, FMaterial const* ma
     mCulling = rasterState.culling;
     mColorWrite = rasterState.colorWrite;
     mDepthWrite = rasterState.depthWrite;
-    mStencilWrite = rasterState.stencilWrite;
-    mStencilDepthFail = rasterState.stencilDepthFail;
-    mStencilDepthPass = rasterState.stencilDepthPass;
     mDepthFunc = rasterState.depthFunc;
 
     mMaterialSortingKey = RenderPass::makeMaterialSortingKey(

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -91,12 +91,6 @@ public:
 
     bool getDepthWrite() const noexcept { return mDepthWrite; }
 
-    bool getStencilWrite() const noexcept { return mStencilWrite; }
-
-    StencilOperation getStencilDepthFail() const noexcept { return mStencilDepthFail; }
-
-    StencilOperation getStencilDepthPass() const noexcept { return mStencilDepthPass; }
-
     TransparencyMode getTransparencyMode() const noexcept { return mTransparencyMode; }
 
     backend::RasterState::DepthFunc getDepthFunc() const noexcept { return mDepthFunc; }
@@ -125,12 +119,6 @@ public:
     void setDepthWrite(bool enable) noexcept { mDepthWrite = enable; }
 
     void setDepthCulling(bool enable) noexcept;
-
-    void setStencilWrite(bool enable) noexcept { mStencilWrite = enable; }
-
-    void setStencilDepthFail(StencilOperation operation) noexcept { mStencilDepthFail = operation; }
-
-    void setStencilDepthPass(StencilOperation operation) noexcept { mStencilDepthPass = operation; }
 
     const char* getName() const noexcept;
 
@@ -174,9 +162,6 @@ private:
     backend::CullingMode mCulling;
     bool mColorWrite;
     bool mDepthWrite;
-    bool mStencilWrite;
-    StencilOperation mStencilDepthFail;
-    StencilOperation mStencilDepthPass;
     backend::RasterState::DepthFunc mDepthFunc;
     TransparencyMode mTransparencyMode;
 

--- a/filament/src/details/Texture.cpp
+++ b/filament/src/details/Texture.cpp
@@ -46,7 +46,6 @@ struct Texture::BuilderDetails {
     uint32_t mHeight = 1;
     uint32_t mDepth = 1;
     uint8_t mLevels = 1;
-    uint8_t mSampleCount = 1;
     Sampler mTarget = Sampler::SAMPLER_2D;
     InternalFormat mFormat = InternalFormat::RGBA8;
     Usage mUsage = Usage::DEFAULT;
@@ -82,12 +81,6 @@ Texture::Builder& Texture::Builder::depth(uint32_t depth) noexcept {
 
 Texture::Builder& Texture::Builder::levels(uint8_t levels) noexcept {
     mImpl->mLevels = std::max(uint8_t(1), levels);
-    return *this;
-}
-
-Texture::Builder &Texture::Builder::samples(uint8_t sampleCount) noexcept {
-    assert_invariant(sampleCount); // sample count can't be zero
-    mImpl->mSampleCount = sampleCount;
     return *this;
 }
 
@@ -147,7 +140,6 @@ FTexture::FTexture(FEngine& engine, const Builder& builder) {
     mTarget = builder->mTarget;
     mDepth  = static_cast<uint32_t>(builder->mDepth);
     mLevelCount = std::min(builder->mLevels, FTexture::maxLevelCount(mWidth, mHeight));
-    mSampleCount = builder->mSampleCount;
 
     FEngine::DriverApi& driver = engine.getDriverApi();
     intptr_t importedId = builder->mImportedId;

--- a/filament/src/details/View.h
+++ b/filament/src/details/View.h
@@ -72,7 +72,6 @@ class FEngine;
 class FMaterialInstance;
 class FRenderer;
 class FScene;
-class FTexture;
 
 static constexpr Culler::result_type VISIBLE_RENDERABLE = 1u << VISIBLE_RENDERABLE_BIT;
 
@@ -191,22 +190,6 @@ public:
         assert_invariant(!renderTarget || !mMultiSampleAntiAliasingOptions.enabled ||
                 !renderTarget->hasSampleableDepth());
         mRenderTarget = renderTarget;
-    }
-
-    void setHdrColorTexture(FTexture* texture) noexcept {
-        mHdrTexture = texture;
-    }
-
-    FTexture* getHdrColorTexture() const noexcept {
-        return mHdrTexture;
-    }
-
-    void setDepthStencilTexture(FTexture* texture) noexcept {
-        mDepthStencilTexture = texture;
-    }
-
-    FTexture* getDepthStencilTexture() const noexcept {
-        return mDepthStencilTexture;
     }
 
     FRenderTarget* getRenderTarget() const noexcept {
@@ -499,8 +482,6 @@ private:
     bool mFrontFaceWindingInverted = false;
 
     FRenderTarget* mRenderTarget = nullptr;
-    FTexture* mHdrTexture = nullptr;
-    FTexture* mDepthStencilTexture = nullptr;
 
     uint8_t mVisibleLayers = 0x1;
     AntiAliasing mAntiAliasing = AntiAliasing::FXAA;

--- a/libs/filabridge/include/filament/MaterialChunkType.h
+++ b/libs/filabridge/include/filament/MaterialChunkType.h
@@ -74,10 +74,6 @@ enum UTILS_PUBLIC ChunkType : uint64_t {
     MaterialDepthTest = charTo64bitNum("MAT_DTEST"),
     MaterialCullingMode = charTo64bitNum("MAT_CUMO"),
 
-    MaterialStencilWrite = charTo64bitNum("MAT_SWRIT"),
-    MaterialStencilDepthFail = charTo64bitNum("MAT_SFAIL"),
-    MaterialStencilDepthPass = charTo64bitNum("MAT_SPASS"),
-
     MaterialHasCustomDepthShader =charTo64bitNum("MAT_CSDP"),
 
     MaterialVertexDomain = charTo64bitNum("MAT_VEDO"),

--- a/libs/filamat/include/filamat/MaterialBuilder.h
+++ b/libs/filamat/include/filamat/MaterialBuilder.h
@@ -200,7 +200,6 @@ public:
     using TransparencyMode = filament::TransparencyMode;
     using SpecularAmbientOcclusion = filament::SpecularAmbientOcclusion;
 
-    using StencilOperation = filament::backend::StencilOperation;
     using UniformType = filament::backend::UniformType;
     using SamplerType = filament::backend::SamplerType;
     using SubpassType = filament::backend::SubpassType;
@@ -388,15 +387,6 @@ public:
 
     //! Enable / disable depth based culling (enabled by default, material instances can override).
     MaterialBuilder& depthCulling(bool enable) noexcept;
-
-    //! Enable / disable stencil-buffer write (disabled by default, material instances can override).
-    MaterialBuilder& stencilWrite(bool enable) noexcept;
-
-    //! Set the stencil depth fail operation. Stencil value kept by default.
-    MaterialBuilder& stencilDepthFail(StencilOperation operation) noexcept;
-
-    //! Set the stencil depth pass operation. Stencil value kept by default.
-    MaterialBuilder& stencilDepthPass(StencilOperation operation) noexcept;
 
     /**
      * Double-sided materials don't cull faces, equivalent to culling(CullingMode::NONE).
@@ -743,11 +733,6 @@ private:
     bool mDepthTest = true;
     bool mDepthWrite = true;
     bool mDepthWriteSet = false;
-
-    bool mStencilWrite = false;
-
-    StencilOperation mStencilDepthFail = StencilOperation::KEEP;
-    StencilOperation mStencilDepthPass = StencilOperation::KEEP;
 
     bool mSpecularAntiAliasing = false;
     bool mClearCoatIorChange = true;

--- a/libs/filamat/src/MaterialBuilder.cpp
+++ b/libs/filamat/src/MaterialBuilder.cpp
@@ -301,21 +301,6 @@ MaterialBuilder& MaterialBuilder::depthWrite(bool enable) noexcept {
     return *this;
 }
 
-MaterialBuilder& MaterialBuilder::stencilWrite(bool enable) noexcept {
-    mStencilWrite = enable;
-    return *this;
-}
-
-MaterialBuilder& MaterialBuilder::stencilDepthFail(StencilOperation operation) noexcept {
-    mStencilDepthFail = operation;
-    return *this;
-}
-
-MaterialBuilder& MaterialBuilder::stencilDepthPass(StencilOperation operation) noexcept {
-    mStencilDepthPass = operation;
-    return *this;
-}
-
 MaterialBuilder& MaterialBuilder::depthCulling(bool enable) noexcept {
     mDepthTest = enable;
     return *this;
@@ -1066,10 +1051,6 @@ void MaterialBuilder::writeCommonChunks(ChunkContainer& container, MaterialInfo&
     container.addSimpleChild<bool>(ChunkType::MaterialDepthWrite, mDepthWrite);
     container.addSimpleChild<bool>(ChunkType::MaterialDepthTest, mDepthTest);
     container.addSimpleChild<uint8_t>(ChunkType::MaterialCullingMode, static_cast<uint8_t>(mCullingMode));
-
-    container.addSimpleChild<bool>(ChunkType::MaterialStencilWrite, mStencilWrite);
-    container.addSimpleChild<uint8_t>(ChunkType::MaterialStencilDepthFail, static_cast<uint8_t>(mStencilDepthFail));
-    container.addSimpleChild<uint8_t>(ChunkType::MaterialStencilDepthPass, static_cast<uint8_t>(mStencilDepthPass));
 
     uint64_t properties = 0;
     for (size_t i = 0; i < MATERIAL_PROPERTIES_COUNT; i++) {

--- a/libs/matdbg/src/CommonWriter.h
+++ b/libs/matdbg/src/CommonWriter.h
@@ -198,18 +198,6 @@ const char* toString(backend::SamplerType type) noexcept {
 }
 
 inline
-const char* toString(backend::SamplerFormat type) noexcept {
-    switch (type) {
-    case backend::SamplerFormat::INT: return "int";
-    case backend::SamplerFormat::UINT: return "uint";
-    case backend::SamplerFormat::FLOAT: return "float";
-    case backend::SamplerFormat::SHADOW: return "shadow";
-    default: break;
-    }
-    return "int";
-}
-
-inline
 const char* toString(backend::SubpassType type) noexcept {
     switch (type) {
         case backend::SubpassType::SUBPASS_INPUT: return "subpassInput";
@@ -227,15 +215,13 @@ const char* toString(backend::Precision precision) noexcept {
 }
 
 inline
-const char* toString(backend::StencilOperation stencilOp) noexcept {
-    switch (stencilOp) {
-    case backend::StencilOperation::KEEP: return "keep";
-    case backend::StencilOperation::ZERO: return "zero";
-    case backend::StencilOperation::INVERT: return "invert";
-    case backend::StencilOperation::REPLACE: return "replace";
-    default: break;
+const char* toString(backend::SamplerFormat format) noexcept {
+    switch (format) {
+        case backend::SamplerFormat::INT: return "int";
+        case backend::SamplerFormat::UINT: return "uint";
+        case backend::SamplerFormat::FLOAT: return "float";
+        case backend::SamplerFormat::SHADOW: return "shadow";
     }
-    return "keep";
 }
 
 // Returns a human-readable variant description.

--- a/libs/matdbg/src/JsonWriter.cpp
+++ b/libs/matdbg/src/JsonWriter.cpp
@@ -103,10 +103,6 @@ static bool printMaterial(ostream& json, const ChunkContainer& container) {
     printChunk<bool, bool>(json, container, MaterialColorWrite, "color_write");
     printChunk<bool, bool>(json, container, MaterialDepthWrite, "depth_write");
     printChunk<bool, bool>(json, container, MaterialDepthTest, "depth_test");
-    printChunk<bool, bool>(json, container, MaterialStencilWrite, "stencil_write");
-    printChunk<backend::StencilOperation, uint8_t>(json, container, MaterialStencilDepthFail, "stencil_depth_fail");
-    printChunk<backend::StencilOperation, uint8_t>(json, container, MaterialStencilDepthPass, "stencil_depth_pass");
-
     printChunk<bool, bool>(json, container, MaterialDoubleSided, "double_sided");
     printChunk<CullingMode, uint8_t>(json, container, MaterialCullingMode, "culling");
     printChunk<TransparencyMode, uint8_t>(json, container, MaterialTransparencyMode, "transparency");

--- a/libs/matdbg/src/TextWriter.cpp
+++ b/libs/matdbg/src/TextWriter.cpp
@@ -122,10 +122,6 @@ static bool printMaterial(ostream& text, const ChunkContainer& container) {
     printChunk<bool, bool>(text, container, MaterialColorWrite, "Color write: ");
     printChunk<bool, bool>(text, container, MaterialDepthWrite, "Depth write: ");
     printChunk<bool, bool>(text, container, MaterialDepthTest, "Depth test: ");
-    printChunk<bool, bool>(text, container, MaterialStencilWrite, "Stencil write: ");
-    printChunk<backend::StencilOperation, uint8_t>(text, container, MaterialStencilDepthFail, "Stencil depth fail operation: ");
-    printChunk<backend::StencilOperation, uint8_t>(text, container, MaterialStencilDepthPass, "Stencil depth pass operation: ");
-
     printChunk<bool, bool>(text, container, MaterialDoubleSided, "Double sided: ");
     printChunk<CullingMode, uint8_t>(text, container, MaterialCullingMode, "Culling: ");
     printChunk<TransparencyMode, uint8_t>(text, container, MaterialTransparencyMode, "Transparency: ");

--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -1216,8 +1216,8 @@ void applySettings(const ViewerOptions& settings, Camera* camera, Skybox* skybox
         // we have to clear because the side-bar doesn't have a background, we cannot use
         // a skybox on the ui scene, because the ui view is always full screen.
         renderer->setClearOptions({
-                .clearColorValue = { inverseTonemapSRGB(settings.backgroundColor), 1.0f },
-                .clearColor = true
+                .clearColor = { inverseTonemapSRGB(settings.backgroundColor), 1.0f },
+                .clear = true
         });
     }
     if (skybox) {

--- a/samples/lightbulb.cpp
+++ b/samples/lightbulb.cpp
@@ -197,8 +197,8 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
 
     // Without an IBL, we must clear the swapchain to black before each frame.
     renderer->setClearOptions({
-            .clearColorValue = { 0.0f, 0.0f, 0.0f, 1.0f },
-            .clearColor = !FilamentApp::get().getIBL()  });
+            .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f },
+            .clear = !FilamentApp::get().getIBL()  });
 
 }
 

--- a/samples/material_sandbox.cpp
+++ b/samples/material_sandbox.cpp
@@ -1021,8 +1021,8 @@ static void preRender(filament::Engine* engine, filament::View* view, filament::
 
     // Without an IBL, we must clear the swapchain to black before each frame.
     renderer->setClearOptions({
-            .clearColorValue = { 0.0f, 0.0f, 0.0f, 1.0f },
-            .clearColor = !FilamentApp::get().getIBL()  });
+            .clearColor = { 0.0f, 0.0f, 0.0f, 1.0f },
+            .clear = !FilamentApp::get().getIBL()  });
 
     Camera& camera = view->getCamera();
     camera.setExposure(g_params.cameraAperture, 1.0f / g_params.cameraSpeed, g_params.cameraISO);

--- a/samples/rendertarget.cpp
+++ b/samples/rendertarget.cpp
@@ -338,7 +338,7 @@ int main(int argc, char** argv) {
     };
 
     auto preRender = [&app](Engine*, View*, Scene*, Renderer* renderer) {
-        renderer->setClearOptions({.clearColorValue = {0.1,0.2,0.4,1.0}, .clearColor = true});
+        renderer->setClearOptions({.clearColor = {0.1,0.2,0.4,1.0}, .clear = true});
     };
 
     FilamentApp::get().animate([&app](Engine* engine, View* view, double now) {

--- a/tools/matc/src/matc/ParametersProcessor.cpp
+++ b/tools/matc/src/matc/ParametersProcessor.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <iostream>
-#include <optional>
 
 #include <ctype.h>
 #include <private/filament/Variant.h>
@@ -514,42 +513,6 @@ static bool processDepthWrite(MaterialBuilder& builder, const JsonishValue& valu
     return true;
 }
 
-static bool processStencilWrite(MaterialBuilder& builder, const JsonishValue& value) {
-    builder.stencilWrite(value.toJsonBool()->getBool());
-    return true;
-}
-
-static std::optional<MaterialBuilder::StencilOperation> processStencilOperation(const JsonishValue& value, const std::string& log) {
-    static const std::unordered_map<std::string, MaterialBuilder::StencilOperation> strToEnum {
-        { "zero", MaterialBuilder::StencilOperation::ZERO },
-        { "keep", MaterialBuilder::StencilOperation::KEEP },
-        { "replace", MaterialBuilder::StencilOperation::REPLACE },
-        { "invert", MaterialBuilder::StencilOperation::INVERT },
-    };
-    auto jsonString = value.toJsonString();
-    if (!isStringValidEnum(strToEnum, jsonString->getString())) {
-        logEnumIssue(log, *jsonString, strToEnum);
-        return std::nullopt;
-    }
-    return stringToEnum(strToEnum, jsonString->getString());
-}
-
-static bool processStencilDepthFail(MaterialBuilder& builder, const JsonishValue& value) {
-    if (auto op = processStencilOperation(value, "stencil_depth_fail"); op) {
-        builder.stencilDepthFail(*op);
-        return true;
-    }
-    return false;
-}
-
-static bool processStencilDepthPass(MaterialBuilder& builder, const JsonishValue& value) {
-    if (auto op = processStencilOperation(value, "stencil_depth_pass"); op) {
-        builder.stencilDepthPass(*op);
-        return true;
-    }
-    return false;
-}
-
 static bool processDepthCull(MaterialBuilder& builder, const JsonishValue& value) {
     builder.depthCulling(value.toJsonBool()->getBool());
     return true;
@@ -787,11 +750,6 @@ ParametersProcessor::ParametersProcessor() {
     mParameters["colorWrite"]                    = { &processColorWrite, Type::BOOL };
     mParameters["depthWrite"]                    = { &processDepthWrite, Type::BOOL };
     mParameters["depthCulling"]                  = { &processDepthCull, Type::BOOL };
-
-    mParameters["stencilWrite"]                  = { &processStencilWrite, Type::BOOL};
-    mParameters["stencilDepthFail"]              = { &processStencilDepthFail, Type::STRING};
-    mParameters["stencilDepthPass"]              = { &processStencilDepthPass, Type::STRING};
-
     mParameters["doubleSided"]                   = { &processDoubleSided, Type::BOOL };
     mParameters["transparency"]                  = { &processTransparencyMode, Type::STRING };
     mParameters["reflections"]                   = { &processReflectionMode, Type::STRING };


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3486](https://shapr3d.atlassian.net/browse/GFX-3486)

## Short description (What? How?) 📖
This PR reverts #55, #57, #58, #59, #61, #66, #67, #68 (based on the upstream code at tag v1.22.1).

## Material shader statistics implications
N/A. The actual shader code generated from our materials don't change.

## Upstreaming scope
One thing we could consider upstreaming is specifying stencil write in .mat files. They plan to do it, but haven't yet.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Visulization in Shapr3D.

### Special use-cases to test 🧷
Selection outline in Shapr3D Visualization.

### How did you test it? 🤔
Manual 💁‍♂️
I have been using the changes here for one week and haven't noticed a problem.

Automated 💻


[GFX-3486]: https://shapr3d.atlassian.net/browse/GFX-3486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ