### PR TITLE
[GFX-3480] Update shader statistics part of the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,9 +20,9 @@ Don't duplicate what's in the Jira ticket. If it's outdated, let's update that.
 
 ## Material shader statistics implications
 <!---
-The statistics regarding the performance of material shaders are updated four-weekly and can be found in:
+The statistics regarding the performance of material shaders are updated after each filament version change and can be found in:
 https://shapr3d.atlassian.net/wiki/spaces/RT/pages/3323134029/Benchmark+material+attribute+performance .
-If you belive that your commit has a heavy impact on performance, please inform @benceboros2 .
+If you belive that your commit has a heavy impact on performance and needs an additional check, please inform @benceboros2 .
 -->
 
 ## Upstreaming scope


### PR DESCRIPTION
## Jira ticket URL (Why?)
<!---
Use the Jira ticket id as text in PROJ-XXX format and append it to the end of the link.
If there are multiple tickets, list all.
-->
[GFX-3480](https://shapr3d.atlassian.net/browse/GFX-3480)
## Short description (What? How?) 📖
The goal of this PR is to actualize the `Material shader statistics implications` part in the PR template.
## Material shader statistics implications
n/a
## Upstreaming scope
n/a
## Testing
n/a
### Design review 🎨
n/a
### Affected areas 🧭
n/a
### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
n/a
Manual 💁‍♂️
n/a
Automated 💻
n/a

[GFX-3480]: https://shapr3d.atlassian.net/browse/GFX-3480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ