### PR TITLE
[GFX-3532] Change default fog cutOffDistance

### DIFF
--- a/filament/include/filament/Options.h
+++ b/filament/include/filament/Options.h
@@ -177,7 +177,7 @@ struct FogOptions {
      * Note: The SkyBox is typically at a distance of 1e19 in world space (depending on the near
      * plane distance and projection used though).
      */
-    float cutOffDistance = INFINITY;
+    float cutOffDistance = 1e19;
 
     /**
      * fog's maximum opacity between 0 and 1

--- a/libs/viewer/src/Settings_generated.cpp
+++ b/libs/viewer/src/Settings_generated.cpp
@@ -350,7 +350,7 @@ int parse(jsmntok_t const* tokens, int i, const char* jsonChunk, FogOptions* out
 std::ostream& operator<<(std::ostream& out, const FogOptions& in) {
     return out << "{\n"
         << "\"distance\": " << (in.distance) << ",\n"
-        << "\"cutOffDistance\": " << (std::isinf(in.cutOffDistance) ? 1e99 : in.cutOffDistance) << ",\n"
+        << "\"cutOffDistance\": " << (in.cutOffDistance) << ",\n"
         << "\"maximumOpacity\": " << (in.maximumOpacity) << ",\n"
         << "\"height\": " << (in.height) << ",\n"
         << "\"heightFalloff\": " << (in.heightFalloff) << ",\n"


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3532](https://shapr3d.atlassian.net/browse/GFX-3532)

## Short description (What? How?) 📖
This PR changes the default value of `cutOffDistance` from `INFINITY`, to make integrating artist settings easier. This is necessary because when exporting views from `gltf_viewer` with this setting, `inf` will be included in the `.json` file, and this cannot be processed by our script.
(We are not planning to use this option in the future)
## Material shader statistics implications
n/a
## Upstreaming scope
n/a
## Testing
n/a
### Design review 🎨
n/a
### Affected areas 🧭
fog in `gltf_viewer`
### Special use-cases to test 🧷
n/a
### How did you test it? 🤔
Manual 💁‍♂️
exported view settings from `gltf_viewer` , and used the generated `.json` file to integrate the settings into shapr with `import_artist_settings.py`

Automated 💻


[GFX-3532]: https://shapr3d.atlassian.net/browse/GFX-3532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ