### PR TITLE
[GFX-5288] Revert CMake constants because we can set them from Shapr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,15 +53,15 @@ set(FILAMENT_NDK_VERSION "" CACHE STRING
     "Android NDK version or version prefix to be used when building for Android."
 )
 
-set(FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB "7" CACHE STRING
+set(FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB "3" CACHE STRING
     "Per render pass arena size. Must be roughly 1 MB larger than FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB, default 3."
 )
 
-set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "6" CACHE STRING
+set(FILAMENT_PER_FRAME_COMMANDS_SIZE_IN_MB "2" CACHE STRING
     "Size of the high-level draw commands buffer. Rule of thumb, 1 MB less than FILAMENT_PER_RENDER_PASS_ARENA_SIZE_IN_MB, default 2."
 )
 
-set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "11" CACHE STRING
+set(FILAMENT_MIN_COMMAND_BUFFERS_SIZE_IN_MB "2" CACHE STRING
     "Size of the command-stream buffer. As a rule of thumb use the same value as FILAMENT_PER_FRRAME_COMMANDS_SIZE_IN_MB, default 2."
 )
 


### PR DESCRIPTION
## Jira ticket URL (Why?)
[GFX-5288](https://shapr3d.atlassian.net/browse/GFX-5288)

## Short description (What? How?) 📖
Ever since v1.25.3 (https://github.com/google/filament/commit/6a1cc3abe910f488e9ce8f0925a4b1107db1d16e) an app using Filament can override the Engine arena sizes at runtime so we don't have to increase our surface of code conflicts by changing the constants in CMake. I reverted them to the values of v1.50.3, the current version of our Filament.

## Material shader statistics implications
n/a

## Upstreaming scope
n/a

## Testing

### Design review 🎨
n/a

### Affected areas 🧭
Nothing, if the constants overriden in Shapr3D.

### Special use-cases to test 🧷
n/a

### How did you test it? 🤔
Manual 💁‍♂️

Automated 💻


[GFX-5288]: https://shapr3d.atlassian.net/browse/GFX-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ