### PR TITLE
Fix warnings on Apple platforms

### DIFF
--- a/libs/viewer/src/TweakableMaterial.cpp
+++ b/libs/viewer/src/TweakableMaterial.cpp
@@ -93,8 +93,8 @@ void TweakableMaterial::fromJson(const json& source) {
 
     readTexturedFromJson(source, "baseColor", mBaseColor, true, isAlpha, isAlpha ? 4 : 3);
     readValueFromJson(source, "tintColor", mTintColor, { 1.0f, 1.0f, 1.0f });
-    readValueFromJson(source, "emissiveIntensity", mEmissiveIntensity, { 0.0f });
-    readValueFromJson(source, "emissiveExposureWeight", mEmissiveExposureWeight, { 0.0f });
+    readValueFromJson(source, "emissiveIntensity", mEmissiveIntensity, 0.0f);
+    readValueFromJson(source, "emissiveExposureWeight", mEmissiveExposureWeight, 0.0f);
 
     readValueFromJson(source, "normalIntensity", mNormalIntensity, 1.0f);
     readTexturedFromJson(source, "normalTexture", mNormal, false, false, 3);
@@ -234,7 +234,7 @@ void TweakableMaterial::drawUI(const std::string& header) {
             }
         }
         if (header.size() > 0) {
-            ImGui::TextColored({ 1,0,0,1 }, header.c_str());
+            ImGui::TextColored({ 1,0,0,1 }, "%s", header.c_str());
         }
         else {
             ImGui::TextColored({ 0,1,0,1 }, "OK");

--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -922,6 +922,8 @@ const char* ViewerGui::formatToName(filament::Texture::InternalFormat format) co
 }
 
 std::string ViewerGui::validateTweaks(const TweakableMaterial& tweaks) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc++20-extensions"
     auto verifyTextured = [&]<typename T, bool MayContainFile, bool IsColor, bool IsDerivable>(
         std::string & result,
         const std::string & prompt,
@@ -979,6 +981,7 @@ std::string ViewerGui::validateTweaks(const TweakableMaterial& tweaks) {
             result += "ERROR: " + prompt + " has no channel numbers! Expected a " + std::to_string(expectedChannelCount) + " channel texture.\n";
         }
     };
+#pragma clang diagnostic pop
 
     std::string result = "";
     verifyTextured(result, "BaseColor", tweaks.mBaseColor);


### PR DESCRIPTION
## Jira ticket URL (Why?)
None

## Short description (What? How?) 📖
While building Filament several times during development, I thought of fixing these low hanging fruits. Two times we initialize a scalar with braces, once we provide a variable value as a format string, and we use a C++20 feature (explicit template parameters for generic lambda) while the repo is still on C++17.

## Material shader statistics implications
N/A

## Upstreaming scope
None, this is in our addition to the codebase.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
gltf_viewer only

### Special use-cases to test 🧷
Material import/load and saving from/to JSON inside `gltf_viewer`

### How did you test it? 🤔
Manual 💁‍♂️
Built the code, ran gltf_viewer, loaded some materials, all worked
Automated 💻
❌ 