### PR TITLE
[GFX-3649] Fix gradient background

### DIFF
--- a/shaders/src/getters.vs
+++ b/shaders/src/getters.vs
@@ -256,8 +256,8 @@ vec4 computeWorldPosition() {
     vec4 position = transform * p;
     // w could be zero (e.g.: with the skybox) which corresponds to an infinite distance in
     // world-space. However, we want to avoid infinites and divides-by-zero, so we use a very
-    // small number instead in that case (2^-63 seem to work well).
-    const highp float ALMOST_ZERO_FLT = 1.08420217249e-19;
+    // small number instead in that case (2^-52 seem to work well).
+    const highp float ALMOST_ZERO_FLT = 2.22044604925e-16;
     if (abs(position.w) < ALMOST_ZERO_FLT) {
         position.w = position.w < 0.0 ? -ALMOST_ZERO_FLT : ALMOST_ZERO_FLT;
     }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3649](https://shapr3d.atlassian.net/browse/GFX-3649)

## Short description (What? How?) 📖
Commit https://github.com/google/filament/commit/3ec704b91c1bc2d120ce34a35e812ffdeeb96546 upstreamed from the `main` branch introduced less strict clamping what we consider as infinity. This resulted in the following artifact for the gradient background, in case of large camera fovs (~85...90deg):

![image](https://github.com/shapr3d/filament/assets/6261494/4573fcd9-8165-446d-8615-0903f36a0932)

Because of the less strict clamping, when we normalized `variable_eyeDirection` in `skybox.mat`, the result of the normalization ended up being zero.

## Material shader statistics implications
?

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
`computeWorldPosition`, skybox material.

### Special use-cases to test 🧷
Gradient bg in case of fov > ~85...90deg.

### How did you test it? 🤔
Manual 💁‍♂️
Did test it on macOS.
Automated 💻
n/a

[GFX-3649]: https://shapr3d.atlassian.net/browse/GFX-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ