### PR TITLE
[GFX-3990] Fix Ward, auto absorption, auto sheen, and auto subsurface flags

### DIFF
--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -1311,12 +1311,11 @@ void ViewerGui::updateUserInterface() {
                     usageFlags |= static_cast<std::uint32_t>(tweaks.mRoughness.isFile) << 6u;
                     usageFlags |= static_cast<std::uint32_t>(tweaks.mSheenRoughness.isFile) << 7u;
                     usageFlags |= 0u << 8u; // useSwizzledNormalMaps bit
-                    usageFlags |= static_cast<std::uint32_t>(tweaks.mThickness.isFile) << 9u;
-                    usageFlags |= static_cast<std::uint32_t>(tweaks.mTransmission.isFile) << 10u;
-                    usageFlags |= static_cast<std::uint32_t>(tweaks.mUseWard) << 11u;
-                    usageFlags |= static_cast<std::uint32_t>(tweaks.mAbsorption.useDerivedQuantity) << 12u;
-                    usageFlags |= static_cast<std::uint32_t>(tweaks.mSheenColor.useDerivedQuantity) << 13u;
-                    usageFlags |= static_cast<std::uint32_t>(tweaks.mSubsurfaceColor.useDerivedQuantity) << 14u;
+                    usageFlags |= static_cast<std::uint32_t>(tweaks.mTransmission.isFile) << 9u;
+                    usageFlags |= static_cast<std::uint32_t>(tweaks.mUseWard) << 10u;
+                    usageFlags |= static_cast<std::uint32_t>(tweaks.mAbsorption.useDerivedQuantity) << 11u;
+                    usageFlags |= static_cast<std::uint32_t>(tweaks.mSheenColor.useDerivedQuantity) << 12u;
+                    usageFlags |= static_cast<std::uint32_t>(tweaks.mSubsurfaceColor.useDerivedQuantity) << 13u;
                     matInstance->setParameter("usageFlags", usageFlags);
 
                     setTextureIfPresent(tweaks.mBaseColor.isFile, tweaks.mBaseColor.filename, "baseColor");


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-3990](https://shapr3d.atlassian.net/browse/GFX-3990)

## Short description (What? How?) 📖
During a bump, we had to remove a texture/sampler to make room for the extra textures Filament is using. This cost us the thickness texture and while we have correctly handled it in the application, we forgot to update the usage flag computation logic. So recently, whenever the artists were trying to fiddle with using derived colors for absorption, sheen, or subsurface color, they were feeding incorrect data to the shader. The way we have caught it is by the fact that not even Ward was applicable for these. 

## Material shader statistics implications
N//A

## Upstreaming scope
This is Shapr3D only. 

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
GltfViewer.

### Special use-cases to test 🧷
Setting Ward, derived absorption, sheen, and subsurface. 

### How did you test it? 🤔
Manual 💁‍♂️
Yes, as above.

Automated 💻
N/A, unfortunately. 

[GFX-3990]: https://shapr3d.atlassian.net/browse/GFX-3990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ