### PR TITLE
[GFX-5288] Increase HwRenderPrimitiveFactory set size: 4 -> 16 MB

### DIFF
--- a/filament/src/HwRenderPrimitiveFactory.h
+++ b/filament/src/HwRenderPrimitiveFactory.h
@@ -80,7 +80,7 @@ private:
     // Shapr: Each entry in this set corresponds to a RenderableBatch.
     // We saw workspaces with over 100K batches, so we had to increase the arena size from 4 to 16 MBs to accommodate 100K+ entires.
     // The pool below uses 64B entries so 16 MB is enough for ~260K entries. Watch out when bumping Filament!
-    // The pool entry size was replaced with sizeof(Key) in v1.71.2 and arena size was decreased in v1.71.3!
+    // The pool entry size was replaced with sizeof(Key) in v1.50.5 and arena size was decreased in v1.55.0!
     static constexpr size_t SET_ARENA_SIZE = 16 * 1024 * 1024;
 
     // Arena for the set<>, using a pool allocator inside a heap area.

--- a/filament/src/HwRenderPrimitiveFactory.h
+++ b/filament/src/HwRenderPrimitiveFactory.h
@@ -76,7 +76,12 @@ private:
 
 
     // Size of the arena used for the "set" part of the bimap
-    static constexpr size_t SET_ARENA_SIZE = 4 * 1024 * 1024;
+
+    // Shapr: Each entry in this set corresponds to a RenderableBatch.
+    // We saw workspaces with over 100K batches, so we had to increase the arena size from 4 to 16 MBs to accommodate 100K+ entires.
+    // The pool below uses 64B entries so 16 MB is enough for ~260K entries.
+    // Watch out when bumping Filament! The pool entry size was replaced with sizeof(Key) in v1.71.2!
+    static constexpr size_t SET_ARENA_SIZE = 16 * 1024 * 1024;
 
     // Arena for the set<>, using a pool allocator inside a heap area.
     using Arena = utils::Arena<

--- a/filament/src/HwRenderPrimitiveFactory.h
+++ b/filament/src/HwRenderPrimitiveFactory.h
@@ -79,8 +79,8 @@ private:
 
     // Shapr: Each entry in this set corresponds to a RenderableBatch.
     // We saw workspaces with over 100K batches, so we had to increase the arena size from 4 to 16 MBs to accommodate 100K+ entires.
-    // The pool below uses 64B entries so 16 MB is enough for ~260K entries.
-    // Watch out when bumping Filament! The pool entry size was replaced with sizeof(Key) in v1.71.2!
+    // The pool below uses 64B entries so 16 MB is enough for ~260K entries. Watch out when bumping Filament!
+    // The pool entry size was replaced with sizeof(Key) in v1.71.2 and arena size was decreased in v1.71.3!
     static constexpr size_t SET_ARENA_SIZE = 16 * 1024 * 1024;
 
     // Arena for the set<>, using a pool allocator inside a heap area.


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-5288](https://shapr3d.atlassian.net/browse/GFX-5288)

## Short description (What? How?) 📖
What the code comment says. 6843ad53-7e25-4a23-bfa3-978b6d0cd891#3.shapr (attached to the Jira ticket) contains ~100K bodies, so even with perfectly matching rendering attributes we get at least 100K batches. And area selection + LOD are notorious for **doubling/tripling** batch count temporarily. If we used a separate batching strategy for `DrawDelegateFilament` we could remedy this, but sharing the batching simplifies our life, so I didn't change that.

But since having this many batches results in ~100 render primitives inside Filament, and because a ~65K limit was hardcoded I had to do sth. Reaching the 65K limit is UB (but in practice it's a `nullptr` dereference and a crash) so the quickest solution was to increase the limit to ~262K. This should be plenty and only comes with +12MB of memory usage. Note that this extra memory usage occurs right at app launch and will persist until the app is closed!

## Material shader statistics implications
n/a

## Upstreaming scope
They actually decreased the same limit in https://github.com/google/filament/commit/2cade209b583b5c9fd8cff2726f65678fdf3376f (partly because they decreased the pool entry size earlier in https://github.com/google/filament/commit/6e5930c2a00ab32cd6bfa8e1065d1aba22e09eba, allowing for smaller set size) so upstreaming this is unrealistic. When we bump Filament, we will have to watch out for conflicts!

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Visualization with workspaces that contain many bodies

### Special use-cases to test 🧷
The workspaces in the Jira ticket

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-5288]: https://shapr3d.atlassian.net/browse/GFX-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ