### PR TITLE
Re-enable fast-math in Metal compiler

### DIFF
--- a/filament/backend/src/metal/MetalShaderCompiler.mm
+++ b/filament/backend/src/metal/MetalShaderCompiler.mm
@@ -111,7 +111,7 @@ void MetalShaderCompiler::terminate() noexcept {
         // This ensures that operations adhere to IEEE standards for floating-point arithmetic,
         // which is crucial for half precision floats in scenarios where fast math optimizations
         // lead to inaccuracies, such as in handling special values like NaN or Infinity.
-        options.fastMathEnabled = NO;
+        options.fastMathEnabled = YES;
 
         NSError* error = nil;
         id<MTLLibrary> library = [device newLibraryWithSource:objcSource


### PR DESCRIPTION
<!---
If a section is not applicable for your PR,
please just mark it with "n/a" rather than deleting it.
Also these comment sections should be deleted from the final PR.
-->

## Jira ticket URL (Why?)
<!---
Use the Jira ticket id as text in PROJ-XXX format and append it to the end of the link.
If there are multiple tickets, list all.
-->
[](https://shapr3d.atlassian.net/browse/)

## Short description (What? How?) 📖
<!---
Short description of the change, can include screenshot, gif, etc.
Let's focus on the what? and how?.
Don't duplicate what's in the Jira ticket. If it's outdated, let's update that.
-->
Fast-math enablement in Metal compiler was switched off in Filament version 1.50.1 which resulted in a significant GPU frame-time regression in case of Apple devices, detailed here: https://shapr3d.atlassian.net/browse/GFX-3729. To solve it, we re-enabled it.
## Material shader statistics implications
<!---
The statistics regarding the performance of material shaders are updated after each filament version change and can be found in:
https://shapr3d.atlassian.net/wiki/spaces/RT/pages/3323134029/Benchmark+material+attribute+performance .
If you belive that your commit has a heavy impact on performance and needs an additional check, please inform @benceboros2 .
-->
n/a
## Upstreaming scope
<!---
Should we propagate these changes to upstream? If so, reference the upstream PR
or the ticket that should result in an upstream PR. If not, elaborate why.
-->
n/a
## Testing

### Design review 🎨
<!--- List the design team members who approved the implementation -->
n/a
### Affected areas 🧭
<!--- List all areas that can be affected by the changes introduced -->
Frame-times in visualization on Apple devices
### Special use-cases to test 🧷
<!--- List special use-cases that could have changed -->
n/a
### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
Manual 💁‍♂️
Built and ran the app, measured frame-times on iPad and Mac Mini
Automated 💻
n/a