### PR TITLE
 [GFX-3464] Disable 'exhaustive inlining' on Metal

### DIFF
--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -710,7 +710,7 @@ void GLSLPostProcessor::registerPerformancePasses(Optimizer& optimizer, Config c
     RegisterPass(CreateWrapOpKillPass());
     RegisterPass(CreateDeadBranchElimPass());
     RegisterPass(CreateMergeReturnPass(), MaterialBuilder::TargetApi::METAL);
-    RegisterPass(CreateInlineExhaustivePass());
+    RegisterPass(CreateInlineExhaustivePass(), MaterialBuilder::TargetApi::OPENGL | MaterialBuilder::TargetApi::VULKAN);
     RegisterPass(CreateAggressiveDCEPass());
     RegisterPass(CreatePrivateToLocalPass());
     RegisterPass(CreateLocalSingleBlockLoadStoreElimPass());

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -16,9 +16,6 @@
 
 #include "GLSLPostProcessor.h"
 
-#include <string>
-#include <string_view>
-
 #include <GlslangToSpv.h>
 #include <SPVRemapper.h>
 #include <spirv-tools/libspirv.hpp>

--- a/libs/filamat/src/GLSLPostProcessor.cpp
+++ b/libs/filamat/src/GLSLPostProcessor.cpp
@@ -58,53 +58,6 @@ using namespace utils;
 
 namespace msl {  // this is only used for MSL
 
-std::string addMaybeUnusedToVariables(const std::string& mslShader) {
-    // Since we turned off SPIRV optimization unused variables are not stripped and
-    // generate runtime warnings. In order to silence them, we tag them with [[maybe_unused]].
-    constexpr std::string_view unusedVariables[] = {
-        // global variables in common_shading.fs
-        "float3x3 shading_tangentToWorld;",
-        "float3 shading_position;",
-        "float3 shading_view;",
-        "float3 shading_normal;",
-        "float3 shading_geometricNormal;",
-        "float3 shading_reflected;",
-        "float shading_NoV;",
-        "float3 shading_bentNormal;",
-        "float3 shading_clearCoatNormal;",
-        "float2 shading_normalizedViewportCoord;",
-
-        // unused variable in main.fs and depth_main.fs
-        "float filament_lodBias =",
-
-        // generateSpecializationConstant() emits these:
-        "constant int BACKEND_FEATURE_LEVEL =",
-        "constant int CONFIG_MAX_INSTANCES =",
-        "constant int CONFIG_FROXEL_BUFFER_HEIGHT =",
-        "constant bool CONFIG_DEBUG_DIRECTIONAL_SHADOWMAP =",
-        "constant bool CONFIG_DEBUG_FROXEL_VISUALIZATION =",
-        "constant bool CONFIG_STATIC_TEXTURE_TARGET_WORKAROUND =",
-        "constant bool CONFIG_POWER_VR_SHADER_WORKAROUNDS =",
-        "constant int CONFIG_STEREO_EYE_COUNT =",
-        "constant bool CONFIG_SRGB_SWAPCHAIN_EMULATION =",
-
-        // ...
-    };
-
-    constexpr std::string_view maybeUnused = "[[maybe_unused]] ";
-
-    std::string patchedMslShader;
-    patchedMslShader.reserve(std::size(maybeUnused) * std::size(unusedVariables) + std::size(mslShader));
-    patchedMslShader = mslShader;
-    for (const auto& variable : unusedVariables) {
-        auto pos = patchedMslShader.find(variable);
-        if (pos != std::string::npos) {
-            patchedMslShader.insert(pos, maybeUnused);
-        }
-    }
-    return patchedMslShader;
-}
-
 using BindingIndexMap = std::unordered_map<std::string, uint16_t>;
 
 static void collectSibs(const GLSLPostProcessor::Config& config, SibVector& sibs) {
@@ -333,7 +286,6 @@ void GLSLPostProcessor::spirvToMsl(const SpirvBlob *spirv, std::string *outMsl,
     mslCompiler.add_discrete_descriptor_set(0);
 
     *outMsl = mslCompiler.compile();
-    *outMsl = addMaybeUnusedToVariables(*outMsl);
     if (minifier) {
         *outMsl = minifier->removeWhitespace(*outMsl);
     }
@@ -786,6 +738,7 @@ void GLSLPostProcessor::registerSizePasses(Optimizer& optimizer, Config const& c
     RegisterPass(CreateSimplificationPass(), MaterialBuilder::TargetApi::METAL);
     RegisterPass(CreateAggressiveDCEPass());
     RegisterPass(CreateCFGCleanupPass());
+    RegisterPass(CreateEliminateDeadConstantPass());
 }
 
 } // namespace filamat


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3464](https://shapr3d.atlassian.net/browse/GFX-3464)

## Short description (What? How?) 📖
### Turning on `matc` optimizations
On older iPads (e.g. iPad Air 4 with A14 or iPad Pro 3 with A12X) _'exhaustive inlining'_ SPIR-V pass resulted in freezing the app in visualization. 

Our best guess is that these old devices are not able to handle such shader program sizes - thus, we're disabling this pass on Metal.

### Remove unused variables with SPIR-V
With optimization turned on, variables are renamed. Thus, We are removing `addMaybeUnusedToVariables` patch and will use `EliminateDeadConstantPass` instead to remove unused variables.

## Material shader statistics implications
[This card](https://shapr3d.atlassian.net/browse/GFX-3654) will measure perf impact of disabling _'exhaustive inlining'_.

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Optimazing material binaries.

### Special use-cases to test 🧷
[A12X Crash ws](https://shapr3d.atlassian.net/browse/GFX-1528?focusedCommentId=29017) shouldn't crash on the iPad Air 4.

### How did you test it? 🤔
Manual 💁‍♂️
Couldn't repo the crash on the iPad Air 4.
Automated 💻
n/a

[GFX-3464]: https://shapr3d.atlassian.net/browse/GFX-3464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ