### PR TITLE
[GFX-3841] Adjust handle arena pool ratios after Filament bumps

### DIFF
--- a/filament/backend/src/metal/MetalDriver.mm
+++ b/filament/backend/src/metal/MetalDriver.mm
@@ -62,7 +62,7 @@ Dispatcher MetalDriver::getDispatcher() const noexcept {
 MetalDriver::MetalDriver(MetalPlatform* platform, const Platform::DriverConfig& driverConfig) noexcept
         : mPlatform(*platform),
           mContext(new MetalContext(driverConfig.textureUseAfterFreePoolSize)),
-          mHandleAllocator("Handles", driverConfig.handleArenaSize, {1,1,254}) {
+          mHandleAllocator("Handles", driverConfig.handleArenaSize, {1,11,500}) {
     mContext->driver = this;
 
     mContext->device = mPlatform.createDevice();

--- a/filament/backend/src/opengl/OpenGLDriver.cpp
+++ b/filament/backend/src/opengl/OpenGLDriver.cpp
@@ -170,7 +170,7 @@ OpenGLDriver::OpenGLDriver(OpenGLPlatform* platform, const Platform::DriverConfi
         : mPlatform(*platform),
           mContext(),
           mShaderCompilerService(*this),
-          mHandleAllocator("Handles", driverConfig.handleArenaSize, {1,84,15}),
+          mHandleAllocator("Handles", driverConfig.handleArenaSize, {1,116,11}),
           mSamplerMap(32),
           mDriverConfig(driverConfig) {
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3841](https://shapr3d.atlassian.net/browse/GFX-3841)

## Short description (What? How?) 📖
Both backends needed changes to how the handle arena memory is distributed between the 3 pools. I updated [the Confluence doc](https://shapr3d.atlassian.net/wiki/spaces/DD/pages/3467444546/Filament+constants+in+root+CMakeLists.txt#Handle-arena) with the new numbers, distirbutions whatnot so it's easy to track why these constants were chosen. In summary, the handle sizes changed so some handles go to a different pool than before (making some pools more or less important, which is also backend-specific).

## Material shader statistics implications
n/a

## Upstreaming scope
These ratios are finetuned for Shapr3D. As before, we don't want to upstream them.

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Visualization in Shapr3D. There should be less slowdowns and 'not rendered parts' in complex workspaces than before. Personally, I think a sanity check is enough here from QA side (this change is very technical and low-risk).

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-3841]: https://shapr3d.atlassian.net/browse/GFX-3841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ