### PR TITLE
[PRES-851] Metal backend: log if argument buffer sampler limit exceeded

### DIFF
--- a/filament/backend/src/metal/MetalState.mm
+++ b/filament/backend/src/metal/MetalState.mm
@@ -163,6 +163,11 @@ id<MTLArgumentEncoder> ArgumentEncoderCreator::operator()(id<MTLDevice> device,
     const auto& count = textureTypes.size();
     assert_invariant(count > 0);
 
+    const auto maxArgumentBufferSamplerCount = device.maxArgumentBufferSamplerCount;
+    if (count > maxArgumentBufferSamplerCount) {
+        utils::slog.e << "Error: max sampler per argument buffer supported by this GPU (" << maxArgumentBufferSamplerCount << ") exceeded (" << count << ")" << utils::io::endl;
+    }
+
     // Metal has separate data types for textures versus samplers, so the argument buffer layout
     // alternates between texture and sampler, i.e.:
     // textureA


### PR DESCRIPTION
## Jira ticket URL (Why?)
<!---
Use the Jira ticket id as text in PROJ-XXX format and append it to the end of the link.
If there are multiple tickets, list all.
-->
[PRES-851](https://shapr3d.atlassian.net/browse/PRES-851)

## Short description (What? How?) 📖
We have been receiving crash reports related to argument buffer usage with Metal, on old Macs (10+ years old). Our hunch was that the amount of samplers per argument buffer limit was exceeded on those devices. Looking into it, Filament only uses 8 samplers, while the least amount supported by any GPU should be 16 (according to Metal Feature Set Tables). It is possible that such old GPUs don't support argument buffers at all, but unfortunately, there's no API for querying that (only whether Tier1 or Tier2 is supported, and GPU family or GPU feature set APIs are non-viable either). I'm _hoping_ querying `maxArgumentBufferSamplerCount` returns `0` for those devices, that don't support argument buffers.

## Material shader statistics implications
N/A

## Upstreaming scope
I don't think it's worth upstreaming.

## Testing

### Design review 🎨
N/A

### Affected areas 🧭
Metal backend

### Special use-cases to test 🧷
Nothing visible should change

### How did you test it? 🤔
Manual 💁‍♂️
Tried the code, with special edits
Automated 💻
❌ 

[PRES-851]: https://shapr3d.atlassian.net/browse/PRES-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ