### PR TITLE
[VP-28] Fix macro check: macOS or Catalyst

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -1281,7 +1281,7 @@ void MetalDriver::readPixels(Handle<HwRenderTarget> src, uint32_t x, uint32_t y,
 
     mContext->blitter->blit(getPendingCommandBuffer(mContext), args, "readPixels blit");
 
-#if !defined(IOS) || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
     // Managed textures on macOS require explicit synchronization between GPU / CPU.
     if (readPixelsTexture.storageMode == MTLStorageModeManaged) {
         id <MTLBlitCommandEncoder> blitEncoder = [getPendingCommandBuffer(mContext) blitCommandEncoder];


### PR DESCRIPTION
## Jira ticket URL (Why?)
[VP-28](https://shapr3d.atlassian.net/browse/VP-28)

## Short description (What? How?) 📖
This PR fixes an OS check intended to be true only, when running on macOS or Catalyst. Unfortunately, as formulated, `!IOS || CATALYST` is true for visionOS, but `MTLStorageModeManaged` is unavailable on that platform.

## Material shader statistics implications
N/A

## Upstreaming scope
Probably none, macOS and Catalyst are of no interest to Google, as far as we know.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Filament Metal backend, so all Apple platforms

### Special use-cases to test 🧷
Filament should still work as expected both inside Shapr3D, and gltf_viewer

### How did you test it? 🤔
Manual 💁‍♂️
Tested Filament-based features on our target platforms, and tried gltf_viewer, all worked as expected
Automated 💻
Shapr-side is covered by automated tests

[VP-28]: https://shapr3d.atlassian.net/browse/VP-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ