### PR TITLE
[GFX-3775] Fix mixed up FBO targets in status check code in OpenGLDriver::blit()

### DIFF
--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -3578,7 +3578,7 @@ void OpenGLDriver::blit(
         case SamplerType::SAMPLER_EXTERNAL:
             break;
     }
-    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
 
     gl.bindFramebuffer(GL_READ_FRAMEBUFFER, fbo[1]);
     switch (s->target) {
@@ -3604,7 +3604,7 @@ void OpenGLDriver::blit(
         case SamplerType::SAMPLER_EXTERNAL:
             break;
     }
-    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_DRAW_FRAMEBUFFER)
+    CHECK_GL_FRAMEBUFFER_STATUS(utils::slog.e, GL_READ_FRAMEBUFFER)
 
     gl.disable(GL_SCISSOR_TEST);
     glBlitFramebuffer(


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3775](https://shapr3d.atlassian.net/browse/GFX-3775)

## Short description (What? How?) 📖
`blit()` mixed up the FBO targets when checking the FBO completeness (after attaching images to the FBO). This caused the warnings in ANGLE. The typo was introduced in v1.49.1 in https://github.com/google/filament/pull/7333 and consequently in #156. I couldn't repro the warning in v1.49.0 (tried with reverting #156)

## Material shader statistics implications
n/a

## Upstreaming scope
https://github.com/google/filament/pull/7825

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
n/a

### Special use-cases to test 🧷
Launch Shapr3D on Windows with a debugger attached. You should no longer see the warnings in debug output during shader prewarming.

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-3775]: https://shapr3d.atlassian.net/browse/GFX-3775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ