### PR TITLE
[GFX-3464] Disable 'exhaustive inlining' on Metal

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -710,7 +710,7 @@ void GLSLPostProcessor::registerPerformancePasses(Optimizer& optimizer, Config c
     RegisterPass(CreateWrapOpKillPass());
     RegisterPass(CreateDeadBranchElimPass());
     RegisterPass(CreateMergeReturnPass(), MaterialBuilder::TargetApi::METAL);
-    RegisterPass(CreateInlineExhaustivePass());
+    RegisterPass(CreateInlineExhaustivePass(), MaterialBuilder::TargetApi::OPENGL | MaterialBuilder::TargetApi::VULKAN);
     RegisterPass(CreateAggressiveDCEPass());
     RegisterPass(CreatePrivateToLocalPass());
     RegisterPass(CreateLocalSingleBlockLoadStoreElimPass());


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3464](https://shapr3d.atlassian.net/browse/GFX-3464)

## Short description (What? How?) 📖
On older iPads (e.g. iPad Air 4 with A14 or iPad Pro 3 with A12X) _'exhaustive inlining'_ SPIR-V pass resulted in freezing the app in visualization. 

Our best guess is that these old devices are not able to handle such shader program sizes - thus, we're disabling this pass on Metal.

## Material shader statistics implications


## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Optimazing material binaries.

### Special use-cases to test 🧷
[A12X Crash ws](https://shapr3d.atlassian.net/browse/GFX-1528?focusedCommentId=29017) shouldn't crash on the iPad Air 4.

### How did you test it? 🤔
Manual 💁‍♂️
Couldn't repo the crash on the iPad Air 4.
Automated 💻
n/a

[GFX-3464]: https://shapr3d.atlassian.net/browse/GFX-3464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ