### PR TITLE
[GFX-3509] Disable half optimisation

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -477,7 +477,6 @@ std::shared_ptr<spvtools::Optimizer> GLSLPostProcessor::createOptimizer(
         registerPerformancePasses(*optimizer, config);
         // Metal doesn't support relaxed precision, but does have support for float16 math operations.
         if (config.targetApi == MaterialBuilder::TargetApi::METAL) {
-            optimizer->RegisterPass(CreateConvertRelaxedToHalfPass());
             optimizer->RegisterPass(CreateSimplificationPass());
             optimizer->RegisterPass(CreateRedundancyEliminationPass());
             optimizer->RegisterPass(CreateAggressiveDCEPass());


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3509](https://shapr3d.atlassian.net/browse/GFX-3509)

## Short description (What? How?) 📖
`SPIR-V` "float to half" optimisation is very aggressive. It ignores the `GLSL` precision specifications and introduces clamping conversions. This was the reasons behind why the DoF behaved differently after the bump. The optimiser introduces a float to half cast into the `dofDownsample.mat` code, which clamped the `cocParams` to the [-65536.0f, 65536.0f] range (`cocParams` can easily reach the -200000 value range).

## Material shader statistics implications
Yes, it affects the shader statistics quite negatively 😞. 

## Upstreaming scope
N/A: They certainly wouldn't accept a PR disabling an optimisation. Instead we can provide a patch file to SPIR-V.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Every material on Apple platforms.

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️
I did test it with the attached workspace on my MacBook Pro.

Automated 💻
n/a

[GFX-3509]: https://shapr3d.atlassian.net/browse/GFX-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ