### PR TITLE
[PRES-314] Clear colorBuffer too in colorGrading sampler group

### DIFF
--- a/filament/src/PostProcessManager.cpp
+++ b/filament/src/PostProcessManager.cpp
@@ -2505,7 +2505,8 @@ FrameGraphId<FrameGraphTexture> PostProcessManager::colorGrading(FrameGraph& fg,
 
                 commitAndRender(out, material, variant, driver);
 
-                // Clear reference to LUT texture of color grading, in case it gets destroyed
+                // Clear reference to colorBuffer and LUT textures, in case they get destroyed
+                mi->clearParameter("colorBuffer");
                 mi->clearParameter("lut");
             }
     );


### PR DESCRIPTION

## Jira ticket URL (Why?)
[PRES-314](https://shapr3d.atlassian.net/browse/PRES-314)

## Short description (What? How?) 📖
As the linked ticket says we still get use-after-free errors in the colorGrading sampler group even after manually clearing the LUT parameter in #153. This time the culprit seems to be `colorBuffer`. Although we found no repro we try fixing the problem by clearing that parameter manually too.

## Material shader statistics implications
n/a

## Upstreaming scope
We didn't upstream #153 and I think we shouldn't upstream this either. This is a bug in the Filament frontend logic and the fix is probably more involved. Raising an issue is not worth it either because they have completely removed sampler groups upstream:
<img width="1443" height="400" alt="image" src="https://github.com/user-attachments/assets/4da87f19-4388-44a1-b7c9-cd613ba99141" />

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Rendering in general

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
<!--- Short summary of how did you test your own implementation, :thumbsup: is not detailed enough -->
Manual 💁‍♂️

Automated 💻


[PRES-314]: https://shapr3d.atlassian.net/browse/PRES-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ