### PR TITLE
[GFX-4253] Represent material orientation transformations as quaternions

### DIFF
--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2409,7 +2409,7 @@ The following APIs are only available from the fragment block:
 **getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
 **getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
 **getNormalizedViewportCoord()**        | float3   |  Normalized user viewport position (i.e. NDC coordinates normalized to [0, 1] for the position, [1, 0] for the depth), can be used before `prepareMaterial()`). Because the user viewport is smaller than the actual physical viewport, these coordinates can be negative or superior to 1 in the non-visible area of the physical viewport.
-**getMaterialOrientation()**            | float4    |  Rotation represented as quaternion to apply to bi/triplanar mapping. ![](images/shapr-logo.png)  
+**getMaterialOrientation()**            | float4   |  Rotation represented as quaternion to apply to bi/triplanar mapping. ![](images/shapr-logo.png)  
 **getMaterialOrientationCenter()**      | float3   |  World space position to apply bi/triplanar mapping from. World space caveats do not apply. ![](images/shapr-logo.png)
 **getNdotV()**                          | float    |  The result of `dot(normal, view)`, always strictly greater than 0 (must be used after `prepareMaterial()`)
 **getColor()**                          | float4   |  Interpolated color of the fragment, if the color attribute is required

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2409,8 +2409,8 @@ The following APIs are only available from the fragment block:
 **getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
 **getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
 **getNormalizedViewportCoord()**        | float3   |  Normalized user viewport position (i.e. NDC coordinates normalized to [0, 1] for the position, [1, 0] for the depth), can be used before `prepareMaterial()`). Because the user viewport is smaller than the actual physical viewport, these coordinates can be negative or superior to 1 in the non-visible area of the physical viewport.
-**getMaterialOrientationMatrix()**      | float3x3 |  Rotation matrix to apply to bi/triplanar mapping. ![](images/shapr-logo.png)
 **getMaterialOrientationCenter()**      | float3   |  World space position to apply bi/triplanar mapping from. World space caveats do not apply. ![](images/shapr-logo.png)
+**getMaterialOrientation()**            | float4    |  Rotation represented as quaternion to apply to bi/triplanar mapping. ![](images/shapr-logo.png)  
 **getNdotV()**                          | float    |  The result of `dot(normal, view)`, always strictly greater than 0 (must be used after `prepareMaterial()`)
 **getColor()**                          | float4   |  Interpolated color of the fragment, if the color attribute is required
 **getUV0()**                            | float2   |  First interpolated set of UV coordinates, only available if the uv0 attribute is required

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2409,7 +2409,7 @@ The following APIs are only available from the fragment block:
 **getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
 **getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
 **getNormalizedViewportCoord()**        | float3   |  Normalized user viewport position (i.e. NDC coordinates normalized to [0, 1] for the position, [1, 0] for the depth), can be used before `prepareMaterial()`). Because the user viewport is smaller than the actual physical viewport, these coordinates can be negative or superior to 1 in the non-visible area of the physical viewport.
-**getMaterialOrientation()**            | float4   |  Rotation represented as quaternion to apply to bi/triplanar mapping. ![](images/shapr-logo.png)  
+**getMaterialOrientation()**            | float4   |  Rotation represented as quaternion to apply to bi/triplanar mapping. ![](images/shapr-logo.png)
 **getMaterialOrientationCenter()**      | float3   |  World space position to apply bi/triplanar mapping from. World space caveats do not apply. ![](images/shapr-logo.png)
 **getNdotV()**                          | float    |  The result of `dot(normal, view)`, always strictly greater than 0 (must be used after `prepareMaterial()`)
 **getColor()**                          | float4   |  Interpolated color of the fragment, if the color attribute is required

--- a/docs/Materials.md.html
+++ b/docs/Materials.md.html
@@ -2409,8 +2409,8 @@ The following APIs are only available from the fragment block:
 **getWorldGeometricNormalVector()**     | float3   |  Normalized normal in world space, before bump mapping (can be used before `prepareMaterial()`)
 **getWorldReflectedVector()**           | float3   |  Reflection of the view vector about the normal (must be used after `prepareMaterial()`)
 **getNormalizedViewportCoord()**        | float3   |  Normalized user viewport position (i.e. NDC coordinates normalized to [0, 1] for the position, [1, 0] for the depth), can be used before `prepareMaterial()`). Because the user viewport is smaller than the actual physical viewport, these coordinates can be negative or superior to 1 in the non-visible area of the physical viewport.
-**getMaterialOrientationCenter()**      | float3   |  World space position to apply bi/triplanar mapping from. World space caveats do not apply. ![](images/shapr-logo.png)
 **getMaterialOrientation()**            | float4    |  Rotation represented as quaternion to apply to bi/triplanar mapping. ![](images/shapr-logo.png)  
+**getMaterialOrientationCenter()**      | float3   |  World space position to apply bi/triplanar mapping from. World space caveats do not apply. ![](images/shapr-logo.png)
 **getNdotV()**                          | float    |  The result of `dot(normal, view)`, always strictly greater than 0 (must be used after `prepareMaterial()`)
 **getColor()**                          | float4   |  Interpolated color of the fragment, if the color attribute is required
 **getUV0()**                            | float2   |  First interpolated set of UV coordinates, only available if the uv0 attribute is required

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -315,7 +315,7 @@ public:
      *            will be particularly bad when updating a lot of transforms. In that case,
      *            consider using openLocalTransformTransaction() / commitLocalTransformTransaction().
      */
-    void setMaterialOrientation(Instance ci, const math::quatf & rotation) noexcept;
+    void setMaterialOrientation(Instance ci, const math::quatf& rotation) noexcept;
 
     /**
      * Returns the local material orientation of a transform component.

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -315,7 +315,7 @@ public:
      *            will be particularly bad when updating a lot of transforms. In that case,
      *            consider using openLocalTransformTransaction() / commitLocalTransformTransaction().
      */
-    void setMaterialOrientation(Instance ci, const math::mat3f& rotation) noexcept;
+    void setMaterialOrientation(Instance ci, const math::quatf & rotation) noexcept;
 
     /**
      * Returns the local material orientation of a transform component.
@@ -324,7 +324,7 @@ public:
      *         returns the value set by setMaterialOrientation()).
      * @see setMaterialOrientation()
      */
-    const math::mat3f& getMaterialOrientation(Instance ci) const noexcept;
+    const math::quatf& getMaterialOrientation(Instance ci) const noexcept;
 
     /**
      * Sets whether the world transformation's rotation component should be applied to the material
@@ -351,7 +351,7 @@ public:
      *         material orientation.
      * @see setMaterialOrientation()
      */
-    const math::mat3f& getMaterialWorldOrientation(Instance ci) const noexcept;
+    const math::quatf& getMaterialWorldOrientation(Instance ci) const noexcept;
 
     /**
      * Sets the center of material texture mapping of a transform component in local space.

--- a/filament/include/filament/TransformManager.h
+++ b/filament/include/filament/TransformManager.h
@@ -309,7 +309,7 @@ public:
      * Sets a local material orientation of a transform component. This enables changing texture
      * bi/triplanar mapping direction.
      * @param ci              The instance of the transform component to set the local material orientation to.
-     * @param localTransform  The local material orientation (i.e. relative to the parent).
+     * @param rotation        The local material orientation (i.e. relative to the parent).
      * @see getMaterialOrientation()
      * @attention This operation can be slow if the hierarchy of transform is too deep, and this
      *            will be particularly bad when updating a lot of transforms. In that case,

--- a/filament/src/TransformManager.cpp
+++ b/filament/src/TransformManager.cpp
@@ -115,7 +115,7 @@ void TransformManager::applyWorldTransformToMaterialOrientation(Instance ci, boo
     downcast(this)->applyWorldTransformToMaterialOrientation(ci, apply);
 }
 
-const quatf &TransformManager::getMaterialWorldOrientation(Instance ci) const noexcept {
+const quatf& TransformManager::getMaterialWorldOrientation(Instance ci) const noexcept {
     return downcast(this)->getMaterialWorldOrientation(ci);
 }
 

--- a/filament/src/TransformManager.cpp
+++ b/filament/src/TransformManager.cpp
@@ -103,11 +103,11 @@ size_t TransformManager::getChildren(Instance i, utils::Entity* children,
     return downcast(this)->getChildren(i, children, count);
 }
 
-void TransformManager::setMaterialOrientation(Instance ci, const mat3f& rotation) noexcept {
+void TransformManager::setMaterialOrientation(Instance ci, const quatf& rotation) noexcept {
     downcast(this)->setMaterialOrientation(ci, rotation);
 }
 
-const mat3f& TransformManager::getMaterialOrientation(Instance ci) const noexcept {
+const quatf& TransformManager::getMaterialOrientation(Instance ci) const noexcept {
     return downcast(this)->getMaterialOrientation(ci);
 }
 
@@ -115,7 +115,7 @@ void TransformManager::applyWorldTransformToMaterialOrientation(Instance ci, boo
     downcast(this)->applyWorldTransformToMaterialOrientation(ci, apply);
 }
 
-const mat3f &TransformManager::getMaterialWorldOrientation(Instance ci) const noexcept {
+const quatf &TransformManager::getMaterialWorldOrientation(Instance ci) const noexcept {
     return downcast(this)->getMaterialWorldOrientation(ci);
 }
 

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -193,7 +193,7 @@ void FTransformManager::setTransform(Instance ci, const mat4& model) noexcept {
     }
 }
 
-void FTransformManager::setMaterialOrientation(Instance ci, const math::mat3f& rotation) noexcept {
+void FTransformManager::setMaterialOrientation(Instance ci, const math::quatf& rotation) noexcept {
     validateNode(ci);
     if (ci) {
         auto& manager = mManager;
@@ -474,9 +474,9 @@ void FTransformManager::computeWorldTransform(
 }
 
 void FTransformManager::computeMaterialWorldOrientation(
-        math::mat3f& outOrientation, 
-        math::mat3f const& parentOrientation, 
-        math::mat3f const& localOrientation,
+        math::quatf& outOrientation, 
+        math::quatf const& parentOrientation, 
+        math::quatf const& localOrientation,
         math::float3& outOrientationCenter,
         math::float3 const& parentOrientationCenter,
         math::float3 const& localOrientationCenter) {
@@ -485,22 +485,18 @@ void FTransformManager::computeMaterialWorldOrientation(
     outOrientationCenter = parentOrientationCenter + localOrientationCenter;
 }
 
-math::mat3f FTransformManager::getMaterialCompoundOrientation(Instance ci) const noexcept {
+math::quatf FTransformManager::getMaterialCompoundOrientation(Instance ci) const noexcept {
     const mat4f& world = mManager[ci].world;
-    const mat3f& orientation = mManager[ci].materialOrientation;
+    const quatf& orientation = mManager[ci].materialOrientation;
 
-    // we need to strip everything from our world transform, except rotation
-    mat3f worldRotation = mat3f(world[0].xyz, world[1].xyz, world[2].xyz);
-    worldRotation[0] = normalize(worldRotation[0]);
-    worldRotation[1] = normalize(worldRotation[1]);
-    worldRotation[2] = normalize(worldRotation[2]);
+    quatf worldRotationQuaternion = world.toQuaternion();
 
     // We need to apply the inverse of the world transformation's rotation component
     // then apply our own orientation. Multiplying with worldRotation on the right is
     // equivalent to multiplying on the left with the transpose of it, which in this
     // case is equal to the inverse (orthonormal matrix). This allows us to compute only
     // one matrix multiplication, instead of two (one on the left, one on the right).
-    return worldRotation * orientation;
+    return worldRotationQuaternion * orientation;
 }
 
 void FTransformManager::validateNode(UTILS_UNUSED_IN_RELEASE Instance i) noexcept {

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -491,13 +491,13 @@ math::quatf FTransformManager::getMaterialCompoundOrientation(Instance ci) const
     const mat4f& world = mManager[ci].world;
     const quatf& orientation = mManager[ci].materialOrientation;
 
-    quatf worldRotationQuaternion = world.toQuaternion();
+    const quatf worldRotationQuaternion = world.toQuaternion();
 
     // We need to apply the inverse of the world transformation's rotation component
-    // then apply our own orientation. Multiplying with worldRotation on the right is
-    // equivalent to multiplying on the left with the transpose of it, which in this
-    // case is equal to the inverse (orthonormal matrix). This allows us to compute only
-    // one matrix multiplication, instead of two (one on the left, one on the right).
+    // then apply our own orientation. Since the worldRotation is already applied to the material, 
+    // applying the inverse worldRotation to it will leave us with an identity transform. After that
+    // orientation can be applied and worldRotation re-applied. Leveraging that an identity transform occurs
+    // in an intermediate step, instead of two quaternion-vector operation only one needs to be done.
     return worldRotationQuaternion * orientation;
 }
 

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -61,6 +61,7 @@ void FTransformManager::create(Entity entity, Instance parent, const mat4f& loca
     assert_invariant(i != parent);
 
     manager[i].applyWorldToMaterialOrientation = true;
+    manager[i].materialLocalOrientation = {0, 0, 0, 1};
 
     if (i && i != parent) {
         manager[i].parent = 0;
@@ -85,6 +86,7 @@ void FTransformManager::create(Entity entity, Instance parent, const mat4& local
     assert_invariant(i != parent);
 
     manager[i].applyWorldToMaterialOrientation = true;
+    manager[i].materialLocalOrientation = {0, 0, 0, 1};
 
     if (i && i != parent) {
         manager[i].parent = 0;
@@ -240,7 +242,7 @@ void FTransformManager::updateNodeTransform(Instance i) noexcept {
             mAccurateTranslations);
 
     // we apply the parent orientation
-    computeMaterialWorldOrientation(manager[i].materialOrientation, manager[parent].materialOrientation,
+    computeMaterialWorldOrientation(manager[i].materialOrientation, parent.isValid() ? manager[parent].materialOrientation : quatf{0, 0, 0, 1},
             manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, manager[parent].materialOrientationCenter,
             manager[i].materialLocalOrientationCenter);
 
@@ -284,9 +286,9 @@ void FTransformManager::computeAllWorldTransforms() noexcept {
                 manager[parent].worldTranslationLo, manager[i].localTranslationLo,
                 accurate);
         
-        computeMaterialWorldOrientation(manager[i].materialOrientation, manager[parent].materialOrientation, 
-                manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, 
-                manager[parent].materialOrientationCenter, manager[i].materialLocalOrientationCenter);
+        computeMaterialWorldOrientation(manager[i].materialOrientation, parent.isValid() ? manager[parent].materialOrientation : quatf{0, 0, 0, 1},
+            manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, manager[parent].materialOrientationCenter,
+            manager[i].materialLocalOrientationCenter);
     }
 }
 
@@ -424,9 +426,9 @@ void FTransformManager::transformChildren(Sim& manager, Instance i) noexcept {
                 accurate);
 
         // we need to update our orientation too
-        computeMaterialWorldOrientation(manager[i].materialOrientation, manager[parent].materialOrientation, 
-                manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, 
-                manager[parent].materialOrientationCenter, manager[i].materialLocalOrientationCenter);
+        computeMaterialWorldOrientation(manager[i].materialOrientation, parent.isValid() ? manager[parent].materialOrientation : quatf{0, 0, 0, 1},
+            manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, manager[parent].materialOrientationCenter,
+            manager[i].materialLocalOrientationCenter);
 
         // assume we don't have a deep hierarchy
         Instance const child = manager[i].firstChild;

--- a/filament/src/components/TransformManager.cpp
+++ b/filament/src/components/TransformManager.cpp
@@ -27,7 +27,10 @@ using namespace filament::math;
 
 namespace filament {
 
-FTransformManager::FTransformManager() noexcept = default;
+FTransformManager::FTransformManager() noexcept {
+    mManager[0].materialOrientation = {0, 0, 0, 1};
+    mManager[0].materialLocalOrientation = {0, 0, 0, 1};
+}
 
 FTransformManager::~FTransformManager() noexcept = default;
 
@@ -242,7 +245,7 @@ void FTransformManager::updateNodeTransform(Instance i) noexcept {
             mAccurateTranslations);
 
     // we apply the parent orientation
-    computeMaterialWorldOrientation(manager[i].materialOrientation, parent.isValid() ? manager[parent].materialOrientation : quatf{0, 0, 0, 1},
+    computeMaterialWorldOrientation(manager[i].materialOrientation, manager[parent].materialOrientation,
             manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, manager[parent].materialOrientationCenter,
             manager[i].materialLocalOrientationCenter);
 
@@ -286,7 +289,7 @@ void FTransformManager::computeAllWorldTransforms() noexcept {
                 manager[parent].worldTranslationLo, manager[i].localTranslationLo,
                 accurate);
         
-        computeMaterialWorldOrientation(manager[i].materialOrientation, parent.isValid() ? manager[parent].materialOrientation : quatf{0, 0, 0, 1},
+        computeMaterialWorldOrientation(manager[i].materialOrientation, manager[parent].materialOrientation,
             manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, manager[parent].materialOrientationCenter,
             manager[i].materialLocalOrientationCenter);
     }
@@ -426,7 +429,7 @@ void FTransformManager::transformChildren(Sim& manager, Instance i) noexcept {
                 accurate);
 
         // we need to update our orientation too
-        computeMaterialWorldOrientation(manager[i].materialOrientation, parent.isValid() ? manager[parent].materialOrientation : quatf{0, 0, 0, 1},
+        computeMaterialWorldOrientation(manager[i].materialOrientation, manager[parent].materialOrientation,
             manager[i].materialLocalOrientation, manager[i].materialOrientationCenter, manager[parent].materialOrientationCenter,
             manager[i].materialLocalOrientationCenter);
 

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -133,22 +133,22 @@ public:
         return r;
     }
 
-    void setMaterialOrientation(Instance ci, const math::mat3f& rotation) noexcept;
+    void setMaterialOrientation(Instance ci, const math::quatf & rotation) noexcept;
 
     void applyWorldTransformToMaterialOrientation(Instance ci, bool apply) noexcept;
     bool isWorldTransformAppliedToMaterialOrientation(Instance ci) const noexcept {
         return mManager[ci].applyWorldToMaterialOrientation;
     }
 
-    const math::mat3f& getMaterialOrientation(Instance ci) const noexcept {
+    const math::quatf& getMaterialOrientation(Instance ci) const noexcept {
         return mManager[ci].materialLocalOrientation;
     }
 
-    const math::mat3f& getMaterialWorldOrientation(Instance ci) const noexcept {
+    const math::quatf& getMaterialWorldOrientation(Instance ci) const noexcept {
         return mManager[ci].materialOrientation;
     }
 
-    math::mat3f getMaterialCompoundOrientation(Instance ci) const noexcept;
+    math::quatf getMaterialCompoundOrientation(Instance ci) const noexcept;
 
     void setMaterialOrientationCenter(Instance ci, const math::float3& center) noexcept;
 
@@ -177,9 +177,9 @@ private:
             math::mat4f const& pt, math::mat4f const& local,
             math::float3 const& ptTranslationLo, math::float3 const& localTranslationLo,
             bool accurate);
-    
-    void computeMaterialWorldOrientation(math::mat3f& outOrientation, math::mat3f const& parentOrientation,
-            math::mat3f const& localOrientation,math::float3& outOrientationCenter,
+
+    void computeMaterialWorldOrientation(math::quatf& outOrientation, math::quatf const& parentOrientation,
+            math::quatf const& localOrientation,math::float3& outOrientationCenter,
             math::float3 const& parentOrientationCenter, math::float3 const& localOrientationCenter);
 
     friend class TransformManager::children_iterator;
@@ -189,11 +189,11 @@ private:
         WORLD,          // world transform
         LOCAL_LO,       // accurate local translation
         WORLD_LO,       // accurate world translation
-        MATERIAL_LOCAL_ORIENTATION,         // local orientation of bi/triplanar mapping
-        MATERIAL_ORIENTATION,               // bi/triplanar mapping rotation matrix, composed with parent transforms
+        MATERIAL_LOCAL_ORIENTATION,    // local orientation quaternion of bi/triplanar mapping
+        MATERIAL_ORIENTATION,          // bi/triplanar mapping rotation quaternion, composed with parent transforms
         MATERIAL_LOCAL_ORIENTATION_CENTER,  // local center of bi/triplanar mapping
         MATERIAL_ORIENTATION_CENTER,        // bi/triplanar mapping center, composed with parent center
-        APPLY_WORLD_TO_MATERIAL_ORIENTATION,// whether to concatenate the world transform to material orientation
+        APPLY_WORLD_TO_MATERIAL_ORIENTATION,// whether to concatenate the world transform to material orientation quaternion
         PARENT,         // instance to the parent
         FIRST_CHILD,    // instance to our first child
         NEXT,           // instance to our next sibling
@@ -205,11 +205,11 @@ private:
             math::mat4f,    // world
             math::float3,   // accurate local translation
             math::float3,   // accurate world translation
-            math::mat3f,    // local orientation
-            math::mat3f,    // orientation
+            math::quatf,   // local orientation quaternion
+            math::quatf,   // orientation quaternion
             math::float3,   // local orientation center
             math::float3,   // orientation center
-            bool,           // apply world to material orientation
+            bool,           // apply world to material orientation quaternion
             Instance,       // parent
             Instance,       // firstChild
             Instance,       // next
@@ -234,8 +234,8 @@ private:
                 Field<WORLD>        world;
                 Field<LOCAL_LO>     localTranslationLo;
                 Field<WORLD_LO>     worldTranslationLo;
-                Field<MATERIAL_LOCAL_ORIENTATION>           materialLocalOrientation;
-                Field<MATERIAL_ORIENTATION>                 materialOrientation;
+                Field<MATERIAL_LOCAL_ORIENTATION>      materialLocalOrientation;
+                Field<MATERIAL_ORIENTATION>            materialOrientation;
                 Field<MATERIAL_LOCAL_ORIENTATION_CENTER>    materialLocalOrientationCenter;
                 Field<MATERIAL_ORIENTATION_CENTER>          materialOrientationCenter;
                 Field<APPLY_WORLD_TO_MATERIAL_ORIENTATION>  applyWorldToMaterialOrientation;

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -189,8 +189,8 @@ private:
         WORLD,          // world transform
         LOCAL_LO,       // accurate local translation
         WORLD_LO,       // accurate world translation
-        MATERIAL_LOCAL_ORIENTATION,    // local orientation quaternion of bi/triplanar mapping
-        MATERIAL_ORIENTATION,          // bi/triplanar mapping rotation quaternion, composed with parent transforms
+        MATERIAL_LOCAL_ORIENTATION,         // local orientation quaternion of bi/triplanar mapping
+        MATERIAL_ORIENTATION,               // bi/triplanar mapping rotation quaternion, composed with parent transforms
         MATERIAL_LOCAL_ORIENTATION_CENTER,  // local center of bi/triplanar mapping
         MATERIAL_ORIENTATION_CENTER,        // bi/triplanar mapping center, composed with parent center
         APPLY_WORLD_TO_MATERIAL_ORIENTATION,// whether to concatenate the world transform to material orientation quaternion
@@ -205,8 +205,8 @@ private:
             math::mat4f,    // world
             math::float3,   // accurate local translation
             math::float3,   // accurate world translation
-            math::quatf,   // local orientation quaternion
-            math::quatf,   // orientation quaternion
+            math::quatf,    // local orientation quaternion
+            math::quatf,    // orientation quaternion
             math::float3,   // local orientation center
             math::float3,   // orientation center
             bool,           // apply world to material orientation quaternion
@@ -234,8 +234,8 @@ private:
                 Field<WORLD>        world;
                 Field<LOCAL_LO>     localTranslationLo;
                 Field<WORLD_LO>     worldTranslationLo;
-                Field<MATERIAL_LOCAL_ORIENTATION>      materialLocalOrientation;
-                Field<MATERIAL_ORIENTATION>            materialOrientation;
+                Field<MATERIAL_LOCAL_ORIENTATION>           materialLocalOrientation;
+                Field<MATERIAL_ORIENTATION>                 materialOrientation;
                 Field<MATERIAL_LOCAL_ORIENTATION_CENTER>    materialLocalOrientationCenter;
                 Field<MATERIAL_ORIENTATION_CENTER>          materialOrientationCenter;
                 Field<APPLY_WORLD_TO_MATERIAL_ORIENTATION>  applyWorldToMaterialOrientation;

--- a/filament/src/components/TransformManager.h
+++ b/filament/src/components/TransformManager.h
@@ -133,7 +133,7 @@ public:
         return r;
     }
 
-    void setMaterialOrientation(Instance ci, const math::quatf & rotation) noexcept;
+    void setMaterialOrientation(Instance ci, const math::quatf& rotation) noexcept;
 
     void applyWorldTransformToMaterialOrientation(Instance ci, bool apply) noexcept;
     bool isWorldTransformAppliedToMaterialOrientation(Instance ci) const noexcept {

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -183,7 +183,7 @@ void FScene::prepare(utils::JobSystem& js,
             const bool reversedWindingOrder = det(shaderWorldTransform.upperLeft()) < 0;
 
             const bool applyWorldToMaterialOrientation = tcm.isWorldTransformAppliedToMaterialOrientation(ti);
-            const mat3f materialOrientation = applyWorldToMaterialOrientation ? tcm.getMaterialCompoundOrientation(ti) : tcm.getMaterialOrientation(ti);
+            const quatf materialOrientation = applyWorldToMaterialOrientation ? tcm.getMaterialCompoundOrientation(ti) : tcm.getMaterialOrientation(ti);
             const float3 materialOrientationCenter = tcm.getMaterialWorldOrientationCenter(ti);
 
             // compute the world AABB so we can perform culling
@@ -370,7 +370,11 @@ void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables) noexc
 
         uboData.worldFromModelNormalMatrix = m;
 
-        uboData.materialOrientationMatrix = sceneData.elementAt<MATERIAL_ORIENTATION>(i);
+        uboData.materialOrientation = {sceneData.elementAt<MATERIAL_ORIENTATION>(i).x, 
+                                       sceneData.elementAt<MATERIAL_ORIENTATION>(i).y, 
+                                       sceneData.elementAt<MATERIAL_ORIENTATION>(i).z, 
+                                       sceneData.elementAt<MATERIAL_ORIENTATION>(i).w};
+
         uboData.materialOrientationCenter = sceneData.elementAt<MATERIAL_ORIENTATION_CENTER>(i);
 
         uboData.flagsChannels = PerRenderableData::packFlagsChannels(

--- a/filament/src/details/Scene.cpp
+++ b/filament/src/details/Scene.cpp
@@ -370,10 +370,7 @@ void FScene::prepareVisibleRenderables(Range<uint32_t> visibleRenderables) noexc
 
         uboData.worldFromModelNormalMatrix = m;
 
-        uboData.materialOrientation = {sceneData.elementAt<MATERIAL_ORIENTATION>(i).x, 
-                                       sceneData.elementAt<MATERIAL_ORIENTATION>(i).y, 
-                                       sceneData.elementAt<MATERIAL_ORIENTATION>(i).z, 
-                                       sceneData.elementAt<MATERIAL_ORIENTATION>(i).w};
+        uboData.materialOrientation = sceneData.elementAt<MATERIAL_ORIENTATION>(i).xyzw;
 
         uboData.materialOrientationCenter = sceneData.elementAt<MATERIAL_ORIENTATION_CENTER>(i);
 

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -117,7 +117,7 @@ public:
     using RenderableSoa = utils::StructureOfArrays<
             utils::EntityInstance<RenderableManager>,   // RENDERABLE_INSTANCE
             math::mat4f,                                // WORLD_TRANSFORM
-            math::quatf,                               // MATERIAL_ORIENTATION
+            math::quatf,                                // MATERIAL_ORIENTATION
             math::float3,                               // MATERIAL_ORIENTATION_CENTER
             FRenderableManager::Visibility,             // VISIBILITY_STATE
             FRenderableManager::SkinningBindingInfo,    // SKINNING_BUFFER

--- a/filament/src/details/Scene.h
+++ b/filament/src/details/Scene.h
@@ -91,7 +91,7 @@ public:
     enum {
         RENDERABLE_INSTANCE,    //   4 | instance of the Renderable component
         WORLD_TRANSFORM,        //  16 | instance of the Transform component
-        MATERIAL_ORIENTATION,           // 36 | orientation matrix for bi/triplanar mapping
+        MATERIAL_ORIENTATION,      // 16 | orientation quaternion for bi/triplanar mapping
         MATERIAL_ORIENTATION_CENTER,    // 12 | orientation center for bi/triplanar mapping
         VISIBILITY_STATE,       //   2 | visibility data of the component
         SKINNING_BUFFER,        //   8 | bones uniform buffer handle, offset, indices and weights
@@ -117,7 +117,7 @@ public:
     using RenderableSoa = utils::StructureOfArrays<
             utils::EntityInstance<RenderableManager>,   // RENDERABLE_INSTANCE
             math::mat4f,                                // WORLD_TRANSFORM
-            math::mat3f,                                // MATERIAL_ORIENTATION
+            math::quatf,                               // MATERIAL_ORIENTATION
             math::float3,                               // MATERIAL_ORIENTATION_CENTER
             FRenderableManager::Visibility,             // VISIBILITY_STATE
             FRenderableManager::SkinningBindingInfo,    // SKINNING_BUFFER

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -225,7 +225,7 @@ static_assert(sizeof(PerViewUib) == sizeof(math::float4) * 128,
 struct PerRenderableData {
     std140::mat44 worldFromModelMatrix;
     std140::mat33 worldFromModelNormalMatrix;
-    std140::mat33 materialOrientationMatrix;
+    std140::vec4 materialOrientation;
     int32_t morphTargetCount;
     int32_t flagsChannels;                   // see packFlags() below (0x00000fll)
     int32_t objectId;                        // used for picking
@@ -233,7 +233,7 @@ struct PerRenderableData {
     float userData;
     alignas(16) math::float3 materialOrientationCenter;   // center of renderable's material mapping in world space
 
-    math::float4 reserved[4];
+    math::float4 reserved[6];
 
     static uint32_t packFlagsChannels(
             bool skinning, bool morphing, bool contactShadows, bool hasInstanceBuffer,

--- a/libs/filabridge/include/private/filament/UibStructs.h
+++ b/libs/filabridge/include/private/filament/UibStructs.h
@@ -225,7 +225,7 @@ static_assert(sizeof(PerViewUib) == sizeof(math::float4) * 128,
 struct PerRenderableData {
     std140::mat44 worldFromModelMatrix;
     std140::mat33 worldFromModelNormalMatrix;
-    std140::vec4 materialOrientation;
+    math::float4 materialOrientation;
     int32_t morphTargetCount;
     int32_t flagsChannels;                   // see packFlags() below (0x00000fll)
     int32_t objectId;                        // used for picking

--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -90,7 +90,7 @@ public:
     explicit constexpr TQuaternion(no_init) {}
 
     // default constructor. sets all values to zero.
-    constexpr TQuaternion() : x(0), y(0), z(0), w(0) {}
+    constexpr TQuaternion() : x(0), y(0), z(0), w(1) {}
 
     // Handles implicit conversion to a quat. Must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>

--- a/libs/math/include/math/quat.h
+++ b/libs/math/include/math/quat.h
@@ -90,7 +90,7 @@ public:
     explicit constexpr TQuaternion(no_init) {}
 
     // default constructor. sets all values to zero.
-    constexpr TQuaternion() : x(0), y(0), z(0), w(1) {}
+    constexpr TQuaternion() : x(0), y(0), z(0), w(0) {}
 
     // Handles implicit conversion to a quat. Must not be explicit.
     template<typename A, typename = enable_if_arithmetic_t<A>>

--- a/shaders/src/common_instancing.glsl
+++ b/shaders/src/common_instancing.glsl
@@ -43,7 +43,7 @@ void initObjectUniforms() {
 #endif
     object_uniforms_worldFromModelMatrix        = objectUniforms.data[i].worldFromModelMatrix;
     object_uniforms_worldFromModelNormalMatrix  = objectUniforms.data[i].worldFromModelNormalMatrix;
-    object_uniforms_materialOrientation     = objectUniforms.data[i].materialOrientation;
+    object_uniforms_materialOrientation         = objectUniforms.data[i].materialOrientation;
     object_uniforms_morphTargetCount            = objectUniforms.data[i].morphTargetCount;
     object_uniforms_flagsChannels               = objectUniforms.data[i].flagsChannels;
     object_uniforms_objectId                    = objectUniforms.data[i].objectId;

--- a/shaders/src/common_instancing.glsl
+++ b/shaders/src/common_instancing.glsl
@@ -4,7 +4,7 @@
 
 highp mat4 object_uniforms_worldFromModelMatrix;
 highp mat3 object_uniforms_worldFromModelNormalMatrix;
-highp mat3 object_uniforms_materialOrientationMatrix;
+highp vec4 object_uniforms_materialOrientation;
 highp int object_uniforms_morphTargetCount;
 highp int object_uniforms_flagsChannels;                   // see packFlags() below (0x00000fll)
 highp int object_uniforms_objectId;                        // used for picking
@@ -43,7 +43,7 @@ void initObjectUniforms() {
 #endif
     object_uniforms_worldFromModelMatrix        = objectUniforms.data[i].worldFromModelMatrix;
     object_uniforms_worldFromModelNormalMatrix  = objectUniforms.data[i].worldFromModelNormalMatrix;
-    object_uniforms_materialOrientationMatrix   = objectUniforms.data[i].materialOrientationMatrix;
+    object_uniforms_materialOrientation     = objectUniforms.data[i].materialOrientation;
     object_uniforms_morphTargetCount            = objectUniforms.data[i].morphTargetCount;
     object_uniforms_flagsChannels               = objectUniforms.data[i].flagsChannels;
     object_uniforms_objectId                    = objectUniforms.data[i].objectId;

--- a/shaders/src/common_types.glsl
+++ b/shaders/src/common_types.glsl
@@ -26,13 +26,13 @@ struct BoneData {
 struct PerRenderableData {
     highp mat4 worldFromModelMatrix;
     highp mat3 worldFromModelNormalMatrix;
-    highp mat3 materialOrientationMatrix;
+    highp vec4 materialOrientation;
     highp int morphTargetCount;
     highp int flagsChannels;                   // see packFlags() below (0x00000fll)
     highp int objectId;                        // used for picking
     highp float userData;   // TODO: We need a better solution, this currently holds the average local scale for the renderable
     highp vec3 materialOrientationCenter;
-    highp vec4 reserved[4];
+    highp vec4 reserved[6];
 };
 
 // Bits for flagsChannels

--- a/shaders/src/getters.fs
+++ b/shaders/src/getters.fs
@@ -83,8 +83,8 @@ float getNdotV() {
     return shading_NoV;
 }
 
-mat3 getMaterialOrientationMatrix() {
-    return object_uniforms_materialOrientationMatrix;
+vec4 getMaterialOrientation() {
+    return object_uniforms_materialOrientation;
 }
 
 vec3 getMaterialOrientationCenter() {


### PR DESCRIPTION
## Jira ticket URL (Why?)

[GFX-4253](https://shapr3d.atlassian.net/browse/GFX-4253)

## Short description (What? How?) 📖
In this pull request we changed from using matrices as material orientation transformation objects to using quaternions instead, thus hoping to improve memory usage and frame times. 

Obtained advantages:
- Instead of 3x3 float values we only need to store 4 float values by changing from 3x3 matrices to quaternions. This is only an implicit advantage, since as `PerRenderableData` we upload 256 byte sized structs either way, but now we have more free space within this struct to use freely.
- Instead of 9 dot product calculations of 3-component vectors we only need to do 2 different cross product calculations and 2 additions.

The logic of the changes implemented in this pull request came mainly from [here](https://github.com/shapr3d/filament/pull/117).

## Upstreaming scope
We do not intend to upstream these modifications.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Appearance of materials in Visualization on all platforms, with a focus on their orientation in case auto orientation is enabled.

### Special use-cases to test 🧷
Materials should look exactly the same as before

### How did you test it? 🤔

Manual 💁‍♂️
Built and ran the application both on MacOS and Windows.
- MacOS: Ran `VisualizationToolTests_MaterialOrientation_Auto` tests
- Windows: Checked several manual orientation setups and auto orientation enablement on/off combinations for a few wooden and metallic materials

Automated 💻
N/A

[GFX-4253]: https://shapr3d.atlassian.net/browse/GFX-4253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ