### PR TITLE
[GFX-3718] Fix use-after-free error in color grading material

### DIFF
--- a/filament/backend/include/private/backend/SamplerGroup.h
+++ b/filament/backend/include/private/backend/SamplerGroup.h
@@ -73,7 +73,7 @@ public:
     // set sampler at given index
     void setSampler(size_t index, backend::SamplerDescriptor sampler) noexcept;
 
-    inline void clearSampler(size_t index) {
+    inline void clearSampler(size_t index) noexcept {
         setSampler(index, {});
     }
 

--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2450,6 +2450,9 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
                             PostProcessVariant::TRANSLUCENT : PostProcessVariant::OPAQUE);
 
                 commitAndRender(out, material, variant, driver);
+
+                // Clear reference to LUT texture of color grading, in case it gets destroyed
+                mi->clearParameter("lut");
             }
     );
 

--- a/filament/src/details/MaterialInstance.cpp
+++ b/filament/src/details/MaterialInstance.cpp
@@ -179,6 +179,11 @@ void FMaterialInstance::setParameter(std::string_view name,
     mSamplers.setSampler(index, { texture, params });
 }
 
+void FMaterialInstance::clearParameter(std::string_view name) noexcept {
+    size_t const index = mMaterial->getSamplerInterfaceBlock().getSamplerInfo(name)->offset;
+    mSamplers.clearSampler(index);
+}
+
 void FMaterialInstance::setParameterImpl(std::string_view name,
         FTexture const* texture, TextureSampler const& sampler) {
 

--- a/filament/src/details/MaterialInstance.h
+++ b/filament/src/details/MaterialInstance.h
@@ -210,6 +210,8 @@ public:
     void setParameter(std::string_view name,
             backend::Handle<backend::HwTexture> texture, backend::SamplerParams params) noexcept;
 
+    void clearParameter(std::string_view name) noexcept;
+
     using MaterialInstance::setParameter;
 
 private:


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3718](https://shapr3d.atlassian.net/browse/GFX-3718)

## Short description (What? How?) 📖
The Jira ticket summarizes the problem well. The color grading pass used a material that used a sampler group which held a reference to the color grading LUT texture. Whenever the color grading LUT texture was recreated (e.g. because tone mapping settings changed in Shapr3D) the sampler group referencing the old texture remained bound and the first draw call in the frame attempted to use the dead texture. It wasn't a real issue in the live app, because only Metal API validation complained, but it hinders development.

## Material shader statistics implications
n/a

## Upstreaming scope
- [x] Discuss this on SU or during PR review

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
The repro in the ticket.

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-3718]: https://shapr3d.atlassian.net/browse/GFX-3718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ