### PR TITLE
[GFX-3532] Fix gltf_viewer view settings export

### DIFF
--- a/libs/viewer/src/Settings.cpp
+++ b/libs/viewer/src/Settings.cpp
@@ -39,17 +39,6 @@ using namespace utils;
 
 namespace filament::viewer {
 
-std::string_view to_string(color::ColorSpace const& colorspace) noexcept {
-    using namespace color;
-    if (colorspace == Rec709-Linear-D65) {
-        return "Rec709-Linear-D65";
-    }
-    if (colorspace == Rec709-sRGB-D65) {
-        return "Rec709-sRGB-D65";
-    }
-    return "unknown";
-}
-
 // Skips over an unused token.
 int parse(jsmntok_t const* tokens, int i) {
     int end = i + 1;
@@ -798,6 +787,17 @@ ColorGrading* createColorGrading(const ColorGradingSettings& settings, Engine* e
     return colorGrading;
 }
 
+static std::ostream& operator<<(std::ostream& out, ColorSpace in) {
+    using namespace color;
+    if (in == Rec709-Linear-D65) {
+        return out << "\"Rec709-Linear-D65\"";
+    }
+    if (in == Rec709-sRGB-D65) {
+        return out << "\"Rec709-sRGB-D65\"";
+    }
+    return out << "\"INVALID\"";
+}
+
 static std::ostream& operator<<(std::ostream& out, CGQL in) {
     switch (in) {
         case CGQL::LOW: return out << "\"LOW\"";
@@ -841,14 +841,14 @@ static std::ostream& operator<<(std::ostream& out, AgxToneMapper::AgxLook in) {
 
 static std::ostream& operator<<(std::ostream& out, const AgxToneMapperSettings& in) {
     return out << "{\n"
-               << "\"look\": " << (in.look) << ",\n"
+               << "\"look\": " << (in.look) << "\n"
                << "}";
 }
 
 static std::ostream& operator<<(std::ostream& out, const ColorGradingSettings& in) {
     return out << "{\n"
         << "\"enabled\": " << to_string(in.enabled) << ",\n"
-        << "\"colorspace\": " << to_string(in.colorspace) << ",\n"
+        << "\"colorspace\": " << (in.colorspace) << ",\n"
         << "\"quality\": " << (in.quality) << ",\n"
         << "\"toneMapping\": " << (in.toneMapping) << ",\n"
         << "\"genericToneMapper\": " << (in.genericToneMapper) << ",\n"
@@ -889,12 +889,12 @@ static std::ostream& operator<<(std::ostream& out, const LightManager::ShadowOpt
         << "},\n"
         << "\"mapSize\": " << in.mapSize << ",\n"
         << "\"shadowCascades\": " << int(in.shadowCascades) << ",\n"
-        << "\"cascadeSplitPositions\": " << (splitsVector) << "\n"
+        << "\"cascadeSplitPositions\": " << (splitsVector) << ",\n"
         << "\"stable\": " << to_string(in.stable) << ",\n"
         << "\"lispsm\": " << to_string(in.lispsm) << ",\n"
         << "\"screenSpaceContactShadows\": " << to_string(in.screenSpaceContactShadows) << ",\n"
         << "\"shadowBulbRadius\": " << in.shadowBulbRadius << ",\n"
-        << "\"transform\": " << in.transform.xyzw << ",\n"
+        << "\"transform\": " << in.transform.xyzw << "\n"
         << "}";
 }
 

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -350,7 +350,7 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, FogOptions* out
 std::ostream& operator<<(std::ostream& out, const FogOptions& in) {
     return out << "{\n"
         << "\"distance\": " << (in.distance) << ",\n"
-        << "\"cutOffDistance\": " << (std::isnan(in.cutOffDistance) ? "\"NAN\"" : std::isinf(in.cutOffDistance) ? "\"INFINITY\"" : std::to_string(in.cutOffDistance)) << ",\n"
+        << "\"cutOffDistance\": " << (std::isinf(in.cutOffDistance) ? 1e99 : in.cutOffDistance) << ",\n"
         << "\"maximumOpacity\": " << (in.maximumOpacity) << ",\n"
         << "\"height\": " << (in.height) << ",\n"
         << "\"heightFalloff\": " << (in.heightFalloff) << ",\n"

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -350,7 +350,7 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, FogOptions* out
 std::ostream& operator<<(std::ostream& out, const FogOptions& in) {
     return out << "{\n"
         << "\"distance\": " << (in.distance) << ",\n"
-        << "\"cutOffDistance\": " << (std::isinf(in.cutOffDistance) ? "\"INFINITY\"" : std::to_string(in.cutOffDistance)) << ",\n"
+        << "\"cutOffDistance\": " << (std::isnan(in.cutOffDistance) ? "\"NAN\"" : std::isinf(in.cutOffDistance) ? "\"INFINITY\"" : std::to_string(in.cutOffDistance)) << ",\n"
         << "\"maximumOpacity\": " << (in.maximumOpacity) << ",\n"
         << "\"height\": " << (in.height) << ",\n"
         << "\"heightFalloff\": " << (in.heightFalloff) << ",\n"

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -350,7 +350,7 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, FogOptions* out
 std::ostream& operator<<(std::ostream& out, const FogOptions& in) {
     return out << "{\n"
         << "\"distance\": " << (in.distance) << ",\n"
-        << "\"cutOffDistance\": " << (in.cutOffDistance) << ",\n"
+        << "\"cutOffDistance\": " << (std::isinf(in.cutOffDistance) ? "\"INFINITY\"" : std::to_string(in.cutOffDistance)) << ",\n"
         << "\"maximumOpacity\": " << (in.maximumOpacity) << ",\n"
         << "\"height\": " << (in.height) << ",\n"
         << "\"heightFalloff\": " << (in.heightFalloff) << ",\n"


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3532](https://shapr3d.atlassian.net/browse/GFX-3532)
## Short description (What? How?) 📖
In `gltf_viewer`, the view setting export option currently generates a faulty `.json` file. The purpose of this PR is to address and fix the issues with `.json` file generation. This option is crucial for serializing artist settings and integrating them into Shapr3D.
## Material shader statistics implications
n/a
## Upstreaming scope
n/a
## Testing
Check the exported view settings.
### Design review 🎨
n/a
### Affected areas 🧭
`gltf_viewer` view export
### Special use-cases to test 🧷

### How did you test it? 🤔

Manual 💁‍♂️

Created the `.json` file with different settings.  The`shapr3d/tools/Rendering/ArtistSettingsImporter/import_artist_settings.py` script is a good tool to test the `.json`.

Automated 💻

-

[GFX-3532]: https://shapr3d.atlassian.net/browse/GFX-3532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ