### PR TITLE
[PRES-44] Expose additional shadow parameters to GLTF Viewer

### DIFF
--- a/libs/viewer/src/ViewerGui.cpp
+++ b/libs/viewer/src/ViewerGui.cpp
@@ -1689,6 +1689,12 @@ void ViewerGui::updateUserInterface() {
             ImGui::SliderFloat("Split pos 1", &light.shadowOptions.cascadeSplitPositions[1], 0.0f, 1.0f);
             ImGui::SliderFloat("Split pos 2", &light.shadowOptions.cascadeSplitPositions[2], 0.0f, 1.0f);
             light.shadowOptions.shadowCascades = shadowCascades;
+
+            ImGui::SliderFloat("PolygonOffsetConstant", &light.shadowOptions.polygonOffsetConstant, 0.0f, 1.0f);
+            ImGui::SliderFloat("PolygonOffsetSlope", &light.shadowOptions.polygonOffsetSlope, 0.0f, 5.0f);
+            if (mSettings.view.shadowType != ShadowType::VSM) {
+                ImGui::SliderFloat("NormalBias (no VSM)", &light.shadowOptions.normalBias, 0.0f, 2.0f);
+            }
         }
         ImGui::Unindent();
     }


### PR DESCRIPTION
## Jira ticket URL (Why?)
[PRES-44](https://shapr3d.atlassian.net/browse/PRES-44)

## Short description (What? How?) 📖
Additional shadow parameters were exposed to the GLTF Viewer GUI. These parameters are:
- `PolygonOffsetConstant`
- `PolygonOffsetSlope`
- `normalBias`

**Note:** the `(no VSM)` note was shortened as much as possible, anything longer that can not fit onto the GUI. While this message is not too elaborate, it is at least readable.

## Material shader statistics implications
n/a

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
GLTF Viewer shadow parameters

### Special use-cases to test 🧷
- Check if the upper mentioned parameters are visible on the GUI and if changing them influences the scene's appearance
- Check if `normalBias` is unavailable if shadow type is VSM (should not be)

### How did you test it? 🤔
Manual 💁‍♂️
Built and ran the GLTF Viewer on Windows
Automated 💻
n/a

[PRES-44]: https://shapr3d.atlassian.net/browse/PRES-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ