### PR TITLE
Changing shader compiling mode to ASYNCHRONOUS instead of THREAD_POOL in case of Angle compiling

### DIFF
--- a/filament/backend/src/opengl/ShaderCompilerService.cpp
+++ b/filament/backend/src/opengl/ShaderCompilerService.cpp
@@ -165,10 +165,13 @@ void ShaderCompilerService::init() noexcept {
     // In practice, we already know that with ANGLE, Mode::ASYNCHRONOUS can cause very long
     // pauses at glDraw() time in the situation where glLinkProgram() has been emitted, but has
     // other programs ahead of it in ANGLE's queue.
+#ifndef FILAMENT_USE_ANGLE
     if (mDriver.mPlatform.isExtraContextSupported()) {
         // our thread-pool if possible
         mMode = Mode::THREAD_POOL;
-    } else if (mDriver.getContext().ext.KHR_parallel_shader_compile) {
+    } else
+#endif // FILAMENT_USE_ANGLE
+    if (mDriver.getContext().ext.KHR_parallel_shader_compile) {
         // if not, async shader compilation and link if the driver supports it
         mMode = Mode::ASYNCHRONOUS;
     } else {


### PR DESCRIPTION


<!---
If a section is not applicable for your PR,
please just mark it with "n/a" rather than deleting it.
Also these comment sections should be deleted from the final PR.
-->

## Jira ticket URL (Why?)
<!---
Use the Jira ticket id as text in PROJ-XXX format and append it to the end of the link.
If there are multiple tickets, list all.
-->
[](https://shapr3d.atlassian.net/browse/)

## Short description (What? How?) 📖
<!---
Short description of the change, can include screenshot, gif, etc.
Let's focus on the what? and how?.
Don't duplicate what's in the Jira ticket. If it's outdated, let's update that.
-->
In Filament version 1.49.1 the shader compiling mode in ShaderCompilerServices.cpp was changed from `MODE::ASYNCHRONOUS` to `MODE::THREAD_POOL` which resulted on crashes in case of Nvidia GPU-s. To resolve the problem, we changed the compiling mode selection to be `MODE::ASYNCHRONOUS` again in case of Angle compiling. Details to be found here: [Filament bump notes - 1.49.0 to 1.50.3](https://shapr3d.atlassian.net/wiki/spaces/~7120200cb5d16624b04433b3f117d68e846a84/pages/3678371854/Filament+bump+notes+-+1.49.0+to+1.50.3).
## Material shader statistics implications
<!---
The statistics regarding the performance of material shaders are updated after each filament version change and can be found in:
https://shapr3d.atlassian.net/wiki/spaces/RT/pages/3323134029/Benchmark+material+attribute+performance .
If you belive that your commit has a heavy impact on performance and needs an additional check, please inform @benceboros2 .
-->

## Upstreaming scope
<!---
Should we propagate these changes to upstream? If so, reference the upstream PR
or the ticket that should result in an upstream PR. If not, elaborate why.
-->
n/a
## Testing

### Design review 🎨
<!--- List the design team members who approved the implementation -->
n/a
### Affected areas 🧭
<!--- List all areas that can be affected by the changes introduced -->
Visualization on Windows devices, with a focus on Nvidia GPUs
### Special use-cases to test 🧷
<!--- List special use-cases that could have changed -->
n/a
### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
Manual 💁‍♂️
Built and ran the app on a device with Geforce Gtx 1650Ti
Automated 💻
n/a